### PR TITLE
Implement .NET garden CRUD services and durable JSON app-state persistence

### DIFF
--- a/backend/SurvivalGarden.Api/Program.cs
+++ b/backend/SurvivalGarden.Api/Program.cs
@@ -1,6 +1,12 @@
+using System.Text.Json.Nodes;
+using SurvivalGarden.Application;
+using SurvivalGarden.Persistence;
+
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddOpenApi();
+builder.Services.AddPersistence(builder.Configuration["Persistence:AppStatePath"]);
+builder.Services.AddApplication();
 
 var app = builder.Build();
 
@@ -23,4 +29,121 @@ app.MapGet("/", () => Results.Ok(new
     contracts = "mirrored"
 }));
 
+app.MapGet("/api/app-state", async (IGardenApplicationService service, CancellationToken ct) =>
+{
+    var state = await service.LoadAppStateAsync(ct);
+    return state is null ? Results.NotFound() : Results.Ok(state);
+});
+
+app.MapPut("/api/app-state", async (IGardenApplicationService service, JsonObject payload, CancellationToken ct) =>
+{
+    await service.SaveAppStateAsync(payload, ct);
+    return Results.Ok(payload);
+});
+
+app.MapGet("/api/settings", async (IGardenApplicationService service, CancellationToken ct) =>
+{
+    var state = await service.LoadAppStateAsync(ct);
+    return state?["settings"] is JsonObject settings ? Results.Ok(settings) : Results.NotFound();
+});
+
+app.MapPut("/api/settings", async (IGardenApplicationService service, JsonObject payload, CancellationToken ct) =>
+{
+    var state = await service.LoadAppStateAsync(ct) ?? new JsonObject();
+    state["settings"] = payload.DeepClone();
+    await service.SaveAppStateAsync(state, ct);
+    return Results.Ok(payload);
+});
+
+MapEntityCrud(app, "species", "id");
+MapEntityCrud(app, "crops", "cropId");
+MapEntityCrud(app, "cultivars", "id");
+MapEntityCrud(app, "segments", "segmentId");
+MapEntityCrud(app, "beds", "bedId");
+MapEntityCrud(app, "paths", "pathId");
+MapEntityCrud(app, "seedInventoryItems", "seedInventoryItemId");
+MapEntityCrud(app, "cropPlans", "planId");
+
+app.MapGet("/api/batches", async (
+    IGardenApplicationService service,
+    string? stage,
+    string? cropId,
+    string? bedId,
+    string? startedAtFrom,
+    string? startedAtTo,
+    CancellationToken ct) =>
+{
+    var rows = await service.ListBatchesAsync(stage, cropId, bedId, startedAtFrom, startedAtTo, ct);
+    return Results.Ok(rows);
+});
+
+app.MapGet("/api/batches/{id}", async (IGardenApplicationService service, string id, CancellationToken ct) =>
+{
+    var batch = await service.GetByIdAsync("batches", "batchId", id, ct);
+    return batch is null ? Results.NotFound() : Results.Ok(batch);
+});
+
+app.MapPut("/api/batches/{id}", async (IGardenApplicationService service, string id, JsonObject payload, CancellationToken ct) =>
+{
+    payload["batchId"] = id;
+    var validation = service.Validate("batches", payload);
+    if (!validation.Ok)
+    {
+        return Results.BadRequest(new { errors = validation.Issues });
+    }
+
+    var saved = await service.UpsertAsync("batches", "batchId", payload, ct);
+    return Results.Ok(saved);
+});
+
+app.MapDelete("/api/batches/{id}", async (IGardenApplicationService service, string id, CancellationToken ct) =>
+{
+    var removed = await service.RemoveAsync("batches", "batchId", id, ct);
+    return removed ? Results.NoContent() : Results.NotFound();
+});
+
+app.MapPost("/api/validate/{collection}", (IGardenApplicationService service, string collection, JsonObject payload) =>
+{
+    var validation = service.Validate(collection, payload);
+    return Results.Ok(new
+    {
+        ok = validation.Ok,
+        issues = validation.Issues
+    });
+});
+
 await app.RunAsync();
+
+static void MapEntityCrud(WebApplication app, string collectionName, string idProperty)
+{
+    app.MapGet($"/api/{collectionName}", async (IGardenApplicationService service, CancellationToken ct) =>
+    {
+        var rows = await service.ListAsync(collectionName, ct);
+        return Results.Ok(rows);
+    });
+
+    app.MapGet($"/api/{collectionName}/{{id}}", async (IGardenApplicationService service, string id, CancellationToken ct) =>
+    {
+        var row = await service.GetByIdAsync(collectionName, idProperty, id, ct);
+        return row is null ? Results.NotFound() : Results.Ok(row);
+    });
+
+    app.MapPut($"/api/{collectionName}/{{id}}", async (IGardenApplicationService service, string id, JsonObject payload, CancellationToken ct) =>
+    {
+        payload[idProperty] = id;
+        var validation = service.Validate(collectionName, payload);
+        if (!validation.Ok)
+        {
+            return Results.BadRequest(new { errors = validation.Issues });
+        }
+
+        var saved = await service.UpsertAsync(collectionName, idProperty, payload, ct);
+        return Results.Ok(saved);
+    });
+
+    app.MapDelete($"/api/{collectionName}/{{id}}", async (IGardenApplicationService service, string id, CancellationToken ct) =>
+    {
+        var removed = await service.RemoveAsync(collectionName, idProperty, id, ct);
+        return removed ? Results.NoContent() : Results.NotFound();
+    });
+}

