### PR TITLE
Ensure root collections on load/save; add default settings, schemaVersion, and tasks collection

### DIFF
--- a/backend/SurvivalGarden.Application/GardenApplicationService.cs
+++ b/backend/SurvivalGarden.Application/GardenApplicationService.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Nodes;
+using System.Globalization;
 
 namespace SurvivalGarden.Application;
 
@@ -14,10 +15,21 @@ public sealed class GardenApplicationService(IGardenStateStore store) : IGardenA
         "beds",
         "paths",
         "seedInventoryItems",
-        "cropPlans"
+        "cropPlans",
+        "tasks"
     ];
 
-    public Task<JsonObject?> LoadAppStateAsync(CancellationToken cancellationToken = default) => store.LoadAsync(cancellationToken);
+    public async Task<JsonObject?> LoadAppStateAsync(CancellationToken cancellationToken = default)
+    {
+        var state = await store.LoadAsync(cancellationToken);
+        if (state is null)
+        {
+            return null;
+        }
+
+        EnsureRootCollections(state);
+        return state;
+    }
 
     public async Task SaveAppStateAsync(JsonObject appState, CancellationToken cancellationToken = default)
     {
@@ -166,9 +178,35 @@ public sealed class GardenApplicationService(IGardenStateStore store) : IGardenA
 
     private static void EnsureRootCollections(JsonObject state)
     {
+        if (state["schemaVersion"] is null)
+        {
+            state["schemaVersion"] = 1;
+        }
+
+        if (state["settings"] is not JsonObject)
+        {
+            state["settings"] = new JsonObject
+            {
+                ["settingsId"] = "settings-default",
+                ["locale"] = "de-DE",
+                ["timezone"] = "Europe/Berlin",
+                ["weekStartsOn"] = "monday",
+                ["units"] = new JsonObject
+                {
+                    ["temperature"] = "celsius",
+                    ["yield"] = "metric"
+                },
+                ["createdAt"] = UtcNowIso(),
+                ["updatedAt"] = UtcNowIso()
+            };
+        }
+
         foreach (var name in RootCollections)
         {
             _ = GardenJsonCollectionHelpers.GetCollection(state, name);
         }
     }
+
+    private static string UtcNowIso() =>
+        DateTimeOffset.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ", CultureInfo.InvariantCulture);
 }


### PR DESCRIPTION
### Motivation
- Ensure application state always contains the expected root collections and a minimal schema/settings backbone so new installs and older states are compatible with new features such as `tasks`.
- Provide sensible default `settings` (locale, timezone, units, week start) and a `schemaVersion` so downstream code can rely on these fields being present.

### Description
- Added `tasks` to the `RootCollections` list and ensured `EnsureRootCollections` is invoked when loading state by converting `LoadAppStateAsync` to an async method that calls `EnsureRootCollections` on the loaded state.
- `EnsureRootCollections` now sets a default `schemaVersion` when missing and creates a default `settings` `JsonObject` with `settingsId`, `locale`, `timezone`, `weekStartsOn`, `units`, `createdAt`, and `updatedAt` when `settings` is absent or not an object.
- Introduced `UtcNowIso()` to generate ISO UTC timestamps using `CultureInfo.InvariantCulture` and added the `System.Globalization` import.
- Kept existing behavior of creating/ensuring each named collection via `GardenJsonCollectionHelpers.GetCollection` and ensured `SaveAppStateAsync` still calls `EnsureRootCollections` before saving.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcdcce1abc83269b68f51ed37a1c9e)