### PR TITLE
Enforce cutover-complete routing and emergency-only TypeScript rollback shims

### DIFF
--- a/docs/dotnet-readiness.md
+++ b/docs/dotnet-readiness.md
@@ -215,6 +215,9 @@ Mirror critical business rules in C# domain services while preserving behavior f
 - Both runtimes must pass against the same fixture version before release.
 - Run the shared harness `node scripts/equivalence/run-equivalence.mjs --tsBaseUrl=<ts> --dotnetBaseUrl=<dotnet>` with `fixtures/equivalence/equivalence-scenarios.v1.json`; block cutover on non-zero exit.
 - Require workflow-level cutover checks before flipping backend-only mode: run with `--cutoverCriteria=fixtures/equivalence/cutover-criteria.v1.json --flipWorkflows=<workflow,...>` and block on any unmet mismatch-rate/min-run threshold.
+- Define **cutover-complete** as: parity accepted (`VITE_PARITY_ACCEPTED_WORKFLOWS`) + successful gated runs meeting `fixtures/equivalence/cutover-criteria.v1.json` thresholds.
+- After a workflow is cutover-complete, add it to `VITE_CUTOVER_COMPLETE_WORKFLOWS` so frontend mutation/derivation paths remain backend-owned by default.
+- `VITE_ENABLE_EMERGENCY_TYPESCRIPT_ROLLBACK=true` (optionally scoped by `VITE_EMERGENCY_TYPESCRIPT_ROLLBACK_WORKFLOWS`) is reserved for emergency rollback only and should be removed after the confidence window.
 
 ### Contract tests as release gate
 

--- a/fixtures/equivalence/cutover-criteria.v1.json
+++ b/fixtures/equivalence/cutover-criteria.v1.json
@@ -26,5 +26,12 @@
       "maxMismatchRate": 0,
       "maxValidationMismatches": 0
     }
+  },
+  "cutoverCompleteCondition": {
+    "requiresParityAcceptedWorkflow": true,
+    "requiresMinSuccessfulGatedRuns": true,
+    "minSuccessfulRunSource": "workflows.<feature>.minRuns",
+    "maxMismatchRateSource": "workflows.<feature>.maxMismatchRate",
+    "maxValidationMismatchesSource": "workflows.<feature>.maxValidationMismatches"
   }
 }

