### PR TITLE
Deprecate TypeScript workflow paths behind parity gating and rollback shims

### DIFF
--- a/frontend/src/data/index.ts
+++ b/frontend/src/data/index.ts
@@ -14,7 +14,13 @@ import {
   upsertGeneratedTasksInAppState as upsertGeneratedTasksInAppStateLocal,
 } from './repos/taskRepository';
 import { applyStageEvent } from '../domain';
-import { getFrontendMode, isWorkflowRoutedToBackend, toBackendApiUrl, workflowAdapter } from './workflowAdapter';
+import {
+  getFrontendMode,
+  shouldUseCanonicalBackendPath,
+  shouldUseTypescriptRollbackShim,
+  toBackendApiUrl,
+  workflowAdapter,
+} from './workflowAdapter';
 import goldenDatasetFixture from '../../../fixtures/golden/trier-v1.json';
 
 export {
@@ -1671,10 +1677,12 @@ export const transitionBatchStage = async (
   nextStage: string,
   occurredAt: string,
 ): Promise<Batch> => {
-  if (isWorkflowRoutedToBackend('batches')) {
+  if (shouldUseCanonicalBackendPath('batches') && !shouldUseTypescriptRollbackShim('batches')) {
     return assertValid('batch', await workflowAdapter.batches.transitionStage(batchId, nextStage, occurredAt));
   }
 
+  // Deprecated rollback shim. Remove once TypeScript rollback window is retired.
+  console.warn('[DEPRECATED] Using TypeScript batch stage transition rollback shim.');
   const appState = await loadAppStateFromIndexedDb();
   if (!appState) {
     throw new Error('App state unavailable.');
@@ -1699,10 +1707,12 @@ export const mutateBatchAssignment = async (
   operation: 'assign' | 'move' | 'remove',
   payload: { batchId: string; bedId?: string; at: string },
 ): Promise<Batch> => {
-  if (isWorkflowRoutedToBackend('batches')) {
+  if (shouldUseCanonicalBackendPath('batches') && !shouldUseTypescriptRollbackShim('batches')) {
     return assertValid('batch', await workflowAdapter.batches.mutateAssignment(operation, payload));
   }
 
+  // Deprecated rollback shim. Remove once TypeScript rollback window is retired.
+  console.warn('[DEPRECATED] Using TypeScript batch assignment rollback shim.');
   const appState = await loadAppStateFromIndexedDb();
   if (!appState) {
     throw new Error('App state unavailable.');
@@ -1725,7 +1735,7 @@ export const mutateBatchAssignment = async (
 };
 
 export const regenerateCalendarTasks = async (year: number) => {
-  if (isWorkflowRoutedToBackend('tasks')) {
+  if (shouldUseCanonicalBackendPath('tasks') && !shouldUseTypescriptRollbackShim('tasks')) {
     const payload = await workflowAdapter.tasks.regenerateCalendar(year);
     return {
       generatedTasks: payload.generatedTasks,
@@ -1734,6 +1744,8 @@ export const regenerateCalendarTasks = async (year: number) => {
     };
   }
 
+  // Deprecated rollback shim. Remove once TypeScript rollback window is retired.
+  console.warn('[DEPRECATED] Using TypeScript task regeneration rollback shim.');
   const appState = await loadAppStateFromIndexedDb();
   if (!appState) {
     throw new Error('App state unavailable.');

--- a/frontend/src/data/workflowAdapter.test.ts
+++ b/frontend/src/data/workflowAdapter.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   isWorkflowRoutedToBackend,
+  shouldUseCanonicalBackendPath,
+  shouldUseTypescriptRollbackShim,
   workflowAdapter,
 } from './workflowAdapter';
 
@@ -27,6 +29,31 @@ describe('workflow routing flags', () => {
 
     expect(isWorkflowRoutedToBackend('batches')).toBe(true);
     expect(isWorkflowRoutedToBackend('tasks')).toBe(false);
+  });
+
+  it('treats parity-accepted workflows as canonical backend paths', () => {
+    vi.stubEnv('VITE_FRONTEND_MODE', 'backend');
+    vi.stubEnv('VITE_PARITY_ACCEPTED_WORKFLOWS', 'batches,tasks');
+    vi.stubEnv('VITE_ROUTE_BATCHES_TO_BACKEND', 'false');
+
+    expect(shouldUseCanonicalBackendPath('batches')).toBe(true);
+  });
+
+  it('keeps rollback shim disabled unless explicitly enabled', () => {
+    vi.stubEnv('VITE_FRONTEND_MODE', 'backend');
+    vi.stubEnv('VITE_PARITY_ACCEPTED_WORKFLOWS', 'batches');
+
+    expect(shouldUseTypescriptRollbackShim('batches')).toBe(false);
+  });
+
+  it('re-enables rollback shim for accepted workflows when rollback flags are enabled', () => {
+    vi.stubEnv('VITE_FRONTEND_MODE', 'backend');
+    vi.stubEnv('VITE_PARITY_ACCEPTED_WORKFLOWS', 'batches,tasks');
+    vi.stubEnv('VITE_ENABLE_TYPESCRIPT_ROLLBACK_SHIMS', 'true');
+    vi.stubEnv('VITE_TYPESCRIPT_ROLLBACK_WORKFLOWS', 'batches');
+
+    expect(shouldUseTypescriptRollbackShim('batches')).toBe(true);
+    expect(shouldUseTypescriptRollbackShim('tasks')).toBe(false);
   });
 });
 

--- a/frontend/src/data/workflowAdapter.ts
+++ b/frontend/src/data/workflowAdapter.ts
@@ -26,6 +26,13 @@ export const getBackendApiBaseUrl = (): string => {
 export const toBackendApiUrl = (path: string): string => `${getBackendApiBaseUrl()}${path}`;
 
 const isFeatureFlagEnabled = (value: string | undefined): boolean => value?.trim().toLowerCase() === 'true';
+const parseWorkflowList = (value: string | undefined): WorkflowFeature[] =>
+  (value ?? '')
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry): entry is WorkflowFeature =>
+      entry === 'batches' || entry === 'tasks' || entry === 'bedsSegments' || entry === 'taxonomy' || entry === 'inventory',
+    );
 
 export const getFrontendMode = (): 'typescript' | 'backend' => {
   const env = resolveRuntimeEnv();
@@ -48,6 +55,39 @@ export const isWorkflowRoutedToBackend = (feature: WorkflowFeature): boolean => 
   const env = resolveRuntimeEnv();
   return isFeatureFlagEnabled(env[workflowFlagByFeature[feature]]);
 };
+
+const isParityAcceptedWorkflow = (feature: WorkflowFeature): boolean => {
+  const env = resolveRuntimeEnv();
+  return parseWorkflowList(env.VITE_PARITY_ACCEPTED_WORKFLOWS).includes(feature);
+};
+
+const isTypescriptRollbackShimEnabled = (feature: WorkflowFeature): boolean => {
+  const env = resolveRuntimeEnv();
+  if (!isFeatureFlagEnabled(env.VITE_ENABLE_TYPESCRIPT_ROLLBACK_SHIMS)) {
+    return false;
+  }
+
+  const rollbackFeatures = parseWorkflowList(env.VITE_TYPESCRIPT_ROLLBACK_WORKFLOWS);
+  return rollbackFeatures.length === 0 || rollbackFeatures.includes(feature);
+};
+
+export const shouldUseCanonicalBackendPath = (feature: WorkflowFeature): boolean => {
+  if (getFrontendMode() !== 'backend') {
+    return false;
+  }
+
+  if (isParityAcceptedWorkflow(feature)) {
+    return true;
+  }
+
+  return isWorkflowRoutedToBackend(feature);
+};
+
+/**
+ * @deprecated Rollback-only helper. Remove alongside VITE_ENABLE_TYPESCRIPT_ROLLBACK_SHIMS retirement.
+ */
+export const shouldUseTypescriptRollbackShim = (feature: WorkflowFeature): boolean =>
+  !shouldUseCanonicalBackendPath(feature) || isTypescriptRollbackShimEnabled(feature);
 
 export const parseBackendError = async (response: Response): Promise<string> => {
   try {


### PR DESCRIPTION
### Motivation
- Make backend the canonical execution path for workflows that have passed cross-language parity checks while keeping TypeScript fallbacks during the rollback window. 
- Provide an explicit, opt-in mechanism to retain minimal TS compatibility shims during a controlled rollback window.

### Description
- Added parity-aware routing helpers in `frontend/src/data/workflowAdapter.ts`: `parseWorkflowList`, `isParityAcceptedWorkflow`, `shouldUseCanonicalBackendPath`, and deprecated `shouldUseTypescriptRollbackShim` with environment flags `VITE_PARITY_ACCEPTED_WORKFLOWS`, `VITE_ENABLE_TYPESCRIPT_ROLLBACK_SHIMS`, and `VITE_TYPESCRIPT_ROLLBACK_WORKFLOWS`.
- Preserved existing flag-based routing (`VITE_ROUTE_*`) and layered parity acceptance on top so accepted workflows use backend paths by default.
- Updated runtime execution in `frontend/src/data/index.ts` to prefer canonical backend paths for `batches` and `tasks`, emitting deprecation warnings when the TypeScript rollback shim is used.
- Expanded `frontend/src/data/workflowAdapter.test.ts` to cover parity-accepted routing and rollback-shim enablement semantics.

### Testing
- Ran unit tests for the frontend: `pnpm --filter frontend test -- src/data/workflowAdapter.test.ts`, full suite reports all tests passed (10 files, 126 tests passed, 8 skipped).
- Ran linter: `pnpm --filter frontend lint`, which completed successfully and reported pre-existing React Hook dependency warnings in `frontend/src/App.tsx` (no new lint errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfb75b72a883269f3af41abedb8712)