### PR TITLE
Refactor equivalence scenario fixture to explicit per-step assertions

### DIFF
--- a/fixtures/equivalence/equivalence-scenarios.v1.json
+++ b/fixtures/equivalence/equivalence-scenarios.v1.json
@@ -11,6 +11,12 @@
           "input": {
             "id": "species_equivalence_001",
             "name": "Phaseolus vulgaris"
+          },
+          "assert": {
+            "invariant": "species entity is persisted with the requested identity",
+            "observation": {
+              "createdEntityId": "species_equivalence_001"
+            }
           }
         },
         {
@@ -19,6 +25,12 @@
             "id": "crop_equivalence_001",
             "speciesId": "species_equivalence_001",
             "name": "Bush Bean"
+          },
+          "assert": {
+            "invariant": "crop creation resolves and keeps the species reference",
+            "observation": {
+              "createdEntityId": "crop_equivalence_001"
+            }
           }
         },
         {
@@ -27,12 +39,21 @@
             "id": "cultivar_equivalence_001",
             "cropId": "crop_equivalence_001",
             "name": "Provider"
+          },
+          "assert": {
+            "invariant": "taxonomy references resolve species -> crop -> cultivar",
+            "observation": {
+              "createdEntityId": "cultivar_equivalence_001"
+            }
           }
         },
         {
           "op": "reloadState",
-          "expect": {
-            "status": 200
+          "assert": {
+            "invariant": "taxonomy links survive reload without materialized-trace coupling",
+            "observation": {
+              "stateLoaded": true
+            }
           }
         }
       ]
@@ -47,6 +68,12 @@
             "id": "segment_equivalence_001",
             "name": "North Strip",
             "surface": "ground"
+          },
+          "assert": {
+            "invariant": "segment identity is created for downstream layout operations",
+            "observation": {
+              "createdEntityId": "segment_equivalence_001"
+            }
           }
         },
         {
@@ -55,6 +82,12 @@
             "id": "bed_equivalence_001",
             "segmentId": "segment_equivalence_001",
             "name": "North Bed 1"
+          },
+          "assert": {
+            "invariant": "bed is created beneath the selected segment",
+            "observation": {
+              "createdEntityId": "bed_equivalence_001"
+            }
           }
         },
         {
@@ -63,6 +96,12 @@
             "id": "path_equivalence_001",
             "segmentId": "segment_equivalence_001",
             "name": "North Path"
+          },
+          "assert": {
+            "invariant": "path is created in the same segment namespace as the bed",
+            "observation": {
+              "createdEntityId": "path_equivalence_001"
+            }
           }
         },
         {
@@ -72,6 +111,12 @@
             "cropId": "crop_potato_bintje",
             "stage": "planned",
             "startedAt": "2026-03-01"
+          },
+          "assert": {
+            "invariant": "batch is created with a stable batch identity",
+            "observation": {
+              "createdBatchId": "batch_equivalence_001"
+            }
           }
         },
         {
@@ -80,6 +125,12 @@
             "batchId": "batch_equivalence_001",
             "bedId": "bed_equivalence_001",
             "assignedAt": "2026-03-01"
+          },
+          "assert": {
+            "invariant": "assignment response confirms batch is linked to the bed",
+            "observation": {
+              "assignmentPresent": true
+            }
           }
         },
         {
@@ -87,12 +138,37 @@
           "input": {
             "bedId": "bed_equivalence_001"
           },
-          "expect": {
-            "status": 200
+          "assert": {
+            "invariant": "assigned batch is discoverable by bed query",
+            "observation": {
+              "batchIds": [
+                "batch_equivalence_001"
+              ]
+            }
           }
         },
         {
-          "op": "reloadState"
+          "op": "reloadState",
+          "assert": {
+            "invariant": "batch assignment remains visible after reload",
+            "observation": {
+              "stateLoaded": true
+            }
+          }
+        },
+        {
+          "op": "listBatchesByBed",
+          "input": {
+            "bedId": "bed_equivalence_001"
+          },
+          "assert": {
+            "invariant": "reloaded state returns the same batch assignment",
+            "observation": {
+              "batchIds": [
+                "batch_equivalence_001"
+              ]
+            }
+          }
         }
       ]
     },