--- a/frontend/src/data/index.cutoverRouting.test.ts
+++ b/frontend/src/data/index.cutoverRouting.test.ts
@@ -22,7 +22,7 @@ const failingBackendResponse = {
   json: async () => {
     throw new Error('no-json');
   },
-} as Response;
+} as unknown as Response;
 
 describe('cutover-complete workflow mutation routing', () => {
   it('never executes local batch stage mutation shims for cutover-complete workflows', async () => {

--- a/frontend/src/data/index.cutoverRouting.test.ts
+++ b/frontend/src/data/index.cutoverRouting.test.ts
@@ -11,6 +11,7 @@ afterEach(() => {
 
 const stubCutoverCompleteEnv = () => {
   vi.stubEnv('VITE_FRONTEND_MODE', 'backend');
+  vi.stubEnv('VITE_BACKEND_API_BASE_URL', 'http://localhost:5142');
   vi.stubEnv('VITE_PARITY_ACCEPTED_WORKFLOWS', 'batches,tasks');
   vi.stubEnv('VITE_CUTOVER_COMPLETE_WORKFLOWS', 'batches,tasks');
 };

--- a/frontend/src/data/index.cutoverRouting.test.ts
+++ b/frontend/src/data/index.cutoverRouting.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mutateBatchAssignment, regenerateCalendarTasks, transitionBatchStage } from './index';
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+  globalThis.fetch = originalFetch;
+});
+
+const stubCutoverCompleteEnv = () => {
+  vi.stubEnv('VITE_FRONTEND_MODE', 'backend');
+  vi.stubEnv('VITE_PARITY_ACCEPTED_WORKFLOWS', 'batches,tasks');
+  vi.stubEnv('VITE_CUTOVER_COMPLETE_WORKFLOWS', 'batches,tasks');
+};
+
+const failingBackendResponse = {
+  ok: false,
+  status: 500,
+  statusText: 'Internal Server Error',
+  json: async () => {
+    throw new Error('no-json');
+  },
+} as Response;
+
+describe('cutover-complete workflow mutation routing', () => {
+  it('never executes local batch stage mutation shims for cutover-complete workflows', async () => {
+    stubCutoverCompleteEnv();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const fetchMock = vi.fn().mockResolvedValue(failingBackendResponse);
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    await expect(transitionBatchStage('batch-1', 'harvest', '2026-04-01T00:00:00Z')).rejects.toThrow('500 Internal Server Error');
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('never executes local batch assignment mutation shims for cutover-complete workflows', async () => {
+    stubCutoverCompleteEnv();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const fetchMock = vi.fn().mockResolvedValue(failingBackendResponse);
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    await expect(
+      mutateBatchAssignment('assign', {
+        batchId: 'batch-1',
+        bedId: 'bed-1',
+        at: '2026-04-01T00:00:00Z',
+      }),
+    ).rejects.toThrow('500 Internal Server Error');
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('never executes local task derivation shims for cutover-complete workflows', async () => {
+    stubCutoverCompleteEnv();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const fetchMock = vi.fn().mockResolvedValue(failingBackendResponse);
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    await expect(regenerateCalendarTasks(2026)).rejects.toThrow('500 Internal Server Error');
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/data/index.ts
+++ b/frontend/src/data/index.ts
@@ -1890,7 +1890,7 @@ export const transitionBatchStage = async (
     return assertValid('batch', await workflowAdapter.batches.transitionStage(batchId, nextStage, occurredAt));
   }
 
-  // Deprecated rollback shim. Remove once TypeScript rollback window is retired.
+  // Deprecated rollback shim for emergency rollback only. Removal target: 2026-07-31.
   console.warn('[DEPRECATED] Using TypeScript batch stage transition rollback shim.');
   const appState = await loadAppStateFromIndexedDb();
   if (!appState) {
@@ -1920,7 +1920,7 @@ export const mutateBatchAssignment = async (
     return assertValid('batch', await workflowAdapter.batches.mutateAssignment(operation, payload));
   }
 
-  // Deprecated rollback shim. Remove once TypeScript rollback window is retired.
+  // Deprecated rollback shim for emergency rollback only. Removal target: 2026-07-31.
   console.warn('[DEPRECATED] Using TypeScript batch assignment rollback shim.');
   const appState = await loadAppStateFromIndexedDb();
   if (!appState) {
@@ -1953,7 +1953,7 @@ export const regenerateCalendarTasks = async (year: number) => {
     };
   }
 
-  // Deprecated rollback shim. Remove once TypeScript rollback window is retired.
+  // Deprecated rollback shim for emergency rollback only. Removal target: 2026-07-31.
   console.warn('[DEPRECATED] Using TypeScript task regeneration rollback shim.');
   const appState = await loadAppStateFromIndexedDb();
   if (!appState) {

--- a/frontend/src/data/workflowAdapter.test.ts
+++ b/frontend/src/data/workflowAdapter.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
+  isCutoverCompleteWorkflow,
   isWorkflowRoutedToBackend,
   shouldUseCanonicalBackendPath,
   shouldUseTypescriptRollbackShim,
@@ -68,6 +69,28 @@ describe('workflow routing flags', () => {
     expect(shouldUseTypescriptRollbackShim('tasks')).toBe(false);
     expect(shouldUseTypescriptRollbackShim('taxonomy')).toBe(true);
   });
+  it('treats workflows as cutover-complete only when parity accepted and marked complete', () => {
+    vi.stubEnv('VITE_FRONTEND_MODE', 'backend');
+    vi.stubEnv('VITE_PARITY_ACCEPTED_WORKFLOWS', 'batches,tasks');
+    vi.stubEnv('VITE_CUTOVER_COMPLETE_WORKFLOWS', 'batches');
+
+    expect(isCutoverCompleteWorkflow('batches')).toBe(true);
+    expect(isCutoverCompleteWorkflow('tasks')).toBe(false);
+  });
+
+  it('keeps rollback shims disabled for cutover-complete workflows unless emergency kill switch is enabled', () => {
+    vi.stubEnv('VITE_FRONTEND_MODE', 'backend');
+    vi.stubEnv('VITE_PARITY_ACCEPTED_WORKFLOWS', 'batches');
+    vi.stubEnv('VITE_CUTOVER_COMPLETE_WORKFLOWS', 'batches');
+    vi.stubEnv('VITE_ENABLE_TYPESCRIPT_ROLLBACK_SHIMS', 'true');
+    vi.stubEnv('VITE_TYPESCRIPT_ROLLBACK_WORKFLOWS', 'batches');
+
+    expect(shouldUseTypescriptRollbackShim('batches')).toBe(false);
+
+    vi.stubEnv('VITE_ENABLE_EMERGENCY_TYPESCRIPT_ROLLBACK', 'true');
+    expect(shouldUseTypescriptRollbackShim('batches')).toBe(true);
+  });
+
 });
 
 describe('workflow adapter transport', () => {

--- a/frontend/src/data/workflowAdapter.ts
+++ b/frontend/src/data/workflowAdapter.ts
@@ -71,6 +71,25 @@ const isTypescriptRollbackShimEnabled = (feature: WorkflowFeature): boolean => {
   return rollbackFeatures.length === 0 || rollbackFeatures.includes(feature);
 };
 
+const isEmergencyTypescriptRollbackEnabled = (feature: WorkflowFeature): boolean => {
+  const env = resolveRuntimeEnv();
+  if (!isFeatureFlagEnabled(env.VITE_ENABLE_EMERGENCY_TYPESCRIPT_ROLLBACK)) {
+    return false;
+  }
+
+  const rollbackFeatures = parseWorkflowList(env.VITE_EMERGENCY_TYPESCRIPT_ROLLBACK_WORKFLOWS);
+  return rollbackFeatures.length === 0 || rollbackFeatures.includes(feature);
+};
+
+export const isCutoverCompleteWorkflow = (feature: WorkflowFeature): boolean => {
+  if (!isParityAcceptedWorkflow(feature)) {
+    return false;
+  }
+
+  const env = resolveRuntimeEnv();
+  return parseWorkflowList(env.VITE_CUTOVER_COMPLETE_WORKFLOWS).includes(feature);
+};
+
 export const shouldUseCanonicalBackendPath = (feature: WorkflowFeature): boolean => {
   if (getFrontendMode() !== 'backend') {
     return false;
@@ -84,10 +103,19 @@ export const shouldUseCanonicalBackendPath = (feature: WorkflowFeature): boolean
 };
 
 /**
- * @deprecated Rollback-only helper. Remove alongside VITE_ENABLE_TYPESCRIPT_ROLLBACK_SHIMS retirement.
+ * @deprecated Rollback-only helper. Remove alongside rollback retirement target (2026-07-31).
  */
-export const shouldUseTypescriptRollbackShim = (feature: WorkflowFeature): boolean =>
-  !shouldUseCanonicalBackendPath(feature) || isTypescriptRollbackShimEnabled(feature);
+export const shouldUseTypescriptRollbackShim = (feature: WorkflowFeature): boolean => {
+  if (isEmergencyTypescriptRollbackEnabled(feature)) {
+    return true;
+  }
+
+  if (isCutoverCompleteWorkflow(feature)) {
+    return false;
+  }
+
+  return !shouldUseCanonicalBackendPath(feature) || isTypescriptRollbackShimEnabled(feature);
+};
 
 export const parseBackendError = async (response: Response): Promise<string> => {
   try {


### PR DESCRIPTION
### Motivation
- Provide a formal, configurable "cutover-complete" condition to gate when workflows should use canonical backend domain paths instead of local TypeScript mutation/derivation shims. 
- Prevent accidental execution of local domain mutation paths for workflows that have achieved parity and passed gated equivalence checks, while retaining a controlled emergency rollback mechanism.

### Description
- Codified the cutover-complete criteria in `fixtures/equivalence/cutover-criteria.v1.json` by adding `cutoverCompleteCondition` and documented the policy in `docs/dotnet-readiness.md` (includes `VITE_CUTOVER_COMPLETE_WORKFLOWS` and an emergency rollback kill-switch). 
- Added `isCutoverCompleteWorkflow` and `isEmergencyTypescriptRollbackEnabled` helpers to `frontend/src/data/workflowAdapter.ts` and updated `shouldUseTypescriptRollbackShim` to keep rollback shims disabled for cutover-complete workflows unless the emergency kill-switch is enabled. 
- Marked TypeScript rollback shim locations in `frontend/src/data/index.ts` with a dated removal target (`2026-07-31`) and preserved UI orchestration while enforcing backend ownership for domain mutations/derivations when cutover-complete. 
- Added regression tests: new `frontend/src/data/index.cutoverRouting.test.ts` and extended `frontend/src/data/workflowAdapter.test.ts` to assert that cutover-complete workflows do not execute local mutation/derivation shims and that the emergency kill-switch overrides when present. 

### Testing
- Ran unit tests with `npm test -- --run src/data/workflowAdapter.test.ts src/data/index.cutoverRouting.test.ts src/data/repos/workflowRouting.test.ts`, and all tests passed (3 test files, 16 tests total). 
- Verified the new routing/regression tests exercise backend routing failure behavior and absence of deprecated rollback warnings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d22524d38083269821e4716fe3f086)