### PR TITLE
Add shared parity diff summary utility for parity tests

### DIFF
--- a/frontend/src/data/parity.integration.test.ts
+++ b/frontend/src/data/parity.integration.test.ts
@@ -5,6 +5,8 @@ import { dirname, join, resolve } from 'node:path';
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { spawn, spawnSync, type ChildProcessWithoutNullStreams } from 'node:child_process';
 
+import { summarizeParityDiffs } from './parityTestUtils';
+
 type DataModule = typeof import('./index');
 
 type ParityOperation =
@@ -17,7 +19,7 @@ type BatchMutationOperation =
   | { kind: 'mutateBatchAssignment'; operation: 'assign' | 'move' | 'remove'; at: string; bedId?: string };
 
 const PRODUCTION_DB_NAME = 'survival-garden';
-const MAX_DIFFS = 8;
+const MAX_DIFFS = 20;
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const repoRoot = resolve(__dirname, '../../..');
@@ -192,50 +194,6 @@ const canonicalizeState = (data: DataModule, appState: unknown): unknown =>
 const isPlainObject = (value: unknown): value is Record<string, unknown> =>
   Boolean(value && typeof value === 'object' && !Array.isArray(value));
 
-const summarizeDiffs = (left: unknown, right: unknown, maxDiffs: number): string[] => {
-  const diffs: string[] = [];
-
-  const visit = (leftValue: unknown, rightValue: unknown, path: string): void => {
-    if (diffs.length >= maxDiffs) {
-      return;
-    }
-
-    if (Object.is(leftValue, rightValue)) {
-      return;
-    }
-
-    if (Array.isArray(leftValue) && Array.isArray(rightValue)) {
-      if (leftValue.length !== rightValue.length) {
-        diffs.push(`${path} length mismatch (${leftValue.length} vs ${rightValue.length})`);
-      }
-
-      const maxLength = Math.max(leftValue.length, rightValue.length);
-      for (let index = 0; index < maxLength; index += 1) {
-        visit(leftValue[index], rightValue[index], `${path}[${index}]`);
-        if (diffs.length >= maxDiffs) {
-          return;
-        }
-      }
-      return;
-    }
-
-    if (isPlainObject(leftValue) && isPlainObject(rightValue)) {
-      const keys = [...new Set([...Object.keys(leftValue), ...Object.keys(rightValue)])].sort();
-      for (const key of keys) {
-        visit(leftValue[key], rightValue[key], path === '$' ? `$.${key}` : `${path}.${key}`);
-        if (diffs.length >= maxDiffs) {
-          return;
-        }
-      }
-      return;
-    }
-
-    diffs.push(`${path} differs (${JSON.stringify(leftValue)} vs ${JSON.stringify(rightValue)})`);
-  };
-
-  visit(left, right, '$');
-  return diffs;
-};
 
 const toTaskKey = (task: Record<string, unknown>): string => {
   const sourceKey = task.sourceKey;
@@ -572,7 +530,7 @@ describeParity('parity integration (frontend IndexedDB vs backend persistence)',
     const frontendState = await runTsWorkflow(data, trierSeed, operations);
     const backendState = await runBackendWorkflow(data, backendBaseUrl, paritySeed, operations);
 
-    const diffSummary = summarizeDiffs(frontendState, backendState, MAX_DIFFS);
+    const diffSummary = summarizeParityDiffs(frontendState as Record<string, unknown>, backendState as Record<string, unknown>, MAX_DIFFS);
     expect(frontendState, `Parity mismatch summary:\n${diffSummary.join('\n')}`).toStrictEqual(backendState);
   });
 
@@ -703,7 +661,7 @@ describeParity('parity integration (frontend IndexedDB vs backend persistence)',
       expect(backendBatch.currentStage).toBe('harvest');
       expect(backendBatch.stage).toBe('harvest');
 
-      const diffSummary = summarizeDiffs(frontendState, backendState, MAX_DIFFS);
+      const diffSummary = summarizeParityDiffs(frontendState as Record<string, unknown>, backendState as Record<string, unknown>, MAX_DIFFS);
       expect(frontendState, `Parity mismatch summary:\n${diffSummary.join('\n')}`).toStrictEqual(backendState);
     },
   );
