### PR TITLE
Extend equivalence report with semantic assertions and mismatch buckets

### DIFF
--- a/scripts/equivalence/README.md
+++ b/scripts/equivalence/README.md
@@ -48,6 +48,11 @@ node scripts/equivalence/run-equivalence.mjs \
 - It compares for each scenario:
   - normalized semantic step results (status + response body)
   - normalized final persisted app-state snapshot after scenario execution
-- Report output contains mismatch paths, reasons, scenario IDs, and classification for triage.
+- Report output contains:
+  - `semanticAssertions` (pass/fail assertion results per scenario)
+  - `projectedStateDiff` (business-level state mismatches used for gate decisions)
+  - `rawStateDiff` (debug-only raw snapshot differences)
+  - `allowedMismatches` and `blockingMismatches` (both scenario-level and top-level)
+- Console output includes a short summary of total assertions, blocking failures, allowlisted differences, and suggested next action.
 
 This is intended as a required pre-cutover gate between the legacy TypeScript path and .NET backend.

--- a/scripts/equivalence/run-equivalence.mjs
+++ b/scripts/equivalence/run-equivalence.mjs
@@ -49,11 +49,17 @@ const report = {
   allowlistFile: path.relative(repoRoot, allowlistPath),
   fixture: path.relative(repoRoot, fixturePath),
   summary: {
+    totalAssertions: 0,
+    blockingFailures: 0,
+    allowlistedDifferences: 0,
+    suggestedNextAction: 'Review scenario-level mismatches for next steps.',
     blocked: 0,
     allowed: 0,
     allowlistValidationErrors: allowlistValidationErrors.length,
   },
   allowlistValidationErrors,
+  allowedMismatches: [],
+  blockingMismatches: [],
   mismatches: [],
   scenarios: [],
 };
@@ -113,23 +119,54 @@ for (const scenario of scenariosDoc.scenarios ?? []) {
     };
   }
 
-  const scenarioMismatches = [];
-  compareStepObservations(`scenario:${scenario.id}:stepObservations`, runResults.typescript.stepObservations, runResults.dotnet.stepObservations, scenarioMismatches);
+  const stepObservationDiff = [];
+  compareStepObservations(
+    `scenario:${scenario.id}:stepObservations`,
+    runResults.typescript.stepObservations,
+    runResults.dotnet.stepObservations,
+    stepObservationDiff,
+  );
+
+  const projectedStateDiff = [];
   compareValues(
     `scenario:${scenario.id}:finalState`,
     runResults.typescript.finalStateProjected,
     runResults.dotnet.finalStateProjected,
-    scenarioMismatches,
+    projectedStateDiff,
   );
 
