### PR TITLE
Add feature-flagged frontend workflow adapter routing

### DIFF
--- a/frontend/src/data/index.ts
+++ b/frontend/src/data/index.ts
@@ -14,6 +14,7 @@ import {
   upsertGeneratedTasksInAppState as upsertGeneratedTasksInAppStateLocal,
 } from './repos/taskRepository';
 import { applyStageEvent } from '../domain';
+import { getFrontendMode, isWorkflowRoutedToBackend, toBackendApiUrl, workflowAdapter } from './workflowAdapter';
 import goldenDatasetFixture from '../../../fixtures/golden/trier-v1.json';
 
 export {
@@ -83,10 +84,7 @@ const DEFAULT_SEGMENT_ID = 'segment_default_main';
 const DEFAULT_SEGMENT_NAME = 'Main Segment';
 const DEFAULT_SEGMENT_ORIGIN = 'default_bootstrap';
 type AppSegment = NonNullable<AppState['segments']>[number];
-type DataExecutionMode = 'typescript' | 'backend';
-
 const LEGACY_BED_TYPE = 'vegetable_bed';
-const DEFAULT_BACKEND_API_BASE_URL = '';
 
 type LayoutMigrationWarningCode =
   | 'legacy_layout_segment_created'
@@ -108,28 +106,7 @@ type LayoutMigrationReport = {
   warnings: LayoutMigrationWarning[];
 };
 
-const resolveRuntimeEnv = (): Record<string, string | undefined> => {
-  const importMetaEnv = (import.meta as ImportMeta & { env?: Record<string, string | undefined> }).env;
-  if (importMetaEnv) {
-    return importMetaEnv;
-  }
-
-  const processEnv = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env;
-  return processEnv ?? {};
-};
-
-const getDataExecutionMode = (): DataExecutionMode => {
-  const env = resolveRuntimeEnv();
-  const configuredMode = env.VITE_FRONTEND_MODE ?? 'typescript';
-  return configuredMode.toLowerCase() === 'backend' ? 'backend' : 'typescript';
-};
-
-const getBackendApiBaseUrl = (): string => {
-  const env = resolveRuntimeEnv();
-  return (env.VITE_BACKEND_API_BASE_URL ?? DEFAULT_BACKEND_API_BASE_URL).trim().replace(/\/$/, '');
-};
-
-const toBackendApiUrl = (path: string): string => `${getBackendApiBaseUrl()}${path}`;
+const isBackendModeEnabled = (): boolean => getFrontendMode() === 'backend';
 
 const addTypeToLegacyBed = <T extends Record<string, unknown>>(bed: T): T => ({
   ...bed,
@@ -1323,7 +1300,7 @@ const openAppStateDatabase = async (): Promise<IDBDatabase> => {
 };
 
 export const initializeAppStateStorage = async (): Promise<void> => {
-  if (getDataExecutionMode() === 'backend') {
+  if (isBackendModeEnabled()) {
     try {
       const backendState = await loadAppStateFromBackendApi();
       const localState = await loadAppStateFromLocalIndexedDb();
@@ -1388,7 +1365,7 @@ export const createEmptyAppState = (currentState: AppState | null): AppState => 
 });
 
 export const resetToGoldenDataset = async (): Promise<void> => {
-  if (getDataExecutionMode() === 'backend') {
+  if (isBackendModeEnabled()) {
     await saveAppStateToIndexedDb(GOLDEN_DATASET, { mode: 'replace' });
     return;
   }
@@ -1467,7 +1444,7 @@ const loadAppStateFromLocalIndexedDb = async (): Promise<AppState | null> => {
 };
 
 export const loadAppStateFromIndexedDb = async (): Promise<AppState | null> => {
-  if (getDataExecutionMode() === 'backend') {
+  if (isBackendModeEnabled()) {
     try {
       const backendState = await loadAppStateFromBackendApi();
 
@@ -1489,7 +1466,7 @@ const saveAppStateToLocalIndexedDb = async (
   appState: unknown,
   options: SaveAppStateOptions = {},
 ): Promise<MergeReport | null> => {
-  if (getDataExecutionMode() === 'backend') {
+  if (isBackendModeEnabled()) {
     const candidateState =
       appState && typeof appState === 'object'
         ? {
@@ -1636,7 +1613,7 @@ export const saveAppStateToIndexedDb = async (
   appState: unknown,
   options: SaveAppStateOptions & { mirrorToLocal?: boolean } = {},
 ): Promise<MergeReport | null> => {
-  if (getDataExecutionMode() === 'backend') {
+  if (isBackendModeEnabled()) {
     const candidateState =
       appState && typeof appState === 'object'
         ? {
@@ -1689,36 +1666,13 @@ export const saveAppStateToIndexedDb = async (
   return saveAppStateToLocalIndexedDb(appState, options);
 };
 
-const parseBackendError = async (response: Response): Promise<string> => {
-  try {
-    const payload = await response.json();
-    if (payload && typeof payload.error === 'string') {
-      return payload.error;
-    }
-  } catch {
-    // ignore parse issues; fall back to status text
-  }
-
-  return `${response.status} ${response.statusText}`;
-};
-
 export const transitionBatchStage = async (
   batchId: string,
   nextStage: string,
   occurredAt: string,
 ): Promise<Batch> => {
-  if (getDataExecutionMode() === 'backend') {
-    const response = await fetch(toBackendApiUrl(`/api/domain/batches/${encodeURIComponent(batchId)}/stage-events`), {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ stage: nextStage, occurredAt }),
-    });
-
-    if (!response.ok) {
-      throw new Error(await parseBackendError(response));
-    }
-
-    return assertValid('batch', await response.json());
+  if (isWorkflowRoutedToBackend('batches')) {
+    return assertValid('batch', await workflowAdapter.batches.transitionStage(batchId, nextStage, occurredAt));
   }
 
   const appState = await loadAppStateFromIndexedDb();
@@ -1745,18 +1699,8 @@ export const mutateBatchAssignment = async (
   operation: 'assign' | 'move' | 'remove',
   payload: { batchId: string; bedId?: string; at: string },
 ): Promise<Batch> => {
-  if (getDataExecutionMode() === 'backend') {
-    const response = await fetch(toBackendApiUrl(`/api/domain/batches/${encodeURIComponent(payload.batchId)}/assignment`), {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ operation, bedId: payload.bedId, at: payload.at }),
-    });
-
-    if (!response.ok) {
-      throw new Error(await parseBackendError(response));
-    }
-
-    return assertValid('batch', await response.json());
+  if (isWorkflowRoutedToBackend('batches')) {
+    return assertValid('batch', await workflowAdapter.batches.mutateAssignment(operation, payload));
   }
 
   const appState = await loadAppStateFromIndexedDb();
@@ -1781,21 +1725,11 @@ export const mutateBatchAssignment = async (
 };
 
 export const regenerateCalendarTasks = async (year: number) => {
-  if (getDataExecutionMode() === 'backend') {
-    const response = await fetch(toBackendApiUrl('/api/domain/tasks/regenerate-calendar'), {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ year }),
-    });
-
-    if (!response.ok) {
-      throw new Error(await parseBackendError(response));
-    }
-
-    const payload = await response.json();
+  if (isWorkflowRoutedToBackend('tasks')) {
+    const payload = await workflowAdapter.tasks.regenerateCalendar(year);
     return {
-      generatedTasks: payload.generatedTasks as AppState['tasks'],
-      diagnostics: (payload.diagnostics ?? []) as { cropId: string; reason: string; detail: string }[],
+      generatedTasks: payload.generatedTasks,
+      diagnostics: payload.diagnostics,
       stateAfter: assertValid('appState', payload.stateAfter),
     };
   }

--- a/frontend/src/data/workflowAdapter.test.ts
+++ b/frontend/src/data/workflowAdapter.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  isWorkflowRoutedToBackend,
+  workflowAdapter,
+} from './workflowAdapter';
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+  globalThis.fetch = originalFetch;
+});
+
+describe('workflow routing flags', () => {
+  it('keeps routing disabled outside backend mode', () => {
+    vi.stubEnv('VITE_FRONTEND_MODE', 'typescript');
+    vi.stubEnv('VITE_ROUTE_BATCHES_TO_BACKEND', 'true');
+
+    expect(isWorkflowRoutedToBackend('batches')).toBe(false);
+  });
+
+  it('enables only explicitly flagged workflows in backend mode', () => {
+    vi.stubEnv('VITE_FRONTEND_MODE', 'backend');
+    vi.stubEnv('VITE_ROUTE_BATCHES_TO_BACKEND', 'true');
+    vi.stubEnv('VITE_ROUTE_TASKS_TO_BACKEND', 'false');
+
+    expect(isWorkflowRoutedToBackend('batches')).toBe(true);
+    expect(isWorkflowRoutedToBackend('tasks')).toBe(false);
+  });
+});
+
+describe('workflow adapter transport', () => {
+  it('posts stage transitions to the backend domain endpoint', async () => {
+    vi.stubEnv('VITE_BACKEND_API_BASE_URL', 'http://localhost:5142');
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ batchId: 'batch-1', stage: 'harvest' }),
+    } as Response);
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const batch = await workflowAdapter.batches.transitionStage('batch-1', 'harvest', '2026-04-01T00:00:00Z');
+
+    expect(batch.batchId).toBe('batch-1');
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://localhost:5142/api/domain/batches/batch-1/stage-events',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+});

--- a/frontend/src/data/workflowAdapter.ts
+++ b/frontend/src/data/workflowAdapter.ts
@@ -1,0 +1,116 @@
+import type { AppState, Batch } from '../contracts';
+
+export type WorkflowFeature = 'batches' | 'tasks' | 'bedsSegments' | 'taxonomy' | 'inventory';
+
+const DEFAULT_BACKEND_API_BASE_URL = '';
+
+const resolveRuntimeEnv = (): Record<string, string | undefined> => {
+  const processEnv = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env;
+  if (processEnv) {
+    return processEnv;
+  }
+
+  const importMetaEnv = (import.meta as ImportMeta & { env?: Record<string, string | undefined> }).env;
+  if (importMetaEnv) {
+    return importMetaEnv;
+  }
+
+  return {};
+};
+
+export const getBackendApiBaseUrl = (): string => {
+  const env = resolveRuntimeEnv();
+  return (env.VITE_BACKEND_API_BASE_URL ?? DEFAULT_BACKEND_API_BASE_URL).trim().replace(/\/$/, '');
+};
+
+export const toBackendApiUrl = (path: string): string => `${getBackendApiBaseUrl()}${path}`;
+
+const isFeatureFlagEnabled = (value: string | undefined): boolean => value?.trim().toLowerCase() === 'true';
+
+export const getFrontendMode = (): 'typescript' | 'backend' => {
+  const env = resolveRuntimeEnv();
+  return env.VITE_FRONTEND_MODE?.trim().toLowerCase() === 'backend' ? 'backend' : 'typescript';
+};
+
+const workflowFlagByFeature: Record<WorkflowFeature, string> = {
+  batches: 'VITE_ROUTE_BATCHES_TO_BACKEND',
+  tasks: 'VITE_ROUTE_TASKS_TO_BACKEND',
+  bedsSegments: 'VITE_ROUTE_BEDS_SEGMENTS_TO_BACKEND',
+  taxonomy: 'VITE_ROUTE_TAXONOMY_TO_BACKEND',
+  inventory: 'VITE_ROUTE_INVENTORY_TO_BACKEND',
+};
+
+export const isWorkflowRoutedToBackend = (feature: WorkflowFeature): boolean => {
+  if (getFrontendMode() !== 'backend') {
+    return false;
+  }
+
+  const env = resolveRuntimeEnv();
+  return isFeatureFlagEnabled(env[workflowFlagByFeature[feature]]);
+};
+
+export const parseBackendError = async (response: Response): Promise<string> => {
+  try {
+    const payload = await response.json();
+    if (payload && typeof payload.error === 'string') {
+      return payload.error;
+    }
+  } catch {
+    // ignore parse issues; fall back to status text
+  }
+
+  return `${response.status} ${response.statusText}`;
+};
+
+const fetchJson = async <T>(path: string, init?: RequestInit): Promise<T> => {
+  const response = await fetch(toBackendApiUrl(path), init);
+
+  if (!response.ok) {
+    throw new Error(await parseBackendError(response));
+  }
+
+  return response.json() as Promise<T>;
+};
+
+export const workflowAdapter = {
+  batches: {
+    transitionStage: async (batchId: string, nextStage: string, occurredAt: string): Promise<Batch> =>
+      fetchJson<Batch>(`/api/domain/batches/${encodeURIComponent(batchId)}/stage-events`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ stage: nextStage, occurredAt }),
+      }),
+    mutateAssignment: async (
+      operation: 'assign' | 'move' | 'remove',
+      payload: { batchId: string; bedId?: string; at: string },
+    ): Promise<Batch> =>
+      fetchJson<Batch>(`/api/domain/batches/${encodeURIComponent(payload.batchId)}/assignment`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ operation, bedId: payload.bedId, at: payload.at }),
+      }),
+  },
+  tasks: {
+    regenerateCalendar: async (year: number): Promise<{
+      generatedTasks: AppState['tasks'];
+      diagnostics: { cropId: string; reason: string; detail: string }[];
+      stateAfter: AppState;
+    }> => {
+      const payload = await fetchJson<{
+        generatedTasks: AppState['tasks'];
+        diagnostics?: { cropId: string; reason: string; detail: string }[];
+        stateAfter: AppState;
+      }>('/api/domain/tasks/regenerate-calendar', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ year }),
+      });
+
+      return {
+        generatedTasks: payload.generatedTasks,
+        diagnostics: payload.diagnostics ?? [],
+        stateAfter: payload.stateAfter,
+      };
+    },
+  },
+};


### PR DESCRIPTION
### Motivation
- Provide a rollout-safe adapter layer that maps specific core workflows to backend endpoints instead of relying on whole-app app-state blob sync. 
- Enable feature-by-feature routing so each workflow (batches, tasks, beds/segments, taxonomy, inventory) can be toggled independently during backend rollout. 

### Description
- Added a new `workflowAdapter` module (`frontend/src/data/workflowAdapter.ts`) that centralizes backend URL/env resolution, error parsing, and transport helpers, and exposes `workflowAdapter` methods for `batches` and `tasks`. 
- Introduced per-workflow routing flags via `isWorkflowRoutedToBackend(...)` and environment flags: `VITE_ROUTE_BATCHES_TO_BACKEND`, `VITE_ROUTE_TASKS_TO_BACKEND`, `VITE_ROUTE_BEDS_SEGMENTS_TO_BACKEND`, `VITE_ROUTE_TAXONOMY_TO_BACKEND`, and `VITE_ROUTE_INVENTORY_TO_BACKEND`. 
- Wired the adapter into the existing data boundary by updating `frontend/src/data/index.ts` to route `transitionBatchStage`, `mutateBatchAssignment`, and `regenerateCalendarTasks` through the backend adapter only when the corresponding workflow flag is enabled, otherwise falling back to the existing TypeScript/local app-state implementations. 
- Added unit tests (`frontend/src/data/workflowAdapter.test.ts`) covering routing flag behavior and backend transport mapping for stage transitions. 

### Testing
- Ran the targeted frontend tests with Vitest: `pnpm test -- workflowAdapter.test.ts`, and then the suite; all tests passed (`Tests 123 passed | 8 skipped`) after addressing initial expectations; the adapter tests verify routing flags and request wiring. 
- Ran type checks with `pnpm typecheck` and observed no TypeScript errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfb2c99bfc83269bdb040046aaec75)