### PR TITLE
Make CORS configurable with safe production default

### DIFF
--- a/backend/SurvivalGarden.Api/Program.cs
+++ b/backend/SurvivalGarden.Api/Program.cs
@@ -5,15 +5,24 @@ using SurvivalGarden.Persistence;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddOpenApi();
-builder.Services.AddCors(options =>
+var corsOrigins = builder.Configuration.GetSection("Cors:AllowedOrigins").Get<string[]>() ?? [];
+if (builder.Environment.IsDevelopment() && corsOrigins.Length == 0)
 {
-    options.AddPolicy("FrontendDev", policy =>
+    corsOrigins = ["http://localhost:5173"];
+}
+
+if (corsOrigins.Length > 0)
+{
+    builder.Services.AddCors(options =>
     {
-        policy.WithOrigins("http://localhost:5173")
-            .AllowAnyHeader()
-            .AllowAnyMethod();
+        options.AddPolicy("Frontend", policy =>
+        {
+            policy.WithOrigins(corsOrigins)
+                .AllowAnyHeader()
+                .AllowAnyMethod();
+        });
     });
-});
+}
 var appStatePath =
     builder.Configuration["APP_STATE_FILE_PATH"] ??
     builder.Configuration["Persistence:AppStatePath"];
@@ -25,7 +34,11 @@ var app = builder.Build();
 if (app.Environment.IsDevelopment())
 {
     app.MapOpenApi();
-    app.UseCors("FrontendDev");
+}
+
+if (corsOrigins.Length > 0)
+{
+    app.UseCors("Frontend");
 }
 
 app.MapCoreEndpoints();

--- a/backend/SurvivalGarden.Api/Program.cs
+++ b/backend/SurvivalGarden.Api/Program.cs
@@ -5,6 +5,15 @@ using SurvivalGarden.Persistence;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddOpenApi();
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("FrontendDev", policy =>
+    {
+        policy.WithOrigins("http://localhost:5173")
+            .AllowAnyHeader()
+            .AllowAnyMethod();
+    });
+});
 var appStatePath =
     builder.Configuration["APP_STATE_FILE_PATH"] ??
     builder.Configuration["Persistence:AppStatePath"];
@@ -16,6 +25,7 @@ var app = builder.Build();
 if (app.Environment.IsDevelopment())
 {
     app.MapOpenApi();
+    app.UseCors("FrontendDev");
 }
 
 app.MapCoreEndpoints();


### PR DESCRIPTION
### Motivation
- We need frontend API access during local development without weakening production defaults.
- A hardcoded dev-only origin solved local CORS but didn’t clarify production setup.

### What changed
- Read allowed origins from configuration: `Cors:AllowedOrigins`.
- If running in Development and no origins are configured, default to `http://localhost:5173`.
- Register and apply a `Frontend` CORS policy only when one or more origins are present.

### Production behavior
- If `Cors:AllowedOrigins` is not set in production, no CORS policy is applied (same-origin only).
- If configured, only listed origins are allowed.

### Why this is safe
- No endpoint/business logic changed.
- CORS remains explicit and environment-driven.