### PR TITLE
Add canonical routing adapters for beds, taxonomy, and inventory workflows

### DIFF
--- a/frontend/src/data/index.ts
+++ b/frontend/src/data/index.ts
@@ -1,4 +1,4 @@
-import type { AppState, Batch } from '../contracts';
+import type { AppState, Batch, Bed, Crop, CropPlan, SeedInventoryItem } from '../contracts';
 import { assertValid } from './validation';
 import { getSettingsOrDefault } from './repos/settingsRepository';
 import { mergeTaskForImport } from './repos/taskRepository';
@@ -9,6 +9,31 @@ import {
   removeBatchFromBed as removeBatchFromBedLocal,
   upsertBatchInAppState as upsertBatchInAppStateLocal,
 } from './repos/batchRepository';
+import {
+  getBedFromAppState as getBedFromAppStateLocal,
+  listBedsFromAppState as listBedsFromAppStateLocal,
+  removeBedFromAppState as removeBedFromAppStateLocal,
+  upsertBedInAppState as upsertBedInAppStateLocal,
+} from './repos/bedRepository';
+import {
+  getCropFromAppState as getCropFromAppStateLocal,
+  listCropsFromAppState as listCropsFromAppStateLocal,
+  removeCropFromAppState as removeCropFromAppStateLocal,
+  upsertCropInAppState as upsertCropInAppStateLocal,
+} from './repos/cropRepository';
+import {
+  getCropPlanFromAppState as getCropPlanFromAppStateLocal,
+  listCropPlansFromAppState as listCropPlansFromAppStateLocal,
+  removeCropPlanFromAppState as removeCropPlanFromAppStateLocal,
+  upsertCropPlanInAppState as upsertCropPlanInAppStateLocal,
+} from './repos/cropPlanRepository';
+import {
+  getSeedInventoryItemFromAppState as getSeedInventoryItemFromAppStateLocal,
+  listSeedInventoryItemsFromAppState as listSeedInventoryItemsFromAppStateLocal,
+  removeSeedInventoryItemFromAppState as removeSeedInventoryItemFromAppStateLocal,
+  upsertSeedInventoryItemInAppState as upsertSeedInventoryItemInAppStateLocal,
+} from './repos/seedInventoryRepository';
+import type { ListQuery } from './repos/interfaces';
 import {
   generateCalendarTasksWithDiagnostics as generateCalendarTasksWithDiagnosticsLocal,
   upsertGeneratedTasksInAppState as upsertGeneratedTasksInAppStateLocal,
@@ -1670,6 +1695,190 @@ export const saveAppStateToIndexedDb = async (
   }
 
   return saveAppStateToLocalIndexedDb(appState, options);
+};
+
+const shouldUseCanonicalWorkflowWithoutRollback = (
+  feature: 'bedsSegments' | 'taxonomy' | 'inventory' | 'batches' | 'tasks',
+): boolean => shouldUseCanonicalBackendPath(feature) && !shouldUseTypescriptRollbackShim(feature);
+
+export const getBed = async (bedId: Bed['bedId']): Promise<Bed | null> => {
+  if (shouldUseCanonicalWorkflowWithoutRollback('bedsSegments')) {
+    return workflowAdapter.bedsSegments.getBed(bedId);
+  }
+
+  const appState = await loadAppStateFromIndexedDb();
+  return appState ? getBedFromAppStateLocal(appState, bedId) : null;
+};
+
+export const listBeds = async (): Promise<Bed[]> => {
+  if (shouldUseCanonicalWorkflowWithoutRollback('bedsSegments')) {
+    return workflowAdapter.bedsSegments.listBeds();
+  }
+
+  const appState = await loadAppStateFromIndexedDb();
+  return appState ? listBedsFromAppStateLocal(appState) : [];
+};
+
+export const upsertBed = async (bed: unknown): Promise<Bed> => {
+  if (shouldUseCanonicalWorkflowWithoutRollback('bedsSegments')) {
+    return assertValid('bed', await workflowAdapter.bedsSegments.upsertBed(assertValid('bed', bed)));
+  }
+
+  const appState = await loadAppStateFromIndexedDb();
+  const nextState = upsertBedInAppStateLocal(appState ?? createEmptyAppState(appState), bed);
+  await saveAppStateToIndexedDb(nextState);
+  return assertValid('bed', getBedFromAppStateLocal(nextState, assertValid('bed', bed).bedId));
+};
+
+export const removeBed = async (bedId: Bed['bedId']): Promise<void> => {
+  if (shouldUseCanonicalWorkflowWithoutRollback('bedsSegments')) {
+    await workflowAdapter.bedsSegments.removeBed(bedId);
+    return;
+  }
+
+  const appState = await loadAppStateFromIndexedDb();
+  if (!appState) {
+    return;
+  }
+  await saveAppStateToIndexedDb(removeBedFromAppStateLocal(appState, bedId));
+};
+
+export const getCrop = async (cropId: Crop['cropId']): Promise<Crop | null> => {
+  if (shouldUseCanonicalWorkflowWithoutRollback('taxonomy')) {
+    return workflowAdapter.taxonomy.getCrop(cropId);
+  }
+
+  const appState = await loadAppStateFromIndexedDb();
+  return appState ? getCropFromAppStateLocal(appState, cropId) : null;
+};
+
+export const listCrops = async (): Promise<Crop[]> => {
+  if (shouldUseCanonicalWorkflowWithoutRollback('taxonomy')) {
+    return workflowAdapter.taxonomy.listCrops();
+  }
+
+  const appState = await loadAppStateFromIndexedDb();
+  return appState ? listCropsFromAppStateLocal(appState) : [];
+};
+
+export const upsertCrop = async (crop: unknown): Promise<Crop> => {
+  if (shouldUseCanonicalWorkflowWithoutRollback('taxonomy')) {
+    return assertValid('crop', await workflowAdapter.taxonomy.upsertCrop(assertValid('crop', crop)));
+  }
+
+  const appState = await loadAppStateFromIndexedDb();
+  const nextState = upsertCropInAppStateLocal(appState ?? createEmptyAppState(appState), crop);
+  await saveAppStateToIndexedDb(nextState);
+  return assertValid('crop', getCropFromAppStateLocal(nextState, assertValid('crop', crop).cropId));
+};
+
+export const removeCrop = async (cropId: Crop['cropId']): Promise<void> => {
+  if (shouldUseCanonicalWorkflowWithoutRollback('taxonomy')) {
+    await workflowAdapter.taxonomy.removeCrop(cropId);
+    return;
+  }
+
+  const appState = await loadAppStateFromIndexedDb();
+  if (!appState) {
+    return;
+  }
+  await saveAppStateToIndexedDb(removeCropFromAppStateLocal(appState, cropId));
+};
+
+export const getCropPlan = async (planId: CropPlan['planId']): Promise<CropPlan | null> => {
+  if (shouldUseCanonicalWorkflowWithoutRollback('taxonomy')) {
+    return workflowAdapter.taxonomy.getCropPlan(planId);
+  }
+
+  const appState = await loadAppStateFromIndexedDb();
+  return appState ? getCropPlanFromAppStateLocal(appState, planId) : null;
+};
+
+export const listCropPlans = async (): Promise<CropPlan[]> => {
+  if (shouldUseCanonicalWorkflowWithoutRollback('taxonomy')) {
+    return workflowAdapter.taxonomy.listCropPlans();
+  }
+
+  const appState = await loadAppStateFromIndexedDb();
+  return appState ? listCropPlansFromAppStateLocal(appState) : [];
+};
+
+export const upsertCropPlan = async (cropPlan: unknown): Promise<CropPlan> => {
+  if (shouldUseCanonicalWorkflowWithoutRollback('taxonomy')) {
+    return assertValid('cropPlan', await workflowAdapter.taxonomy.upsertCropPlan(assertValid('cropPlan', cropPlan)));
+  }
+
+  const appState = await loadAppStateFromIndexedDb();
+  const nextState = upsertCropPlanInAppStateLocal(appState ?? createEmptyAppState(appState), cropPlan);
+  await saveAppStateToIndexedDb(nextState);
+  return assertValid('cropPlan', getCropPlanFromAppStateLocal(nextState, assertValid('cropPlan', cropPlan).planId));
+};
+
+export const removeCropPlan = async (planId: CropPlan['planId']): Promise<void> => {
+  if (shouldUseCanonicalWorkflowWithoutRollback('taxonomy')) {
+    await workflowAdapter.taxonomy.removeCropPlan(planId);
+    return;
+  }
+
+  const appState = await loadAppStateFromIndexedDb();
+  if (!appState) {
+    return;
+  }
+  await saveAppStateToIndexedDb(removeCropPlanFromAppStateLocal(appState, planId));
+};
+
+export const getSeedInventoryItem = async (
+  seedInventoryItemId: SeedInventoryItem['seedInventoryItemId'],
+): Promise<SeedInventoryItem | null> => {
+  if (shouldUseCanonicalWorkflowWithoutRollback('inventory')) {
+    return workflowAdapter.inventory.getSeedInventoryItem(seedInventoryItemId);
+  }
+
+  const appState = await loadAppStateFromIndexedDb();
+  return appState ? getSeedInventoryItemFromAppStateLocal(appState, seedInventoryItemId) : null;
+};
+
+export const listSeedInventoryItems = async (
+  query: ListQuery<Pick<SeedInventoryItem, 'cultivarId' | 'status'>> = {},
+): Promise<SeedInventoryItem[]> => {
+  if (shouldUseCanonicalWorkflowWithoutRollback('inventory')) {
+    return workflowAdapter.inventory.listSeedInventoryItems();
+  }
+
+  const appState = await loadAppStateFromIndexedDb();
+  return appState ? listSeedInventoryItemsFromAppStateLocal(appState, query) : [];
+};
+
+export const upsertSeedInventoryItem = async (seedInventoryItem: unknown): Promise<SeedInventoryItem> => {
+  if (shouldUseCanonicalWorkflowWithoutRollback('inventory')) {
+    return assertValid(
+      'seedInventoryItem',
+      await workflowAdapter.inventory.upsertSeedInventoryItem(assertValid('seedInventoryItem', seedInventoryItem)),
+    );
+  }
+
+  const appState = await loadAppStateFromIndexedDb();
+  const nextState = upsertSeedInventoryItemInAppStateLocal(appState ?? createEmptyAppState(appState), seedInventoryItem);
+  await saveAppStateToIndexedDb(nextState);
+  return assertValid(
+    'seedInventoryItem',
+    getSeedInventoryItemFromAppStateLocal(nextState, assertValid('seedInventoryItem', seedInventoryItem).seedInventoryItemId),
+  );
+};
+
+export const removeSeedInventoryItem = async (
+  seedInventoryItemId: SeedInventoryItem['seedInventoryItemId'],
+): Promise<void> => {
+  if (shouldUseCanonicalWorkflowWithoutRollback('inventory')) {
+    await workflowAdapter.inventory.removeSeedInventoryItem(seedInventoryItemId);
+    return;
+  }
+
+  const appState = await loadAppStateFromIndexedDb();
+  if (!appState) {
+    return;
+  }
+  await saveAppStateToIndexedDb(removeSeedInventoryItemFromAppStateLocal(appState, seedInventoryItemId));
 };
 
 export const transitionBatchStage = async (

--- a/frontend/src/data/repos/workflowRouting.test.ts
+++ b/frontend/src/data/repos/workflowRouting.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { shouldUseCanonicalBackendPath, shouldUseTypescriptRollbackShim } from '../workflowAdapter';
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('repository workflow routing gates', () => {
+  it('keeps beds/taxonomy/inventory canonical routing disabled in typescript mode', () => {
+    vi.stubEnv('VITE_FRONTEND_MODE', 'typescript');
+    vi.stubEnv('VITE_ROUTE_BEDS_SEGMENTS_TO_BACKEND', 'true');
+    vi.stubEnv('VITE_ROUTE_TAXONOMY_TO_BACKEND', 'true');
+    vi.stubEnv('VITE_ROUTE_INVENTORY_TO_BACKEND', 'true');
+
+    expect(shouldUseCanonicalBackendPath('bedsSegments')).toBe(false);
+    expect(shouldUseCanonicalBackendPath('taxonomy')).toBe(false);
+    expect(shouldUseCanonicalBackendPath('inventory')).toBe(false);
+  });
+
+  it('supports feature-flag routing in backend mode for repository workflows', () => {
+    vi.stubEnv('VITE_FRONTEND_MODE', 'backend');
+    vi.stubEnv('VITE_ROUTE_BEDS_SEGMENTS_TO_BACKEND', 'true');
+    vi.stubEnv('VITE_ROUTE_TAXONOMY_TO_BACKEND', 'false');
+    vi.stubEnv('VITE_ROUTE_INVENTORY_TO_BACKEND', 'true');
+
+    expect(shouldUseCanonicalBackendPath('bedsSegments')).toBe(true);
+    expect(shouldUseCanonicalBackendPath('taxonomy')).toBe(false);
+    expect(shouldUseCanonicalBackendPath('inventory')).toBe(true);
+  });
+
+  it('promotes parity-accepted repository workflows to canonical', () => {
+    vi.stubEnv('VITE_FRONTEND_MODE', 'backend');
+    vi.stubEnv('VITE_PARITY_ACCEPTED_WORKFLOWS', 'bedsSegments,taxonomy,inventory');
+
+    expect(shouldUseCanonicalBackendPath('bedsSegments')).toBe(true);
+    expect(shouldUseCanonicalBackendPath('taxonomy')).toBe(true);
+    expect(shouldUseCanonicalBackendPath('inventory')).toBe(true);
+  });
+
+  it('allows selectively re-enabling rollback shims by repository workflow', () => {
+    vi.stubEnv('VITE_FRONTEND_MODE', 'backend');
+    vi.stubEnv('VITE_PARITY_ACCEPTED_WORKFLOWS', 'bedsSegments,taxonomy,inventory');
+    vi.stubEnv('VITE_ENABLE_TYPESCRIPT_ROLLBACK_SHIMS', 'true');
+    vi.stubEnv('VITE_TYPESCRIPT_ROLLBACK_WORKFLOWS', 'taxonomy');
+
+    expect(shouldUseTypescriptRollbackShim('bedsSegments')).toBe(false);
+    expect(shouldUseTypescriptRollbackShim('taxonomy')).toBe(true);
+    expect(shouldUseTypescriptRollbackShim('inventory')).toBe(false);
+  });
+});

--- a/frontend/src/data/workflowAdapter.test.ts
+++ b/frontend/src/data/workflowAdapter.test.ts
@@ -26,17 +26,29 @@ describe('workflow routing flags', () => {
     vi.stubEnv('VITE_FRONTEND_MODE', 'backend');
     vi.stubEnv('VITE_ROUTE_BATCHES_TO_BACKEND', 'true');
     vi.stubEnv('VITE_ROUTE_TASKS_TO_BACKEND', 'false');
+    vi.stubEnv('VITE_ROUTE_BEDS_SEGMENTS_TO_BACKEND', 'true');
+    vi.stubEnv('VITE_ROUTE_TAXONOMY_TO_BACKEND', 'false');
+    vi.stubEnv('VITE_ROUTE_INVENTORY_TO_BACKEND', 'true');
 
     expect(isWorkflowRoutedToBackend('batches')).toBe(true);
     expect(isWorkflowRoutedToBackend('tasks')).toBe(false);
+    expect(isWorkflowRoutedToBackend('bedsSegments')).toBe(true);
+    expect(isWorkflowRoutedToBackend('taxonomy')).toBe(false);
+    expect(isWorkflowRoutedToBackend('inventory')).toBe(true);
   });
 
   it('treats parity-accepted workflows as canonical backend paths', () => {
     vi.stubEnv('VITE_FRONTEND_MODE', 'backend');
-    vi.stubEnv('VITE_PARITY_ACCEPTED_WORKFLOWS', 'batches,tasks');
+    vi.stubEnv('VITE_PARITY_ACCEPTED_WORKFLOWS', 'batches,tasks,bedsSegments,taxonomy,inventory');
     vi.stubEnv('VITE_ROUTE_BATCHES_TO_BACKEND', 'false');
+    vi.stubEnv('VITE_ROUTE_BEDS_SEGMENTS_TO_BACKEND', 'false');
+    vi.stubEnv('VITE_ROUTE_TAXONOMY_TO_BACKEND', 'false');
+    vi.stubEnv('VITE_ROUTE_INVENTORY_TO_BACKEND', 'false');
 
     expect(shouldUseCanonicalBackendPath('batches')).toBe(true);
+    expect(shouldUseCanonicalBackendPath('bedsSegments')).toBe(true);
+    expect(shouldUseCanonicalBackendPath('taxonomy')).toBe(true);
+    expect(shouldUseCanonicalBackendPath('inventory')).toBe(true);
   });
 
   it('keeps rollback shim disabled unless explicitly enabled', () => {
@@ -48,12 +60,13 @@ describe('workflow routing flags', () => {
 
   it('re-enables rollback shim for accepted workflows when rollback flags are enabled', () => {
     vi.stubEnv('VITE_FRONTEND_MODE', 'backend');
-    vi.stubEnv('VITE_PARITY_ACCEPTED_WORKFLOWS', 'batches,tasks');
+    vi.stubEnv('VITE_PARITY_ACCEPTED_WORKFLOWS', 'batches,tasks,taxonomy');
     vi.stubEnv('VITE_ENABLE_TYPESCRIPT_ROLLBACK_SHIMS', 'true');
-    vi.stubEnv('VITE_TYPESCRIPT_ROLLBACK_WORKFLOWS', 'batches');
+    vi.stubEnv('VITE_TYPESCRIPT_ROLLBACK_WORKFLOWS', 'batches,taxonomy');
 
     expect(shouldUseTypescriptRollbackShim('batches')).toBe(true);
     expect(shouldUseTypescriptRollbackShim('tasks')).toBe(false);
+    expect(shouldUseTypescriptRollbackShim('taxonomy')).toBe(true);
   });
 });
 
@@ -73,6 +86,29 @@ describe('workflow adapter transport', () => {
     expect(fetchMock).toHaveBeenCalledWith(
       'http://localhost:5142/api/domain/batches/batch-1/stage-events',
       expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('uses explicit CRUD endpoints for beds/segments, taxonomy, and inventory adapters', async () => {
+    vi.stubEnv('VITE_BACKEND_API_BASE_URL', 'http://localhost:5142');
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => [] } as Response)
+      .mockResolvedValueOnce({ ok: true, json: async () => [] } as Response)
+      .mockResolvedValueOnce({ ok: true, json: async () => [] } as Response);
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    await workflowAdapter.bedsSegments.listBeds();
+    await workflowAdapter.taxonomy.listCrops();
+    await workflowAdapter.inventory.listSeedInventoryItems();
+
+    expect(fetchMock).toHaveBeenNthCalledWith(1, 'http://localhost:5142/api/beds', expect.objectContaining({ method: 'GET' }));
+    expect(fetchMock).toHaveBeenNthCalledWith(2, 'http://localhost:5142/api/crops', expect.objectContaining({ method: 'GET' }));
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      'http://localhost:5142/api/seedInventoryItems',
+      expect.objectContaining({ method: 'GET' }),
     );
   });
 });

--- a/frontend/src/data/workflowAdapter.ts
+++ b/frontend/src/data/workflowAdapter.ts
@@ -1,4 +1,4 @@
-import type { AppState, Batch } from '../contracts';
+import type { AppState, Batch, Bed, Crop, CropPlan, SeedInventoryItem, Segment } from '../contracts';
 
 export type WorkflowFeature = 'batches' | 'tasks' | 'bedsSegments' | 'taxonomy' | 'inventory';
 
@@ -151,6 +151,149 @@ export const workflowAdapter = {
         diagnostics: payload.diagnostics ?? [],
         stateAfter: payload.stateAfter,
       };
+    },
+  },
+  bedsSegments: {
+    listBeds: async (): Promise<Bed[]> => fetchJson<Bed[]>('/api/beds', { method: 'GET' }),
+    getBed: async (bedId: string): Promise<Bed | null> => {
+      const response = await fetch(toBackendApiUrl(`/api/beds/${encodeURIComponent(bedId)}`), { method: 'GET' });
+      if (response.status === 404) {
+        return null;
+      }
+      if (!response.ok) {
+        throw new Error(await parseBackendError(response));
+      }
+      return response.json() as Promise<Bed>;
+    },
+    upsertBed: async (bed: Bed): Promise<Bed> =>
+      fetchJson<Bed>(`/api/beds/${encodeURIComponent(bed.bedId)}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(bed),
+      }),
+    removeBed: async (bedId: string): Promise<void> => {
+      const response = await fetch(toBackendApiUrl(`/api/beds/${encodeURIComponent(bedId)}`), { method: 'DELETE' });
+      if (response.status === 404 || response.status === 204) {
+        return;
+      }
+      if (!response.ok) {
+        throw new Error(await parseBackendError(response));
+      }
+    },
+    listSegments: async (): Promise<Segment[]> => fetchJson<Segment[]>('/api/segments', { method: 'GET' }),
+    getSegment: async (segmentId: string): Promise<Segment | null> => {
+      const response = await fetch(toBackendApiUrl(`/api/segments/${encodeURIComponent(segmentId)}`), { method: 'GET' });
+      if (response.status === 404) {
+        return null;
+      }
+      if (!response.ok) {
+        throw new Error(await parseBackendError(response));
+      }
+      return response.json() as Promise<Segment>;
+    },
+    upsertSegment: async (segment: Segment): Promise<Segment> =>
+      fetchJson<Segment>(`/api/segments/${encodeURIComponent(segment.segmentId)}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(segment),
+      }),
+    removeSegment: async (segmentId: string): Promise<void> => {
+      const response = await fetch(toBackendApiUrl(`/api/segments/${encodeURIComponent(segmentId)}`), { method: 'DELETE' });
+      if (response.status === 404 || response.status === 204) {
+        return;
+      }
+      if (!response.ok) {
+        throw new Error(await parseBackendError(response));
+      }
+    },
+  },
+  taxonomy: {
+    listCrops: async (): Promise<Crop[]> => fetchJson<Crop[]>('/api/crops', { method: 'GET' }),
+    getCrop: async (cropId: string): Promise<Crop | null> => {
+      const response = await fetch(toBackendApiUrl(`/api/crops/${encodeURIComponent(cropId)}`), { method: 'GET' });
+      if (response.status === 404) {
+        return null;
+      }
+      if (!response.ok) {
+        throw new Error(await parseBackendError(response));
+      }
+      return response.json() as Promise<Crop>;
+    },
+    upsertCrop: async (crop: Crop): Promise<Crop> =>
+      fetchJson<Crop>(`/api/crops/${encodeURIComponent(crop.cropId)}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(crop),
+      }),
+    removeCrop: async (cropId: string): Promise<void> => {
+      const response = await fetch(toBackendApiUrl(`/api/crops/${encodeURIComponent(cropId)}`), { method: 'DELETE' });
+      if (response.status === 404 || response.status === 204) {
+        return;
+      }
+      if (!response.ok) {
+        throw new Error(await parseBackendError(response));
+      }
+    },
+    listCropPlans: async (): Promise<CropPlan[]> => fetchJson<CropPlan[]>('/api/cropPlans', { method: 'GET' }),
+    getCropPlan: async (planId: string): Promise<CropPlan | null> => {
+      const response = await fetch(toBackendApiUrl(`/api/cropPlans/${encodeURIComponent(planId)}`), { method: 'GET' });
+      if (response.status === 404) {
+        return null;
+      }
+      if (!response.ok) {
+        throw new Error(await parseBackendError(response));
+      }
+      return response.json() as Promise<CropPlan>;
+    },
+    upsertCropPlan: async (cropPlan: CropPlan): Promise<CropPlan> =>
+      fetchJson<CropPlan>(`/api/cropPlans/${encodeURIComponent(cropPlan.planId)}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(cropPlan),
+      }),
+    removeCropPlan: async (planId: string): Promise<void> => {
+      const response = await fetch(toBackendApiUrl(`/api/cropPlans/${encodeURIComponent(planId)}`), { method: 'DELETE' });
+      if (response.status === 404 || response.status === 204) {
+        return;
+      }
+      if (!response.ok) {
+        throw new Error(await parseBackendError(response));
+      }
+    },
+  },
+  inventory: {
+    listSeedInventoryItems: async (): Promise<SeedInventoryItem[]> =>
+      fetchJson<SeedInventoryItem[]>('/api/seedInventoryItems', { method: 'GET' }),
+    getSeedInventoryItem: async (seedInventoryItemId: string): Promise<SeedInventoryItem | null> => {
+      const response = await fetch(
+        toBackendApiUrl(`/api/seedInventoryItems/${encodeURIComponent(seedInventoryItemId)}`),
+        { method: 'GET' },
+      );
+      if (response.status === 404) {
+        return null;
+      }
+      if (!response.ok) {
+        throw new Error(await parseBackendError(response));
+      }
+      return response.json() as Promise<SeedInventoryItem>;
+    },
+    upsertSeedInventoryItem: async (seedInventoryItem: SeedInventoryItem): Promise<SeedInventoryItem> =>
+      fetchJson<SeedInventoryItem>(`/api/seedInventoryItems/${encodeURIComponent(seedInventoryItem.seedInventoryItemId)}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(seedInventoryItem),
+      }),
+    removeSeedInventoryItem: async (seedInventoryItemId: string): Promise<void> => {
+      const response = await fetch(
+        toBackendApiUrl(`/api/seedInventoryItems/${encodeURIComponent(seedInventoryItemId)}`),
+        { method: 'DELETE' },
+      );
+      if (response.status === 404 || response.status === 204) {
+        return;
+      }
+      if (!response.ok) {
+        throw new Error(await parseBackendError(response));
+      }
     },
   },
 };


### PR DESCRIPTION
### Motivation
- Route repository-style workflows (beds/segments, taxonomy/crops/crop-plans, seed inventory) to explicit backend CRUD endpoints when the feature gating indicates canonical backend usage. 
- Preserve existing TypeScript rollback-switch semantics so parity-accepted workflows can be selectively reverted during the rollback window. 
- Improve adapter parity with backend endpoint semantics by providing explicit HTTP methods and consistent error handling.

### Description
- Added new adapter groups to `frontend/src/data/workflowAdapter.ts` for `bedsSegments`, `taxonomy`, and `inventory`, implementing explicit `GET`/`PUT`/`DELETE` and list endpoints and reusing existing backend error parsing. 
- Extended `frontend/src/data/index.ts` with repository-level entry points (`get/list/upsert/remove`) for beds, crops, crop plans, and seed inventory that route to `workflowAdapter` when `shouldUseCanonicalBackendPath(feature)` is true and respect rollback behavior via `shouldUseTypescriptRollbackShim(feature)`, including a small helper `shouldUseCanonicalWorkflowWithoutRollback`. 
- Adjusted local upsert flows to return the canonical record from the persisted next state when using the local (TypeScript) path. 
- Added/updated unit tests: expanded `frontend/src/data/workflowAdapter.test.ts` to cover the new adapters and routing flags, and added `frontend/src/data/repos/workflowRouting.test.ts` to validate repository-level routing and selective rollback behavior. 

### Testing
- Ran the targeted frontend tests with `pnpm --dir frontend test -- workflowAdapter.test.ts repos/workflowRouting.test.ts`, and the new/updated tests passed. 
- Vitest run output showed the test suite completed successfully (requested tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d22297ea008326914b2044baacb2ca)