--- a/backend/SurvivalGarden.Application/DependencyInjection.cs
+++ b/backend/SurvivalGarden.Application/DependencyInjection.cs
@@ -6,6 +6,7 @@ public static class DependencyInjection
 {
     public static IServiceCollection AddApplication(this IServiceCollection services)
     {
+        services.AddScoped<IGardenApplicationService, GardenApplicationService>();
         return services;
     }
 }

--- a/backend/SurvivalGarden.Application/GardenApplicationService.cs
+++ b/backend/SurvivalGarden.Application/GardenApplicationService.cs
@@ -1,0 +1,274 @@
+using System.Text.Json.Nodes;
+
+namespace SurvivalGarden.Application;
+
+public sealed record ValidationIssue(string Path, string Message);
+
+public sealed record ValidationResult(bool Ok, IReadOnlyList<ValidationIssue> Issues)
+{
+    public static ValidationResult Success() => new(true, []);
+    public static ValidationResult Failure(params ValidationIssue[] issues) => new(false, issues);
+}
+
+public interface IGardenApplicationService
+{
+    Task<JsonObject?> LoadAppStateAsync(CancellationToken cancellationToken = default);
+    Task SaveAppStateAsync(JsonObject appState, CancellationToken cancellationToken = default);
+
+    Task<JsonArray> ListAsync(string collectionName, CancellationToken cancellationToken = default);
+    Task<JsonObject?> GetByIdAsync(string collectionName, string idProperty, string id, CancellationToken cancellationToken = default);
+    Task<JsonObject> UpsertAsync(string collectionName, string idProperty, JsonObject entity, CancellationToken cancellationToken = default);
+    Task<bool> RemoveAsync(string collectionName, string idProperty, string id, CancellationToken cancellationToken = default);
+
+    Task<JsonArray> ListBatchesAsync(string? stage, string? cropId, string? bedId, string? startedAtFrom, string? startedAtTo, CancellationToken cancellationToken = default);
+
+    ValidationResult Validate(string collectionName, JsonObject entity);
+}
+
+public interface IGardenStateStore
+{
+    Task<JsonObject?> LoadAsync(CancellationToken cancellationToken = default);
+    Task SaveAsync(JsonObject appState, CancellationToken cancellationToken = default);
+}
+
+public sealed class GardenApplicationService(IGardenStateStore store) : IGardenApplicationService
+{
+    private static readonly string[] RootCollections =
+    [
+        "species",
+        "crops",
+        "cultivars",
+        "batches",
+        "segments",
+        "beds",
+        "paths",
+        "seedInventoryItems",
+        "cropPlans"
+    ];
+
+    public Task<JsonObject?> LoadAppStateAsync(CancellationToken cancellationToken = default) => store.LoadAsync(cancellationToken);
+
+    public async Task SaveAppStateAsync(JsonObject appState, CancellationToken cancellationToken = default)
+    {
+        EnsureRootCollections(appState);
+        await store.SaveAsync(appState, cancellationToken);
+    }
+
+    public async Task<JsonArray> ListAsync(string collectionName, CancellationToken cancellationToken = default)
+    {
+        var state = await EnsureStateAsync(cancellationToken);
+        return CloneArray(GetCollection(state, collectionName));
+    }
+
+    public async Task<JsonObject?> GetByIdAsync(string collectionName, string idProperty, string id, CancellationToken cancellationToken = default)
+    {
+        var records = await ListAsync(collectionName, cancellationToken);
+        return records
+            .OfType<JsonObject>()
+            .FirstOrDefault(x => string.Equals(x[idProperty]?.GetValue<string>(), id, StringComparison.Ordinal));
+    }
+
+    public async Task<JsonObject> UpsertAsync(string collectionName, string idProperty, JsonObject entity, CancellationToken cancellationToken = default)
+    {
+        var validation = Validate(collectionName, entity);
+        if (!validation.Ok)
+        {
+            throw new InvalidOperationException(string.Join("; ", validation.Issues.Select(i => $"{i.Path}: {i.Message}")));
+        }
+
+        if (collectionName == "batches")
+        {
+            CanonicalizeBatchAliases(entity);
+        }
+
+        var state = await EnsureStateAsync(cancellationToken);
+        var records = GetCollection(state, collectionName);
+        var entityId = entity[idProperty]?.GetValue<string>() ?? string.Empty;
+
+        var existingIndex = records
+            .Select((node, index) => new { node, index })
+            .FirstOrDefault(entry =>
+                entry.node is JsonObject item &&
+                string.Equals(item[idProperty]?.GetValue<string>(), entityId, StringComparison.Ordinal))
+            ?.index;
+
+        if (existingIndex.HasValue)
+        {
+            records[existingIndex.Value] = entity.DeepClone();
+        }
+        else
+        {
+            records.Add(entity.DeepClone());
+        }
+
+        await store.SaveAsync(state, cancellationToken);
+        return (JsonObject)entity.DeepClone();
+    }
+
+    public async Task<bool> RemoveAsync(string collectionName, string idProperty, string id, CancellationToken cancellationToken = default)
+    {
+        var state = await EnsureStateAsync(cancellationToken);
+        var records = GetCollection(state, collectionName);
+
+        var existingIndex = records
+            .Select((node, index) => new { node, index })
+            .FirstOrDefault(entry =>
+                entry.node is JsonObject item &&
+                string.Equals(item[idProperty]?.GetValue<string>(), id, StringComparison.Ordinal))
+            ?.index;
+
+        if (!existingIndex.HasValue)
+        {
+            return false;
+        }
+
+        records.RemoveAt(existingIndex.Value);
+        await store.SaveAsync(state, cancellationToken);
+        return true;
+    }
+
+    public async Task<JsonArray> ListBatchesAsync(string? stage, string? cropId, string? bedId, string? startedAtFrom, string? startedAtTo, CancellationToken cancellationToken = default)
+    {
+        var records = await ListAsync("batches", cancellationToken);
+        var fromDate = ParseIso(startedAtFrom);
+        var toDate = ParseIso(startedAtTo);
+
+        var filtered = records
+            .OfType<JsonObject>()
+            .Where(batch => string.IsNullOrWhiteSpace(stage) || string.Equals(batch["stage"]?.GetValue<string>(), stage, StringComparison.OrdinalIgnoreCase))
+            .Where(batch => string.IsNullOrWhiteSpace(cropId) || string.Equals(batch["cropId"]?.GetValue<string>(), cropId, StringComparison.Ordinal))
+            .Where(batch => string.IsNullOrWhiteSpace(bedId) || HasBedAssignment(batch, bedId))
+            .Where(batch =>
+            {
+                var startedAt = ParseIso(batch["startedAt"]?.GetValue<string>());
+                if (fromDate.HasValue && (!startedAt.HasValue || startedAt.Value < fromDate.Value)) return false;
+                if (toDate.HasValue && (!startedAt.HasValue || startedAt.Value > toDate.Value)) return false;
+                return true;
+            })
+            .Select(batch => batch.DeepClone())
+            .ToArray();
+
+        return new JsonArray(filtered);
+    }
+
+    public ValidationResult Validate(string collectionName, JsonObject entity)
+    {
+        return collectionName switch
+        {
+            "species" => RequireId(entity, "id"),
+            "crops" => RequireId(entity, "cropId"),
+            "cultivars" => RequireId(entity, "id"),
+            "batches" => RequireId(entity, "batchId"),
+            "segments" => RequireId(entity, "segmentId"),
+            "beds" => RequireId(entity, "bedId"),
+            "paths" => RequireId(entity, "pathId"),
+            "seedInventoryItems" => RequireId(entity, "seedInventoryItemId"),
+            "cropPlans" => RequireId(entity, "planId"),
+            _ => ValidationResult.Success()
+        };
+    }
+
+    private static void CanonicalizeBatchAliases(JsonObject batch)
+    {
+        if (batch["currentStage"] is null && batch["stage"] is not null)
+        {
+            batch["currentStage"] = batch["stage"]?.DeepClone();
+        }
+
+        if (batch["stage"] is null && batch["currentStage"] is not null)
+        {
+            batch["stage"] = batch["currentStage"]?.DeepClone();
+        }
+
+        if (batch["assignments"] is null && batch["bedAssignments"] is not null)
+        {
+            batch["assignments"] = batch["bedAssignments"]?.DeepClone();
+        }
+
+        if (batch["bedAssignments"] is null && batch["assignments"] is not null)
+        {
+            batch["bedAssignments"] = batch["assignments"]?.DeepClone();
+        }
+
+        if (batch["stageEvents"] is null)
+        {
+            batch["stageEvents"] = new JsonArray();
+        }
+
+        if (batch["assignments"] is null)
+        {
+            batch["assignments"] = new JsonArray();
+        }
+
+        if (batch["bedAssignments"] is null)
+        {
+            batch["bedAssignments"] = batch["assignments"]?.DeepClone();
+        }
+    }
+
+    private static ValidationResult RequireId(JsonObject entity, string idProperty)
+    {
+        var idValue = entity[idProperty]?.GetValue<string>();
+        if (!string.IsNullOrWhiteSpace(idValue))
+        {
+            return ValidationResult.Success();
+        }
+
+        return ValidationResult.Failure(new ValidationIssue($"/{idProperty}", "is required"));
+    }
+
+    private async Task<JsonObject> EnsureStateAsync(CancellationToken cancellationToken)
+    {
+        var state = await store.LoadAsync(cancellationToken) ?? new JsonObject();
+        EnsureRootCollections(state);
+        return state;
+    }
+
+    private static void EnsureRootCollections(JsonObject state)
+    {
+        foreach (var name in RootCollections)
+        {
+            _ = GetCollection(state, name);
+        }
+    }
+
+    private static JsonArray GetCollection(JsonObject state, string name)
+    {
+        if (state[name] is JsonArray existing)
+        {
+            return existing;
+        }
+
+        var created = new JsonArray();
+        state[name] = created;
+        return created;
+    }
+
+    private static JsonArray CloneArray(JsonArray source)
+    {
+        return new JsonArray(source.Select(item => item?.DeepClone()).ToArray());
+    }
+
+    private static bool HasBedAssignment(JsonObject batch, string bedId)
+    {
+        var assignments = batch["assignments"] as JsonArray ?? batch["bedAssignments"] as JsonArray;
+        if (assignments is null)
+        {
+            return false;
+        }
+
+        return assignments
+            .OfType<JsonObject>()
+            .Any(assignment => string.Equals(assignment["bedId"]?.GetValue<string>(), bedId, StringComparison.Ordinal));
+    }
+
+    private static DateTimeOffset? ParseIso(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        return DateTimeOffset.TryParse(value, out var parsed) ? parsed : null;
+    }
+}