@@ -820,7 +778,7 @@ describeParity('parity integration (frontend IndexedDB vs backend persistence)',
         const taskMismatches = collectTaskParityMismatches(frontendState, backendState);
         expect(taskMismatches, `Task parity mismatches:\n${taskMismatches.join('\n')}`).toStrictEqual([]);
 
-        const diffSummary = summarizeDiffs(frontendState, backendState, MAX_DIFFS);
+        const diffSummary = summarizeParityDiffs(frontendState as Record<string, unknown>, backendState as Record<string, unknown>, MAX_DIFFS);
         expect(frontendState, `AppState parity mismatch summary:\n${diffSummary.join('\n')}`).toStrictEqual(backendState);
       } finally {
         if (previousMode === undefined) {

--- a/frontend/src/data/parityTestUtils.test.ts
+++ b/frontend/src/data/parityTestUtils.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { summarizeParityDiffs } from './parityTestUtils';
+
+describe('summarizeParityDiffs', () => {
+  it('reports deterministic path-level expected/actual diffs with normalized object key ordering', () => {
+    const expectedTs = {
+      profile: {
+        beta: 2,
+        alpha: 1,
+      },
+    };
+    const actualBackend = {
+      profile: {
+        alpha: 1,
+        beta: 9,
+      },
+    };
+
+    expect(summarizeParityDiffs(expectedTs, actualBackend)).toStrictEqual([
+      '$.profile.beta: expected 2, actual 9',
+    ]);
+  });
+
+  it('limits output to the first 20 diffs and appends a truncation notice', () => {
+    const expectedTs = Object.fromEntries(Array.from({ length: 25 }, (_, index) => [`k${index}`, index]));
+    const actualBackend = Object.fromEntries(Array.from({ length: 25 }, (_, index) => [`k${index}`, index + 1]));
+
+    const diffs = summarizeParityDiffs(expectedTs, actualBackend);
+
+    expect(diffs).toHaveLength(21);
+    expect(diffs[0]).toBe('$.k0: expected 0, actual 1');
+    expect(diffs[19]).toBe('$.k4: expected 4, actual 5');
+    expect(diffs[20]).toBe('...truncated after first 20 diffs');
+  });
+});

--- a/frontend/src/data/parityTestUtils.ts
+++ b/frontend/src/data/parityTestUtils.ts
@@ -1,0 +1,87 @@
+const DEFAULT_MAX_DIFFS = 20;
+
+type CanonicalJsonObject = Record<string, unknown>;
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value && typeof value === 'object' && !Array.isArray(value));
+
+const normalizeForDiff = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeForDiff(item));
+  }
+
+  if (isPlainObject(value)) {
+    const normalizedEntries = Object.keys(value)
+      .sort()
+      .map((key) => [key, normalizeForDiff(value[key])] as const);
+    return Object.fromEntries(normalizedEntries);
+  }
+
+  return value;
+};
+
+const formatValue = (value: unknown): string => JSON.stringify(normalizeForDiff(value));
+
+export const summarizeParityDiffs = (
+  expectedTs: CanonicalJsonObject,
+  actualBackend: CanonicalJsonObject,
+  maxDiffs: number = DEFAULT_MAX_DIFFS,
+): string[] => {
+  const diffs: string[] = [];
+  let truncated = false;
+
+  const pushDiff = (message: string): void => {
+    if (diffs.length < maxDiffs) {
+      diffs.push(message);
+      return;
+    }
+
+    truncated = true;
+  };
+
+  const visit = (expectedValue: unknown, actualValue: unknown, path: string): void => {
+    if (truncated) {
+      return;
+    }
+
+    if (Object.is(expectedValue, actualValue)) {
+      return;
+    }
+
+    if (Array.isArray(expectedValue) && Array.isArray(actualValue)) {
+      if (expectedValue.length !== actualValue.length) {
+        pushDiff(`${path}: expected length ${expectedValue.length}, actual length ${actualValue.length}`);
+      }
+
+      const maxLength = Math.max(expectedValue.length, actualValue.length);
+      for (let index = 0; index < maxLength; index += 1) {
+        visit(expectedValue[index], actualValue[index], `${path}[${index}]`);
+        if (truncated) {
+          return;
+        }
+      }
+      return;
+    }
+
+    if (isPlainObject(expectedValue) && isPlainObject(actualValue)) {
+      const keys = [...new Set([...Object.keys(expectedValue), ...Object.keys(actualValue)])].sort();
+      for (const key of keys) {
+        visit(expectedValue[key], actualValue[key], path === '$' ? `$.${key}` : `${path}.${key}`);
+        if (truncated) {
+          return;
+        }
+      }
+      return;
+    }
+
+    pushDiff(`${path}: expected ${formatValue(expectedValue)}, actual ${formatValue(actualValue)}`);
+  };
+
+  visit(normalizeForDiff(expectedTs), normalizeForDiff(actualBackend), '$');
+
+  if (truncated) {
+    diffs.push(`...truncated after first ${maxDiffs} diffs`);
+  }
+
+  return diffs;
+};


### PR DESCRIPTION
### Motivation
- Provide a single reusable helper for parity/equivalence tests to produce deterministic, human-readable diffs between canonical TS and backend JSON outputs.
- Reduce duplication and noisy CI logs by capping diff output and normalizing object key ordering before comparison.

### Description
- Add `summarizeParityDiffs` in `frontend/src/data/parityTestUtils.ts` that recursively compares two canonical JSON objects, normalizes object-key ordering, and emits path-level `expected` vs `actual` lines.
- Limit output to the first 20 diffs and append a truncation notice when exceeded, with arrays reporting length mismatches and nested paths included.
- Update `frontend/src/data/parity.integration.test.ts` to use the shared helper and align `MAX_DIFFS` to `20` so integration parity assertions use the same bounded behavior.
- Add focused unit tests in `frontend/src/data/parityTestUtils.test.ts` verifying deterministic formatting and truncation behavior.

### Testing
- Ran the new unit tests with `npm run test -- src/data/parityTestUtils.test.ts`, and they passed (2 tests, 1 file).
- Ran type checking with `npm run typecheck`, and it completed successfully (no TypeScript errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d26f7fc7108326bbb40ad3d9220176)