@@ -107,6 +183,12 @@
             "cultivarId": "cultivar_cabbage_golden_acre",
             "quantity": 20,
             "unit": "seed"
+          },
+          "assert": {
+            "invariant": "inventory item is persisted with a deterministic identity",
+            "observation": {
+              "createdEntityId": "seed_equivalence_001"
+            }
           }
         },
         {
@@ -116,6 +198,12 @@
             "cropId": "crop_cabbage_golden_acre",
             "bedId": "bed_001",
             "plannedDate": "2026-04-01"
+          },
+          "assert": {
+            "invariant": "crop plan creation is represented semantically by plan identity",
+            "observation": {
+              "createdEntityId": "plan_equivalence_001"
+            }
           }
         },
         {
@@ -123,12 +211,66 @@
           "input": {
             "cropId": "crop_cabbage_golden_acre"
           },
-          "expect": {
-            "status": 200
+          "assert": {
+            "invariant": "validation fails with the expected normalized rule category",
+            "observation": {
+              "issues": [
+                {
+                  "messageCategory": "missing_required"
+                }
+              ]
+            }
           }
         },
         {
-          "op": "reloadState"
+          "op": "reloadState",
+          "assert": {
+            "invariant": "state reload succeeds before export/idempotence checks",
+            "observation": {
+              "stateLoaded": true
+            }
+          }
+        },
+        {
+          "op": "validateBatch",
+          "input": {
+            "cropId": "crop_cabbage_golden_acre"
+          },
+          "assert": {
+            "invariant": "repeated reload/validation is idempotent",
+            "observation": {
+              "issues": [
+                {
+                  "messageCategory": "missing_required"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "op": "reloadState",
+          "assert": {
+            "invariant": "second reload preserves export-equivalent state",
+            "observation": {
+              "stateLoaded": true
+            }
+          }
+        },
+        {
+          "op": "validateBatch",
+          "input": {
+            "cropId": "crop_cabbage_golden_acre"
+          },
+          "assert": {
+            "invariant": "second validation remains semantically identical to the first",
+            "observation": {
+              "issues": [
+                {
+                  "messageCategory": "missing_required"
+                }
+              ]
+            }
+          }
         }
       ]
     }


### PR DESCRIPTION
### Motivation
- Make equivalence scenarios assert semantic invariants at each step instead of relying on transport-level trace matching.  
- Express expectations as per-step `assert` blocks containing an `invariant` description and an expected semantic `observation`.  
- Add idempotence checks so equivalence is proven by invariant satisfaction (repeated semantic operations) rather than by matching API call traces.

### Description
- Replaced sparse `expect` usage with explicit per-step `assert` objects in `fixtures/equivalence/equivalence-scenarios.v1.json`, each containing `invariant` and `observation` fields.  
- Added and adjusted steps to cover taxonomy resolution (`species -> crop -> cultivar`), batch assignment persistence across reload, and validation-category expectations (`missing_required`).  
- Introduced repeated `validateBatch`/`reloadState` steps to model idempotence of validation and reload semantics rather than export/trace equality.  
- Kept all semantic `op` names unchanged and made no changes to runtime adapters or code behavior—fixture-only change.

### Testing
- Validated the updated fixture is well-formed JSON with `jq . fixtures/equivalence/equivalence-scenarios.v1.json` which succeeded.  
- No runtime equivalence runs were performed as part of this change; adapters and harness remain unchanged and should interpret the new `assert` blocks when exercised by the equivalence runner.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbc52bb9388326838d3c5d18b6ac1c)