### PR TITLE
Validate backend API base URL and produce absolute backend URLs

### DIFF
--- a/frontend/src/data/workflowAdapter.test.ts
+++ b/frontend/src/data/workflowAdapter.test.ts
@@ -3,6 +3,7 @@ import {
   isWorkflowRoutedToBackend,
   shouldUseCanonicalBackendPath,
   shouldUseTypescriptRollbackShim,
+  toBackendApiUrl,
   workflowAdapter,
 } from './workflowAdapter';
 
@@ -71,6 +72,27 @@ describe('workflow routing flags', () => {
 });
 
 describe('workflow adapter transport', () => {
+  it('throws an explicit configuration error in backend mode when backend base URL is missing', () => {
+    vi.stubEnv('VITE_FRONTEND_MODE', 'backend');
+    vi.stubEnv('VITE_BACKEND_API_BASE_URL', undefined as unknown as string);
+
+    expect(() => toBackendApiUrl('/api/beds')).toThrowError('VITE_BACKEND_API_BASE_URL must be set in backend mode');
+  });
+
+  it('returns an absolute backend URL in backend mode when backend base URL is configured', () => {
+    vi.stubEnv('VITE_FRONTEND_MODE', 'backend');
+    vi.stubEnv('VITE_BACKEND_API_BASE_URL', 'http://localhost:5142');
+
+    expect(toBackendApiUrl('/api/beds')).toBe('http://localhost:5142/api/beds');
+  });
+
+  it('leaves typescript mode paths unchanged when backend base URL is missing', () => {
+    vi.stubEnv('VITE_FRONTEND_MODE', 'typescript');
+    vi.stubEnv('VITE_BACKEND_API_BASE_URL', undefined as unknown as string);
+
+    expect(toBackendApiUrl('/api/beds')).toBe('/api/beds');
+  });
+
   it('posts stage transitions to the backend domain endpoint', async () => {
     vi.stubEnv('VITE_BACKEND_API_BASE_URL', 'http://localhost:5142');
 

--- a/frontend/src/data/workflowAdapter.ts
+++ b/frontend/src/data/workflowAdapter.ts
@@ -23,7 +23,22 @@ export const getBackendApiBaseUrl = (): string => {
   return (env.VITE_BACKEND_API_BASE_URL ?? DEFAULT_BACKEND_API_BASE_URL).trim().replace(/\/$/, '');
 };
 
-export const toBackendApiUrl = (path: string): string => `${getBackendApiBaseUrl()}${path}`;
+const validateBackendApiPath = (path: string, baseUrl: string): void => {
+  if (getFrontendMode() === 'backend' && path.startsWith('/') && baseUrl.length === 0) {
+    throw new Error('VITE_BACKEND_API_BASE_URL must be set in backend mode');
+  }
+};
+
+export const toBackendApiUrl = (path: string): string => {
+  const baseUrl = getBackendApiBaseUrl();
+  validateBackendApiPath(path, baseUrl);
+
+  if (baseUrl.length === 0) {
+    return path;
+  }
+
+  return new URL(path, `${baseUrl}/`).toString();
+};
 
 const isFeatureFlagEnabled = (value: string | undefined): boolean => value?.trim().toLowerCase() === 'true';
 const parseWorkflowList = (value: string | undefined): WorkflowFeature[] =>


### PR DESCRIPTION
### Motivation
- Prevent silent misconfiguration when running the frontend in `backend` mode by failing fast for rooted API paths without a configured backend base URL.
- Use a robust, Node-compatible absolute URL construction for backend requests so endpoints are consistently formed across environments.

### Description
- Added `validateBackendApiPath(path, baseUrl)` and integrated it into `toBackendApiUrl` to throw `VITE_BACKEND_API_BASE_URL must be set in backend mode` when in backend mode and a rooted path is used without a base URL.
- Updated `toBackendApiUrl` to read `getBackendApiBaseUrl()`, return the raw `path` when the base is empty, and otherwise construct an absolute URL using `new URL(path, `${baseUrl}/`).`
- Extended `frontend/src/data/workflowAdapter.test.ts` to import `toBackendApiUrl` and add tests for backend mode with missing base URL (error), backend mode with valid base URL (absolute URL), and typescript mode with missing base URL (path unchanged).

### Testing
- Running the targeted test file with an incorrect path filter initially found no tests, which prompted correcting the test invocation filter.
- Executed `npm test -- --run src/data/workflowAdapter.test.ts` with `vitest`, and the test run completed successfully with all tests passing (10 tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3a72c80c083268e979f40e2bdb299)