### PR TITLE
Use typed `backendPath` for canonical API routes and add tests for dynamic resource operations

### DIFF
--- a/frontend/src/data/workflowAdapter.test.ts
+++ b/frontend/src/data/workflowAdapter.test.ts
@@ -156,4 +156,56 @@ describe('workflow adapter transport', () => {
       expect.objectContaining({ method: 'GET' }),
     );
   });
+
+  it('calls canonical backend endpoints for dynamic resource operations', async () => {
+    vi.stubEnv('VITE_BACKEND_API_BASE_URL', 'http://localhost:5142');
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ bedId: 'bed%201' }) } as Response)
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ cropId: 'crop%201' }) } as Response)
+      .mockResolvedValueOnce({ status: 204, ok: true } as Response);
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    await workflowAdapter.bedsSegments.upsertBed({
+      bedId: 'bed 1',
+      name: 'Bed 1',
+      type: 'vegetable_bed',
+      gardenId: 'garden-1',
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+    });
+    await workflowAdapter.taxonomy.upsertCrop({
+      cropId: 'crop 1',
+      name: 'Potato',
+      companionsGood: [],
+      companionsAvoid: [],
+      rules: {
+        sowing: { sequence: 1, windows: [] },
+        transplant: { sequence: 1, windows: [] },
+        harvest: { sequence: 1, windows: [] },
+        storage: { sequence: 1, windows: [] },
+      },
+      nutritionProfile: [],
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+    });
+    await workflowAdapter.inventory.removeSeedInventoryItem('seed item 1');
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      'http://localhost:5142/api/beds/bed%201',
+      expect.objectContaining({ method: 'PUT' }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      'http://localhost:5142/api/crops/crop%201',
+      expect.objectContaining({ method: 'PUT' }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      'http://localhost:5142/api/seedInventoryItems/seed%20item%201',
+      expect.objectContaining({ method: 'DELETE' }),
+    );
+  });
 });

--- a/frontend/src/data/workflowAdapter.ts
+++ b/frontend/src/data/workflowAdapter.ts
@@ -1,4 +1,5 @@
 import type { AppState, Batch, Bed, Crop, CropPlan, SeedInventoryItem, Segment } from '../contracts';
+import type { BackendApiPath } from '../generated/api-client';
 
 export type WorkflowFeature = 'batches' | 'tasks' | 'bedsSegments' | 'taxonomy' | 'inventory';
 
@@ -39,6 +40,8 @@ export const toBackendApiUrl = (path: string): string => {
 
   return new URL(path, `${baseUrl}/`).toString();
 };
+
+const backendPath = (path: BackendApiPath): string => path;
 
 const isFeatureFlagEnabled = (value: string | undefined): boolean => value?.trim().toLowerCase() === 'true';
 const parseWorkflowList = (value: string | undefined): WorkflowFeature[] =>
@@ -208,7 +211,7 @@ export const workflowAdapter = {
         generatedTasks: AppState['tasks'];
         diagnostics?: { cropId: string; reason: string; detail: string }[];
         stateAfter: AppState;
-      }>('/api/domain/tasks/regenerate-calendar', {
+      }>(backendPath('/api/domain/tasks/regenerate-calendar'), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ year }),
@@ -222,7 +225,7 @@ export const workflowAdapter = {
     },
   },
   bedsSegments: {
-    listBeds: async (): Promise<Bed[]> => fetchJson<Bed[]>('/api/beds', { method: 'GET' }),
+    listBeds: async (): Promise<Bed[]> => fetchJson<Bed[]>(backendPath('/api/beds'), { method: 'GET' }),
     getBed: async (bedId: string): Promise<Bed | null> => {
       const response = await fetch(toBackendApiUrl(`/api/beds/${encodeURIComponent(bedId)}`), { method: 'GET' });
       if (response.status === 404) {
@@ -248,7 +251,7 @@ export const workflowAdapter = {
         throw new Error(await parseBackendError(response));
       }
     },
-    listSegments: async (): Promise<Segment[]> => fetchJson<Segment[]>('/api/segments', { method: 'GET' }),
+    listSegments: async (): Promise<Segment[]> => fetchJson<Segment[]>(backendPath('/api/segments'), { method: 'GET' }),
     getSegment: async (segmentId: string): Promise<Segment | null> => {
       const response = await fetch(toBackendApiUrl(`/api/segments/${encodeURIComponent(segmentId)}`), { method: 'GET' });
       if (response.status === 404) {
@@ -276,7 +279,7 @@ export const workflowAdapter = {
     },
   },
   taxonomy: {
-    listCrops: async (): Promise<Crop[]> => fetchJson<Crop[]>('/api/crops', { method: 'GET' }),
+    listCrops: async (): Promise<Crop[]> => fetchJson<Crop[]>(backendPath('/api/crops'), { method: 'GET' }),
     getCrop: async (cropId: string): Promise<Crop | null> => {
       const response = await fetch(toBackendApiUrl(`/api/crops/${encodeURIComponent(cropId)}`), { method: 'GET' });
       if (response.status === 404) {
@@ -302,7 +305,7 @@ export const workflowAdapter = {
         throw new Error(await parseBackendError(response));
       }
     },
-    listCropPlans: async (): Promise<CropPlan[]> => fetchJson<CropPlan[]>('/api/cropPlans', { method: 'GET' }),
+    listCropPlans: async (): Promise<CropPlan[]> => fetchJson<CropPlan[]>(backendPath('/api/cropPlans'), { method: 'GET' }),
     getCropPlan: async (planId: string): Promise<CropPlan | null> => {
       const response = await fetch(toBackendApiUrl(`/api/cropPlans/${encodeURIComponent(planId)}`), { method: 'GET' });
       if (response.status === 404) {
@@ -331,7 +334,7 @@ export const workflowAdapter = {
   },
   inventory: {
     listSeedInventoryItems: async (): Promise<SeedInventoryItem[]> =>
-      fetchJson<SeedInventoryItem[]>('/api/seedInventoryItems', { method: 'GET' }),
+      fetchJson<SeedInventoryItem[]>(backendPath('/api/seedInventoryItems'), { method: 'GET' }),
     getSeedInventoryItem: async (seedInventoryItemId: string): Promise<SeedInventoryItem | null> => {
       const response = await fetch(
         toBackendApiUrl(`/api/seedInventoryItems/${encodeURIComponent(seedInventoryItemId)}`),


### PR DESCRIPTION
### Motivation
- Centralize and type-check canonical backend API paths to avoid accidental base URL handling differences and ensure consistency for list endpoints and dynamic operations.
- Verify that encoded resource IDs are used when calling backend PUT/DELETE operations via automated tests.

### Description
- Import the `BackendApiPath` type and add a `backendPath` helper (`const backendPath = (path: BackendApiPath): string => path;`) to mark canonical backend routes.
- Replace direct string literals with `backendPath(...)` for list endpoints and the tasks regenerate endpoint, including `listBeds`, `listSegments`, `listCrops`, `listCropPlans`, `listSeedInventoryItems`, and `regenerateCalendar`.
- Add a unit test in `workflowAdapter.test.ts` that asserts canonical backend endpoints are called for dynamic resource operations (`upsertBed`, `upsertCrop`, and `removeSeedInventoryItem`) with proper URL encoding and HTTP methods.

### Testing
- Ran the unit test suite with `vitest` and the updated tests executed alongside existing tests. 
- All tests, including the newly added dynamic resource operations test, passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5dc5446648326bf5da7aa17fcbb56)