-  const classifiedMismatches = scenarioMismatches.map((mismatch) =>
+  const rawStateDiff = [];
+  compareValues(`scenario:${scenario.id}:finalStateRaw`, runResults.typescript.finalStateRaw, runResults.dotnet.finalStateRaw, rawStateDiff);
+
+  const semanticMismatchCandidates = [...stepObservationDiff, ...projectedStateDiff];
+  const classifiedSemanticMismatches = semanticMismatchCandidates.map((mismatch) =>
     classifyMismatch(mismatch, scenario.id, compiledAllowlistEntries),
   );
+  const classifiedRawStateDiff = rawStateDiff.map((mismatch) => classifyMismatch(mismatch, scenario.id, compiledAllowlistEntries));
+
+  const blockingMismatches = classifiedSemanticMismatches.filter((mismatch) => mismatch.classification === 'blocked');
+  const allowedMismatches = classifiedSemanticMismatches.filter((mismatch) => mismatch.classification === 'allowed');
 
   report.scenarios.push({
     id: scenario.id,
     name: scenario.name,
     steps: scenario.steps?.length ?? 0,
+    semanticAssertions: [
+      {
+        id: 'stepObservationsEquivalent',
+        pass: stepObservationDiff.length === 0,
+        failureCount: stepObservationDiff.length,
+      },
+      {
+        id: 'projectedStateEquivalent',
+        pass: projectedStateDiff.length === 0,
+        failureCount: projectedStateDiff.length,
+      },
+    ],
+    projectedStateDiff: classifiedSemanticMismatches.filter((mismatch) => mismatch.path.includes(':finalState')),
+    rawStateDiff: classifiedRawStateDiff,
+    blockingMismatches,
+    allowedMismatches,
     snapshots: {
       typescript: {
         raw: runResults.typescript.finalStateRaw,
@@ -140,14 +177,25 @@ for (const scenario of scenariosDoc.scenarios ?? []) {
         projected: runResults.dotnet.finalStateProjected,
       },
     },
-    mismatches: classifiedMismatches,
+    mismatches: classifiedSemanticMismatches,
   });
 
-  report.mismatches.push(...classifiedMismatches);
+  report.mismatches.push(...classifiedSemanticMismatches);
+  report.blockingMismatches.push(...blockingMismatches);
+  report.allowedMismatches.push(...allowedMismatches);
+  report.summary.totalAssertions += 2;
 }
 
 report.summary.blocked = report.mismatches.filter((mismatch) => mismatch.classification === 'blocked').length;
 report.summary.allowed = report.mismatches.filter((mismatch) => mismatch.classification === 'allowed').length;
+report.summary.blockingFailures = report.summary.blocked;
+report.summary.allowlistedDifferences = report.summary.allowed;
+report.summary.suggestedNextAction =
+  report.summary.blockingFailures > 0
+    ? 'Investigate blocking mismatches in projectedStateDiff and semanticAssertions.'
+    : report.summary.allowlistedDifferences > 0
+      ? 'No blockers found; review allowlisted differences and retire debt where possible.'
+      : 'No mismatches detected; proceed with cutover checks.';
 
 await mkdir(path.dirname(outputPath), { recursive: true });
 await writeFile(outputPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
@@ -167,13 +215,12 @@ if (report.summary.blocked > 0) {
 }
 
 if (allowlistValidationErrors.length > 0 || report.summary.blocked > 0) {
+  logConsoleSummary(report);
   process.exit(1);
 }
 
+logConsoleSummary(report);
 console.log(`Equivalence suite passed (${report.scenarios.length} scenarios).`);
-if (report.summary.allowed > 0) {
-  console.log(`Allowed mismatches (tracked debt): ${report.summary.allowed}`);
-}
 console.log(`Report written to ${path.relative(repoRoot, outputPath)}`);
 
 function compileAllowlist(allowlist, todayDate) {
@@ -629,4 +676,12 @@ function chooseStableSortKey(items) {
   }
 
   return null;
+}
+
+function logConsoleSummary(reportDocument) {
+  console.log('Equivalence summary:');
+  console.log(`- total assertions: ${reportDocument.summary.totalAssertions}`);
+  console.log(`- blocking failures: ${reportDocument.summary.blockingFailures}`);
+  console.log(`- allowlisted differences: ${reportDocument.summary.allowlistedDifferences}`);
+  console.log(`- suggested next action: ${reportDocument.summary.suggestedNextAction}`);
 }


### PR DESCRIPTION
### Motivation
- Improve the equivalence harness report to separate business-level (semantic) failures from raw/debug diffs so triage is clearer.
- Capture allowlisted vs blocking mismatches explicitly to make gate decisions and tracked debt easier to inspect.
- Provide a short console summary that surfaces total assertions, blocking failures, allowlisted differences, and a suggested next action for quick feedback.

### Description
- Extended the top-level report schema in `scripts/equivalence/run-equivalence.mjs` with `summary.totalAssertions`, `summary.blockingFailures`, `summary.allowlistedDifferences`, `summary.suggestedNextAction`, and top-level `allowedMismatches` and `blockingMismatches` arrays.
- For each scenario the report now includes `semanticAssertions` (pass/fail per assertion), `projectedStateDiff` (business-level diffs used for gate decisions), `rawStateDiff` (debug-only), and scenario-level `allowedMismatches` and `blockingMismatches` buckets, plus the existing `mismatches` list now focused on semantic mismatches.
- Added collection of step-observation diffs, projected-state diffs, and raw-state diffs, and classification of semantic vs raw diffs via existing `classifyMismatch` logic.
- Added a `logConsoleSummary(report)` helper that prints the short console summary and integrated it into both pass and fail paths, and updated `scripts/equivalence/README.md` to document the new report fields and console output.

### Testing
- Ran `node --check scripts/equivalence/run-equivalence.mjs` to validate the script parses and is syntactically correct, which succeeded.
- Verified the modified files were the intended targets by checking the repository status after the changes (no automated test failures reported by the script-check step).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbcb93ac348326b355682b58192f44)