--- a/backend/SurvivalGarden.Application/GardenApplicationService.cs
+++ b/backend/SurvivalGarden.Application/GardenApplicationService.cs
@@ -54,13 +54,14 @@ public sealed class GardenApplicationService(IGardenStateStore store) : IGardenA
 
         var state = await EnsureStateAsync(cancellationToken);
         var records = GardenJsonCollectionHelpers.GetCollection(state, collectionName);
-        var entityId = entity[idProperty]?.GetValue<string>() ?? string.Empty;
+        var entityId = entity[idProperty]?.GetValue<string>() ?? entity["id"]?.GetValue<string>() ?? string.Empty;
 
         var existingIndex = records
             .Select((node, index) => new { node, index })
             .FirstOrDefault(entry =>
                 entry.node is JsonObject item &&
-                string.Equals(item[idProperty]?.GetValue<string>(), entityId, StringComparison.Ordinal))
+                (string.Equals(item[idProperty]?.GetValue<string>(), entityId, StringComparison.Ordinal) ||
+                 string.Equals(item["id"]?.GetValue<string>(), entityId, StringComparison.Ordinal)))
             ?.index;
 
         if (existingIndex.HasValue)
@@ -85,7 +86,8 @@ public sealed class GardenApplicationService(IGardenStateStore store) : IGardenA
             .Select((node, index) => new { node, index })
             .FirstOrDefault(entry =>
                 entry.node is JsonObject item &&
-                string.Equals(item[idProperty]?.GetValue<string>(), id, StringComparison.Ordinal))
+                (string.Equals(item[idProperty]?.GetValue<string>(), id, StringComparison.Ordinal) ||
+                 string.Equals(item["id"]?.GetValue<string>(), id, StringComparison.Ordinal)))
             ?.index;
 
         if (!existingIndex.HasValue)
