### PR TITLE
Initialize default app settings & schema version; improve validation logging and ensure root collections

### DIFF
--- a/backend/SurvivalGarden.Application/GardenApplicationService.cs
+++ b/backend/SurvivalGarden.Application/GardenApplicationService.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Nodes;
+using System.Globalization;
 
 namespace SurvivalGarden.Application;
 
@@ -11,13 +12,22 @@ public sealed class GardenApplicationService(IGardenStateStore store) : IGardenA
         "cultivars",
         "batches",
         "segments",
-        "beds",
-        "paths",
         "seedInventoryItems",
-        "cropPlans"
+        "cropPlans",
+        "tasks"
     ];
 
-    public Task<JsonObject?> LoadAppStateAsync(CancellationToken cancellationToken = default) => store.LoadAsync(cancellationToken);
+    public async Task<JsonObject?> LoadAppStateAsync(CancellationToken cancellationToken = default)
+    {
+        var state = await store.LoadAsync(cancellationToken);
+        if (state is null)
+        {
+            return null;
+        }
+
+        EnsureRootCollections(state);
+        return state;
+    }
 
     public async Task SaveAppStateAsync(JsonObject appState, CancellationToken cancellationToken = default)
     {
@@ -166,9 +176,35 @@ public sealed class GardenApplicationService(IGardenStateStore store) : IGardenA
 
     private static void EnsureRootCollections(JsonObject state)
     {
+        if (state["schemaVersion"] is null)
+        {
+            state["schemaVersion"] = 1;
+        }
+
+        if (state["settings"] is not JsonObject)
+        {
+            state["settings"] = new JsonObject
+            {
+                ["settingsId"] = "settings-default",
+                ["locale"] = "de-DE",
+                ["timezone"] = "Europe/Berlin",
+                ["weekStartsOn"] = "monday",
+                ["units"] = new JsonObject
+                {
+                    ["temperature"] = "celsius",
+                    ["yield"] = "metric"
+                },
+                ["createdAt"] = UtcNowIso(),
+                ["updatedAt"] = UtcNowIso()
+            };
+        }
+
         foreach (var name in RootCollections)
         {
             _ = GardenJsonCollectionHelpers.GetCollection(state, name);
         }
     }
+
+    private static string UtcNowIso() =>
+        DateTimeOffset.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ", CultureInfo.InvariantCulture);
 }

--- a/frontend/src/data/index.ts
+++ b/frontend/src/data/index.ts
@@ -1,5 +1,5 @@
 import type { AppState, Batch, Bed, Crop, CropPlan, SeedInventoryItem } from '../contracts';
-import { assertValid } from './validation';
+import { SchemaValidationError, assertValid } from './validation';
 import { getSettingsOrDefault } from './repos/settingsRepository';
 import { mergeTaskForImport } from './repos/taskRepository';
 import {
@@ -1228,6 +1228,15 @@ const transactionDone = (transaction: IDBTransaction): Promise<void> =>
     transaction.onabort = () => reject(transaction.error ?? new Error('IndexedDB transaction aborted.'));
   });
 
+const toValidationDebugPayload = (error: unknown): unknown =>
+  error instanceof SchemaValidationError
+    ? {
+        message: error.message,
+        schema: error.schemaName,
+        issues: error.issues,
+      }
+    : error;
+
 const migrateV1ToV2 = (database: IDBDatabase, transaction: IDBTransaction): void => {
   if (!database.objectStoreNames.contains(META_STORE)) {
     database.createObjectStore(META_STORE);
@@ -1373,7 +1382,7 @@ export const initializeAppStateStorage = async (): Promise<void> => {
       await saveAppStateToIndexedDb(GOLDEN_DATASET, { mode: 'replace', mirrorToLocal: true });
       return;
     } catch (error) {
-      console.warn('Backend mode initialization failed; falling back to local IndexedDB.', error);
+      console.warn('Backend mode initialization failed; falling back to local IndexedDB.', toValidationDebugPayload(error));
     }
   }
 
@@ -1461,7 +1470,14 @@ const loadAppStateFromBackendApi = async (): Promise<AppState | null> => {
     console.warn('AppState backend load migration warnings', migrationResult.report.warnings);
   }
 
-  return canonicalizeForExport(assertValid('appState', migrationResult.payload));
+  try {
+    return canonicalizeForExport(assertValid('appState', migrationResult.payload));
+  } catch (error) {
+    if (error instanceof SchemaValidationError) {
+      console.warn('AppState backend load schema issues', toValidationDebugPayload(error));
+    }
+    throw error;
+  }
 };
 
 const loadAppStateFromLocalIndexedDb = async (): Promise<AppState | null> => {
@@ -1484,6 +1500,11 @@ const loadAppStateFromLocalIndexedDb = async (): Promise<AppState | null> => {
 
     return canonicalizeForExport(assertValid('appState', migrationResult.payload));
   } catch (error) {
+    if (error instanceof SchemaValidationError) {
+      console.warn('AppState local load schema issues', toValidationDebugPayload(error));
+      throw error;
+    }
+
     throw new AppStateStorageError(
       `Failed to load app state from local data storage: ${error instanceof Error ? error.message : String(error)}`,
     );
@@ -1503,7 +1524,7 @@ export const loadAppStateFromIndexedDb = async (): Promise<AppState | null> => {
 
       return backendState;
     } catch (error) {
-      console.warn('Backend app-state load failed; using local IndexedDB state.', error);
+      console.warn('Backend app-state load failed; using local IndexedDB state.', toValidationDebugPayload(error));
       return loadAppStateFromLocalIndexedDb();
     }
   }


### PR DESCRIPTION
### Motivation

- Ensure loaded app state always contains the required root collections and baseline metadata so the app can rely on them even when loading older or empty stores.
- Provide sane default `settings` (locale, timezone, units, etc.) and a `schemaVersion` to support migrations and consistent behavior. 
- Surface schema validation issues more clearly in the frontend logs to aid debugging when backend or local data don't match the expected schema.

### Description

- Update `GardenApplicationService` to call `EnsureRootCollections` when loading app state and to set a default `schemaVersion` when missing. 
- Add default `settings` object (including `settingsId`, `locale`, `timezone`, `weekStartsOn`, `units`, `createdAt`, and `updatedAt`) and a `UtcNowIso()` helper in the backend to populate timestamps. 
- Add `tasks` to the list of root collections and remove `beds`/`paths` entries from that array as part of root collection adjustments. 
- Improve frontend validation logging by introducing `SchemaValidationError` handling and a `toValidationDebugPayload` helper, and wire it into backend/local load flows to log structured validation info for failures. 

### Testing

- Ran the backend unit test suite and repository-level checks which completed successfully. 
- Built the frontend and ran the frontend unit tests and type checks which passed. 
- Performed app-state load/save smoke tests across backend and IndexedDB flows and observed expected defaulting behavior and improved validation logging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcdcce1abc83269b68f51ed37a1c9e)