@@ -126,28 +128,33 @@ public sealed class GardenApplicationService(IGardenStateStore store) : IGardenA
     {
         return collectionName switch
         {
-            "species" => RequireId(entity, "id"),
-            "crops" => RequireId(entity, "cropId"),
-            "cultivars" => RequireId(entity, "id"),
-            "batches" => RequireId(entity, "batchId"),
-            "segments" => RequireId(entity, "segmentId"),
-            "beds" => RequireId(entity, "bedId"),
-            "paths" => RequireId(entity, "pathId"),
-            "seedInventoryItems" => RequireId(entity, "seedInventoryItemId"),
-            "cropPlans" => RequireId(entity, "planId"),
+            "species" => RequireAnyId(entity, "id"),
+            "crops" => RequireAnyId(entity, "cropId"),
+            "cultivars" => RequireAnyId(entity, "id"),
+            "batches" => RequireAnyId(entity, "batchId"),
+            "segments" => RequireAnyId(entity, "segmentId"),
+            "beds" => RequireAnyId(entity, "bedId"),
+            "paths" => RequireAnyId(entity, "pathId"),
+            "seedInventoryItems" => RequireAnyId(entity, "seedInventoryItemId"),
+            "cropPlans" => RequireAnyId(entity, "planId"),
             _ => ValidationResult.Success()
         };
     }
 
-    private static ValidationResult RequireId(JsonObject entity, string idProperty)
+    private static ValidationResult RequireAnyId(JsonObject entity, string preferredIdProperty)
     {
-        var idValue = entity[idProperty]?.GetValue<string>();
-        if (!string.IsNullOrWhiteSpace(idValue))
+        var preferred = entity[preferredIdProperty]?.GetValue<string>();
+        var generic = entity["id"]?.GetValue<string>();
+
+        if (!string.IsNullOrWhiteSpace(preferred) || !string.IsNullOrWhiteSpace(generic))
         {
             return ValidationResult.Success();
         }
 
-        return ValidationResult.Failure(new ValidationIssue($"/{idProperty}", "is required"));
+        return ValidationResult.Failure(
+            new ValidationIssue($"/{preferredIdProperty}", "is required"),
+            new ValidationIssue("/id", "is required")
+        );
     }
 
     private async Task<JsonObject> EnsureStateAsync(CancellationToken cancellationToken)

--- a/backend/SurvivalGarden.Application/GardenApplicationService.cs
+++ b/backend/SurvivalGarden.Application/GardenApplicationService.cs
@@ -2,35 +2,6 @@ using System.Text.Json.Nodes;
 
 namespace SurvivalGarden.Application;
 
-public sealed record ValidationIssue(string Path, string Message);
-
-public sealed record ValidationResult(bool Ok, IReadOnlyList<ValidationIssue> Issues)
-{
-    public static ValidationResult Success() => new(true, []);
-    public static ValidationResult Failure(params ValidationIssue[] issues) => new(false, issues);
-}
-
-public interface IGardenApplicationService
-{
-    Task<JsonObject?> LoadAppStateAsync(CancellationToken cancellationToken = default);
-    Task SaveAppStateAsync(JsonObject appState, CancellationToken cancellationToken = default);
-
-    Task<JsonArray> ListAsync(string collectionName, CancellationToken cancellationToken = default);
-    Task<JsonObject?> GetByIdAsync(string collectionName, string idProperty, string id, CancellationToken cancellationToken = default);
-    Task<JsonObject> UpsertAsync(string collectionName, string idProperty, JsonObject entity, CancellationToken cancellationToken = default);
-    Task<bool> RemoveAsync(string collectionName, string idProperty, string id, CancellationToken cancellationToken = default);
-
-    Task<JsonArray> ListBatchesAsync(string? stage, string? cropId, string? bedId, string? startedAtFrom, string? startedAtTo, CancellationToken cancellationToken = default);
-
-    ValidationResult Validate(string collectionName, JsonObject entity);
-}
-
-public interface IGardenStateStore
-{
-    Task<JsonObject?> LoadAsync(CancellationToken cancellationToken = default);
-    Task SaveAsync(JsonObject appState, CancellationToken cancellationToken = default);
-}
-
 public sealed class GardenApplicationService(IGardenStateStore store) : IGardenApplicationService
 {
     private static readonly string[] RootCollections =
@@ -57,7 +28,7 @@ public sealed class GardenApplicationService(IGardenStateStore store) : IGardenA
     public async Task<JsonArray> ListAsync(string collectionName, CancellationToken cancellationToken = default)
     {
         var state = await EnsureStateAsync(cancellationToken);
-        return CloneArray(GetCollection(state, collectionName));
+        return GardenJsonCollectionHelpers.CloneArray(GardenJsonCollectionHelpers.GetCollection(state, collectionName));
     }
 
     public async Task<JsonObject?> GetByIdAsync(string collectionName, string idProperty, string id, CancellationToken cancellationToken = default)
@@ -78,11 +49,11 @@ public sealed class GardenApplicationService(IGardenStateStore store) : IGardenA
 
         if (collectionName == "batches")
         {
-            CanonicalizeBatchAliases(entity);
+            GardenJsonCollectionHelpers.CanonicalizeBatchAliases(entity);
         }
 
         var state = await EnsureStateAsync(cancellationToken);
-        var records = GetCollection(state, collectionName);
+        var records = GardenJsonCollectionHelpers.GetCollection(state, collectionName);
         var entityId = entity[idProperty]?.GetValue<string>() ?? string.Empty;
 
         var existingIndex = records
@@ -108,7 +79,7 @@ public sealed class GardenApplicationService(IGardenStateStore store) : IGardenA
     public async Task<bool> RemoveAsync(string collectionName, string idProperty, string id, CancellationToken cancellationToken = default)
     {
         var state = await EnsureStateAsync(cancellationToken);
-        var records = GetCollection(state, collectionName);
+        var records = GardenJsonCollectionHelpers.GetCollection(state, collectionName);
 
         var existingIndex = records
             .Select((node, index) => new { node, index })
@@ -130,17 +101,17 @@ public sealed class GardenApplicationService(IGardenStateStore store) : IGardenA
     public async Task<JsonArray> ListBatchesAsync(string? stage, string? cropId, string? bedId, string? startedAtFrom, string? startedAtTo, CancellationToken cancellationToken = default)
     {
         var records = await ListAsync("batches", cancellationToken);
-        var fromDate = ParseIso(startedAtFrom);
-        var toDate = ParseIso(startedAtTo);
+        var fromDate = GardenJsonCollectionHelpers.ParseIso(startedAtFrom);
+        var toDate = GardenJsonCollectionHelpers.ParseIso(startedAtTo);
 
         var filtered = records
             .OfType<JsonObject>()
             .Where(batch => string.IsNullOrWhiteSpace(stage) || string.Equals(batch["stage"]?.GetValue<string>(), stage, StringComparison.OrdinalIgnoreCase))
             .Where(batch => string.IsNullOrWhiteSpace(cropId) || string.Equals(batch["cropId"]?.GetValue<string>(), cropId, StringComparison.Ordinal))
-            .Where(batch => string.IsNullOrWhiteSpace(bedId) || HasBedAssignment(batch, bedId))
+            .Where(batch => string.IsNullOrWhiteSpace(bedId) || GardenJsonCollectionHelpers.HasBedAssignment(batch, bedId))
             .Where(batch =>
             {
-                var startedAt = ParseIso(batch["startedAt"]?.GetValue<string>());
+                var startedAt = GardenJsonCollectionHelpers.ParseIso(batch["startedAt"]?.GetValue<string>());
                 if (fromDate.HasValue && (!startedAt.HasValue || startedAt.Value < fromDate.Value)) return false;
                 if (toDate.HasValue && (!startedAt.HasValue || startedAt.Value > toDate.Value)) return false;
                 return true;
@@ -168,44 +139,6 @@ public sealed class GardenApplicationService(IGardenStateStore store) : IGardenA
         };
     }
 
-    private static void CanonicalizeBatchAliases(JsonObject batch)
-    {
-        if (batch["currentStage"] is null && batch["stage"] is not null)
-        {
-            batch["currentStage"] = batch["stage"]?.DeepClone();
-        }
-
-        if (batch["stage"] is null && batch["currentStage"] is not null)
-        {
-            batch["stage"] = batch["currentStage"]?.DeepClone();
-        }
-
-        if (batch["assignments"] is null && batch["bedAssignments"] is not null)
-        {
-            batch["assignments"] = batch["bedAssignments"]?.DeepClone();
-        }
-
-        if (batch["bedAssignments"] is null && batch["assignments"] is not null)
-        {
-            batch["bedAssignments"] = batch["assignments"]?.DeepClone();
-        }
-
-        if (batch["stageEvents"] is null)
-        {
-            batch["stageEvents"] = new JsonArray();
-        }
-
-        if (batch["assignments"] is null)
-        {
-            batch["assignments"] = new JsonArray();
-        }
-
-        if (batch["bedAssignments"] is null)
-        {
-            batch["bedAssignments"] = batch["assignments"]?.DeepClone();
-        }
-    }
-
     private static ValidationResult RequireId(JsonObject entity, string idProperty)
     {
         var idValue = entity[idProperty]?.GetValue<string>();
@@ -228,47 +161,7 @@ public sealed class GardenApplicationService(IGardenStateStore store) : IGardenA
     {
         foreach (var name in RootCollections)
         {
-            _ = GetCollection(state, name);
+            _ = GardenJsonCollectionHelpers.GetCollection(state, name);
         }
-    }
-
-    private static JsonArray GetCollection(JsonObject state, string name)
-    {
-        if (state[name] is JsonArray existing)
-        {
-            return existing;
-        }
-
-        var created = new JsonArray();
-        state[name] = created;
-        return created;
-    }
-
-    private static JsonArray CloneArray(JsonArray source)
-    {
-        return new JsonArray(source.Select(item => item?.DeepClone()).ToArray());
-    }
-
-    private static bool HasBedAssignment(JsonObject batch, string bedId)
-    {
-        var assignments = batch["assignments"] as JsonArray ?? batch["bedAssignments"] as JsonArray;
-        if (assignments is null)
-        {
-            return false;
-        }
-
-        return assignments
-            .OfType<JsonObject>()
-            .Any(assignment => string.Equals(assignment["bedId"]?.GetValue<string>(), bedId, StringComparison.Ordinal));
-    }
-
-    private static DateTimeOffset? ParseIso(string? value)
-    {
-        if (string.IsNullOrWhiteSpace(value))
-        {
-            return null;
-        }
-
-        return DateTimeOffset.TryParse(value, out var parsed) ? parsed : null;
     }
 }

--- a/backend/SurvivalGarden.Application/GardenJsonCollectionHelpers.cs
+++ b/backend/SurvivalGarden.Application/GardenJsonCollectionHelpers.cs
@@ -1,0 +1,84 @@
+using System.Text.Json.Nodes;
+
+namespace SurvivalGarden.Application;
+
+internal static class GardenJsonCollectionHelpers
+{
+    internal static JsonArray GetCollection(JsonObject state, string name)
+    {
+        if (state[name] is JsonArray existing)
+        {
+            return existing;
+        }
+
+        var created = new JsonArray();
+        state[name] = created;
+        return created;
+    }
+
+    internal static JsonArray CloneArray(JsonArray source)
+    {
+        return new JsonArray(source.Select(item => item?.DeepClone()).ToArray());
+    }
+
+    internal static void CanonicalizeBatchAliases(JsonObject batch)
+    {
+        if (batch["currentStage"] is null && batch["stage"] is not null)
+        {
+            batch["currentStage"] = batch["stage"]?.DeepClone();
+        }
+
+        if (batch["stage"] is null && batch["currentStage"] is not null)
+        {
+            batch["stage"] = batch["currentStage"]?.DeepClone();
+        }
+
+        if (batch["assignments"] is null && batch["bedAssignments"] is not null)
+        {
+            batch["assignments"] = batch["bedAssignments"]?.DeepClone();
+        }
+
+        if (batch["bedAssignments"] is null && batch["assignments"] is not null)
+        {
+            batch["bedAssignments"] = batch["assignments"]?.DeepClone();
+        }
+
+        if (batch["stageEvents"] is null)
+        {
+            batch["stageEvents"] = new JsonArray();
+        }
+
+        if (batch["assignments"] is null)
+        {
+            batch["assignments"] = new JsonArray();
+        }
+
+        if (batch["bedAssignments"] is null)
+        {
+            batch["bedAssignments"] = batch["assignments"]?.DeepClone();
+        }
+    }
+
+    internal static bool HasBedAssignment(JsonObject batch, string bedId)
+    {
+        var assignments = batch["assignments"] as JsonArray ?? batch["bedAssignments"] as JsonArray;
+        if (assignments is null)
+        {
+            return false;
+        }
+
+        return assignments
+            .OfType<JsonObject>()
+            .Any(assignment => string.Equals(assignment["bedId"]?.GetValue<string>(), bedId, StringComparison.Ordinal));
+    }
+
+    internal static DateTimeOffset? ParseIso(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        return DateTimeOffset.TryParse(value, out var parsed) ? parsed : null;
+    }
+}

--- a/backend/SurvivalGarden.Application/GardenJsonCollectionHelpers.cs
+++ b/backend/SurvivalGarden.Application/GardenJsonCollectionHelpers.cs
@@ -23,6 +23,9 @@ internal static class GardenJsonCollectionHelpers
 
     internal static void CanonicalizeBatchAliases(JsonObject batch)
     {
+        // Keep both canonical and legacy alias fields to mirror current TypeScript contract behavior.
+        // `assignments` is canonical while `bedAssignments` is a compatibility alias still present in fixtures.
+
         if (batch["currentStage"] is null && batch["stage"] is not null)
         {
             batch["currentStage"] = batch["stage"]?.DeepClone();

--- a/backend/SurvivalGarden.Application/IGardenApplicationService.cs
+++ b/backend/SurvivalGarden.Application/IGardenApplicationService.cs
@@ -1,0 +1,18 @@
+using System.Text.Json.Nodes;
+
+namespace SurvivalGarden.Application;
+
+public interface IGardenApplicationService
+{
+    Task<JsonObject?> LoadAppStateAsync(CancellationToken cancellationToken = default);
+    Task SaveAppStateAsync(JsonObject appState, CancellationToken cancellationToken = default);
+
+    Task<JsonArray> ListAsync(string collectionName, CancellationToken cancellationToken = default);
+    Task<JsonObject?> GetByIdAsync(string collectionName, string idProperty, string id, CancellationToken cancellationToken = default);
+    Task<JsonObject> UpsertAsync(string collectionName, string idProperty, JsonObject entity, CancellationToken cancellationToken = default);
+    Task<bool> RemoveAsync(string collectionName, string idProperty, string id, CancellationToken cancellationToken = default);
+
+    Task<JsonArray> ListBatchesAsync(string? stage, string? cropId, string? bedId, string? startedAtFrom, string? startedAtTo, CancellationToken cancellationToken = default);
+
+    ValidationResult Validate(string collectionName, JsonObject entity);
+}

--- a/backend/SurvivalGarden.Application/IGardenStateStore.cs
+++ b/backend/SurvivalGarden.Application/IGardenStateStore.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Nodes;
+
+namespace SurvivalGarden.Application;
+
+public interface IGardenStateStore
+{
+    Task<JsonObject?> LoadAsync(CancellationToken cancellationToken = default);
+    Task SaveAsync(JsonObject appState, CancellationToken cancellationToken = default);
+}

--- a/backend/SurvivalGarden.Application/ValidationModels.cs
+++ b/backend/SurvivalGarden.Application/ValidationModels.cs
@@ -1,0 +1,9 @@
+namespace SurvivalGarden.Application;
+
+public sealed record ValidationIssue(string Path, string Message);
+
+public sealed record ValidationResult(bool Ok, IReadOnlyList<ValidationIssue> Issues)
+{
+    public static ValidationResult Success() => new(true, []);
+    public static ValidationResult Failure(params ValidationIssue[] issues) => new(false, issues);
+}

--- a/backend/SurvivalGarden.Persistence/DependencyInjection.cs
+++ b/backend/SurvivalGarden.Persistence/DependencyInjection.cs
@@ -8,7 +8,11 @@ public static class DependencyInjection
     public static IServiceCollection AddPersistence(this IServiceCollection services, string? appStatePath = null)
     {
         var resolvedPath = appStatePath ?? Path.Combine(AppContext.BaseDirectory, "data", "app-state.json");
+
+        // Current default adapter is file-backed JSON persistence.
+        // The IGardenStateStore abstraction remains the seam for swapping to a database-backed adapter later.
         services.AddSingleton<IGardenStateStore>(_ => new JsonFileGardenStateStore(resolvedPath));
+
         return services;
     }
 }

--- a/backend/SurvivalGarden.Persistence/DependencyInjection.cs
+++ b/backend/SurvivalGarden.Persistence/DependencyInjection.cs
@@ -1,11 +1,14 @@
 using Microsoft.Extensions.DependencyInjection;
+using SurvivalGarden.Application;
 
 namespace SurvivalGarden.Persistence;
 
 public static class DependencyInjection
 {
-    public static IServiceCollection AddPersistence(this IServiceCollection services)
+    public static IServiceCollection AddPersistence(this IServiceCollection services, string? appStatePath = null)
     {
+        var resolvedPath = appStatePath ?? Path.Combine(AppContext.BaseDirectory, "data", "app-state.json");
+        services.AddSingleton<IGardenStateStore>(_ => new JsonFileGardenStateStore(resolvedPath));
         return services;
     }
 }

--- a/backend/SurvivalGarden.Persistence/JsonFileGardenStateStore.cs
+++ b/backend/SurvivalGarden.Persistence/JsonFileGardenStateStore.cs
@@ -1,0 +1,39 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using SurvivalGarden.Application;
+
+namespace SurvivalGarden.Persistence;
+
+public sealed class JsonFileGardenStateStore : IGardenStateStore
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true
+    };
+
+    private readonly string _filePath;
+
+    public JsonFileGardenStateStore(string filePath)
+    {
+        _filePath = filePath;
+    }
+
+    public async Task<JsonObject?> LoadAsync(CancellationToken cancellationToken = default)
+    {
+        if (!File.Exists(_filePath))
+        {
+            return null;
+        }
+
+        await using var stream = File.OpenRead(_filePath);
+        var node = await JsonNode.ParseAsync(stream, cancellationToken: cancellationToken);
+        return node as JsonObject;
+    }
+
+    public async Task SaveAsync(JsonObject appState, CancellationToken cancellationToken = default)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(_filePath) ?? ".");
+        await using var stream = File.Create(_filePath);
+        await JsonSerializer.SerializeAsync(stream, appState, JsonOptions, cancellationToken);
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide .NET application services that mirror existing TypeScript read/write/validation semantics for the garden data model so both stacks can operate on the same canonical state.
- Offer durable, reloadable storage for the canonical `AppState` as JSON on disk so .NET can persist/load the same fixtures used by the frontend/TS stack.
- Expose minimal HTTP endpoints for CRUD, batch filtering, and validation to support parity testing and incremental backend adoption.

### Description
- Added a new application service `IGardenApplicationService` and concrete `GardenApplicationService` implementing load/save of `AppState`, generic collection CRUD, batch-specific filtering, ID validation, and batch alias canonicalization; file: `backend/SurvivalGarden.Application/GardenApplicationService.cs`.
- Registered the application service in DI via `backend/SurvivalGarden.Application/DependencyInjection.cs` with `services.AddScoped<IGardenApplicationService, GardenApplicationService>()`.
- Implemented durable JSON file persistence with `JsonFileGardenStateStore` and wired it into persistence DI with a configurable `Persistence:AppStatePath` fallback; files: `backend/SurvivalGarden.Persistence/JsonFileGardenStateStore.cs` and updated `backend/SurvivalGarden.Persistence/DependencyInjection.cs`.
- Expanded API routing in `backend/SurvivalGarden.Api/Program.cs` to add endpoints for `GET/PUT /api/app-state`, `GET/PUT /api/settings`, generic CRUD for taxonomy/layout/inventory/crop plans, batch list/get/put/delete with filtering parameters, and a validation endpoint `POST /api/validate/{collection}` that returns structured validation issues.
- Kept behavior presentation-only: batch upserts canonicalize alias fields (`stage`/`currentStage`, `assignments`/`bedAssignments`) and ensure arrays (`stageEvents`, `assignments`) exist to mirror TS semantics; no domain logic changes to TS behavior.

### Testing
- No automated tests or builds were executed for this patch per FAST PATCH constraints; changes were committed to the repository for local verification and CI to run further validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c656bdf9bc832691bee03195451b08)