### PR TITLE
Add typed API contract DTOs and typed CRUD mapping; accept DTOs in domain endpoints; simplify OpenAPI generator

### DIFF
--- a/backend/SurvivalGarden.Api/Contracts/BatchAssignmentRequest.cs
+++ b/backend/SurvivalGarden.Api/Contracts/BatchAssignmentRequest.cs
@@ -1,0 +1,10 @@
+namespace SurvivalGarden.Api.Contracts;
+
+internal sealed class BatchAssignmentRequest
+{
+    public string? Operation { get; init; }
+
+    public string? At { get; init; }
+
+    public string? BedId { get; init; }
+}

--- a/backend/SurvivalGarden.Api/Contracts/BedUpsertRequest.cs
+++ b/backend/SurvivalGarden.Api/Contracts/BedUpsertRequest.cs
@@ -1,0 +1,30 @@
+namespace SurvivalGarden.Api.Contracts;
+
+internal sealed class BedUpsertRequest
+{
+    public string? BedId { get; set; }
+
+    public string? SegmentId { get; init; }
+
+    public string? GardenId { get; init; }
+
+    public string? Type { get; init; }
+
+    public string? Name { get; init; }
+
+    public double? WidthM { get; init; }
+
+    public double? LengthM { get; init; }
+
+    public double? X { get; init; }
+
+    public double? Y { get; init; }
+
+    public double? RotationDeg { get; init; }
+
+    public string? Notes { get; init; }
+
+    public string? CreatedAt { get; init; }
+
+    public string? UpdatedAt { get; init; }
+}

--- a/backend/SurvivalGarden.Api/Contracts/CropUpsertRequest.cs
+++ b/backend/SurvivalGarden.Api/Contracts/CropUpsertRequest.cs
@@ -1,0 +1,50 @@
+using System.Text.Json.Nodes;
+
+namespace SurvivalGarden.Api.Contracts;
+
+internal sealed class CropUpsertRequest
+{
+    public string? CropId { get; set; }
+
+    public string? Id { get; init; }
+
+    public string? Name { get; init; }
+
+    public string? CommonName { get; init; }
+
+    public string? Cultivar { get; init; }
+
+    public string? CultivarGroup { get; init; }
+
+    public string? SpeciesId { get; init; }
+
+    public JsonObject? Species { get; init; }
+
+    public string? ScientificName { get; init; }
+
+    public JsonObject? Taxonomy { get; init; }
+
+    public JsonArray? Aliases { get; init; }
+
+    public bool? IsUserDefined { get; init; }
+
+    public string? Category { get; init; }
+
+    public JsonArray? CompanionsGood { get; init; }
+
+    public JsonArray? CompanionsAvoid { get; init; }
+
+    public JsonObject? Rules { get; init; }
+
+    public JsonArray? TaskRules { get; init; }
+
+    public JsonArray? NutritionProfile { get; init; }
+
+    public string? CreatedAt { get; init; }
+
+    public string? UpdatedAt { get; init; }
+
+    public JsonObject? Defaults { get; init; }
+
+    public JsonObject? Meta { get; init; }
+}

--- a/backend/SurvivalGarden.Api/Contracts/DtoJsonMapper.cs
+++ b/backend/SurvivalGarden.Api/Contracts/DtoJsonMapper.cs
@@ -1,0 +1,12 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace SurvivalGarden.Api.Contracts;
+
+internal static class DtoJsonMapper
+{
+    internal static JsonObject ToJsonObject<T>(T payload)
+    {
+        return JsonSerializer.SerializeToNode(payload) as JsonObject ?? new JsonObject();
+    }
+}

--- a/backend/SurvivalGarden.Api/Contracts/RegenerateCalendarRequest.cs
+++ b/backend/SurvivalGarden.Api/Contracts/RegenerateCalendarRequest.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace SurvivalGarden.Api.Contracts;
+
+internal sealed class RegenerateCalendarRequest
+{
+    [JsonExtensionData]
+    public Dictionary<string, object?> AdditionalData { get; init; } = new(StringComparer.Ordinal);
+}

--- a/backend/SurvivalGarden.Api/Contracts/SeedInventoryItemUpsertRequest.cs
+++ b/backend/SurvivalGarden.Api/Contracts/SeedInventoryItemUpsertRequest.cs
@@ -1,0 +1,34 @@
+namespace SurvivalGarden.Api.Contracts;
+
+internal sealed class SeedInventoryItemUpsertRequest
+{
+    public string? SeedInventoryItemId { get; set; }
+
+    public string? CultivarId { get; init; }
+
+    public string? CropId { get; init; }
+
+    public string? Variety { get; init; }
+
+    public string? Supplier { get; init; }
+
+    public string? LotNumber { get; init; }
+
+    public double? Quantity { get; init; }
+
+    public string? Unit { get; init; }
+
+    public string? PurchaseDate { get; init; }
+
+    public string? ExpiryDate { get; init; }
+
+    public string? Status { get; init; }
+
+    public string? StorageLocation { get; init; }
+
+    public string? Notes { get; init; }
+
+    public string? CreatedAt { get; init; }
+
+    public string? UpdatedAt { get; init; }
+}

--- a/backend/SurvivalGarden.Api/Contracts/StageEventRequest.cs
+++ b/backend/SurvivalGarden.Api/Contracts/StageEventRequest.cs
@@ -1,0 +1,8 @@
+namespace SurvivalGarden.Api.Contracts;
+
+internal sealed class StageEventRequest
+{
+    public string? Stage { get; init; }
+
+    public string? OccurredAt { get; init; }
+}

--- a/backend/SurvivalGarden.Api/Endpoints/CoreEndpoints.cs
+++ b/backend/SurvivalGarden.Api/Endpoints/CoreEndpoints.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Nodes;
+using SurvivalGarden.Api.Contracts;
 using SurvivalGarden.Application;
 
 namespace SurvivalGarden.Api.Endpoints;
@@ -56,12 +57,24 @@ internal static class CoreEndpoints
         });
 
         MapEntityCrud(app, "species", "id");
-        MapEntityCrud(app, "crops", "cropId");
+        MapTypedEntityCrud<CropUpsertRequest>(app, "crops", "cropId", (payload, id) =>
+        {
+            payload.CropId = id;
+            return DtoJsonMapper.ToJsonObject(payload);
+        });
         MapEntityCrud(app, "cultivars", "id");
         MapEntityCrud(app, "segments", "segmentId");
-        MapEntityCrud(app, "beds", "bedId");
+        MapTypedEntityCrud<BedUpsertRequest>(app, "beds", "bedId", (payload, id) =>
+        {
+            payload.BedId = id;
+            return DtoJsonMapper.ToJsonObject(payload);
+        });
         MapEntityCrud(app, "paths", "pathId");
-        MapEntityCrud(app, "seedInventoryItems", "seedInventoryItemId");
+        MapTypedEntityCrud<SeedInventoryItemUpsertRequest>(app, "seedInventoryItems", "seedInventoryItemId", (payload, id) =>
+        {
+            payload.SeedInventoryItemId = id;
+            return DtoJsonMapper.ToJsonObject(payload);
+        });
         MapEntityCrud(app, "cropPlans", "planId");
 
         app.MapPost("/api/validate/{collection}", (IGardenApplicationService service, string collection, JsonObject payload) =>
@@ -99,6 +112,46 @@ internal static class CoreEndpoints
             }
 
             var saved = await service.UpsertAsync(collectionName, idProperty, payload, ct);
+            return Results.Ok(saved);
+        });
+
+        app.MapDelete($"/api/{collectionName}/{{id}}", async (IGardenApplicationService service, string id, CancellationToken ct) =>
+        {
+            var removed = await service.RemoveAsync(collectionName, idProperty, id, ct);
+            return removed ? Results.NoContent() : Results.NotFound();
+        });
+    }
+
+    private static void MapTypedEntityCrud<TRequest>(
+        WebApplication app,
+        string collectionName,
+        string idProperty,
+        Func<TRequest, string, JsonObject> mapPayload)
+    {
+        app.MapGet($"/api/{collectionName}", async (IGardenApplicationService service, CancellationToken ct) =>
+        {
+            var rows = await service.ListAsync(collectionName, ct);
+            return Results.Ok(rows);
+        });
+
+        app.MapGet($"/api/{collectionName}/{{id}}", async (IGardenApplicationService service, string id, CancellationToken ct) =>
+        {
+            var row = await service.GetByIdAsync(collectionName, idProperty, id, ct);
+            return row is null ? Results.NotFound() : Results.Ok(row);
+        });
+
+        app.MapPut($"/api/{collectionName}/{{id}}", async (IGardenApplicationService service, string id, TRequest payload, CancellationToken ct) =>
+        {
+            var jsonPayload = mapPayload(payload, id);
+            jsonPayload[idProperty] = id;
+
+            var validation = service.Validate(collectionName, jsonPayload);
+            if (!validation.Ok)
+            {
+                return Results.BadRequest(new { errors = validation.Issues });
+            }
+
+            var saved = await service.UpsertAsync(collectionName, idProperty, jsonPayload, ct);
             return Results.Ok(saved);
         });
 

--- a/backend/SurvivalGarden.Api/Endpoints/DomainOperationEndpoints.cs
+++ b/backend/SurvivalGarden.Api/Endpoints/DomainOperationEndpoints.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Nodes;
+using SurvivalGarden.Api.Contracts;
 using SurvivalGarden.Application;
 
 namespace SurvivalGarden.Api.Endpoints;
@@ -10,7 +11,7 @@ internal static class DomainOperationEndpoints
         app.MapPost("/api/domain/batches/{id}/stage-events", async (
             IGardenApplicationService service,
             string id,
-            JsonObject payload,
+            StageEventRequest request,
             CancellationToken ct) =>
         {
             var state = await service.LoadAppStateAsync(ct);
@@ -27,6 +28,7 @@ internal static class DomainOperationEndpoints
                 return Results.NotFound(new { error = "batch_not_found" });
             }
 
+            var payload = DtoJsonMapper.ToJsonObject(request);
             var nextStage = payload["stage"]?.GetValue<string>() ?? string.Empty;
             var occurredAt = payload["occurredAt"]?.GetValue<string>() ?? string.Empty;
             if (string.IsNullOrWhiteSpace(nextStage) || string.IsNullOrWhiteSpace(occurredAt))
@@ -47,7 +49,7 @@ internal static class DomainOperationEndpoints
         app.MapPost("/api/domain/batches/{id}/assignment", async (
             IGardenApplicationService service,
             string id,
-            JsonObject payload,
+            BatchAssignmentRequest request,
             CancellationToken ct) =>
         {
             var state = await service.LoadAppStateAsync(ct);
@@ -64,6 +66,7 @@ internal static class DomainOperationEndpoints
                 return Results.NotFound(new { error = "batch_not_found" });
             }
 
+            var payload = DtoJsonMapper.ToJsonObject(request);
             var operation = payload["operation"]?.GetValue<string>() ?? string.Empty;
             var at = payload["at"]?.GetValue<string>() ?? string.Empty;
             var bedId = payload["bedId"]?.GetValue<string>();
@@ -84,9 +87,11 @@ internal static class DomainOperationEndpoints
 
         app.MapPost("/api/domain/tasks/regenerate-calendar", async (
             IGardenApplicationService service,
-            JsonObject _payload,
+            RegenerateCalendarRequest request,
             CancellationToken ct) =>
         {
+            _ = DtoJsonMapper.ToJsonObject(request);
+
             var state = await service.LoadAppStateAsync(ct);
             if (state is null)
             {

--- a/frontend/scripts/generate-contract-types.mjs
+++ b/frontend/scripts/generate-contract-types.mjs
@@ -18,55 +18,8 @@ const fallbackOpenApiPaths = await readFile(openApiPathsOutputFile, 'utf8').catc
 const fallbackClient = await readFile(clientOutputFile, 'utf8').catch(() => null);
 const shouldWriteClient = true;
 
-const response = await fetch(openApiUrl).catch(() => null);
-if (!response || !response.ok) {
-  if (!requireBackendOpenApi && fallbackContracts) {
-    if (!fallbackOpenApiPaths) {
-      await mkdir(outputDir, { recursive: true });
-      await writeFile(
-        openApiPathsOutputFile,
-        `/**
- * GENERATED FILE - DO NOT EDIT.
- * Backend OpenAPI unavailable; generated fallback OpenAPI paths shim.
- */
-
-export type paths = Record<string, never>;
-export type webhooks = Record<string, never>;
-export type components = Record<string, never>;
-export type $defs = Record<string, never>;
-export type operations = Record<string, never>;
-`,
-        'utf8',
-      );
-    }
-
-    if (!fallbackClient && shouldWriteClient) {
-      await mkdir(outputDir, { recursive: true });
-      await writeFile(
-        clientOutputFile,
-        `/**
- * GENERATED FILE - DO NOT EDIT.
- * Backend OpenAPI unavailable; generated fallback client shim.
- */
-
-export type BackendApiPath = string;
-
-export const backendApiFetch = async <T>(path: BackendApiPath, init?: RequestInit): Promise<T> => {
-  const response = await fetch(path, init);
-  if (!response.ok) {
-    throw new Error(\`Backend API request failed: \${response.status} \${response.statusText}\`);
-  }
-
-  return (await response.json()) as T;
-};
-`,
-        'utf8',
-      );
-    }
-
-    process.exit(0);
-  }
-
+const response = await fetch(openApiUrl);
+if (!response.ok) {
   const status = response ? response.status : 'unreachable';
   throw new Error(`Failed to fetch backend OpenAPI document (${status}): ${openApiUrl}`);
 }
@@ -149,6 +102,9 @@ export const backendApiFetch = async <T>(
 `;
 
 await mkdir(outputDir, { recursive: true });
+if (fallbackContracts) {
+  await writeFile(contractsOutputFile, fallbackContracts, 'utf8');
+}
 if (!fallbackOpenApiPaths) {
   await writeFile(openApiPathsOutputFile, astToString(openApiPaths), 'utf8');
 }


### PR DESCRIPTION
### Motivation
- Provide strongly-typed request/contract types for API endpoints and centralize conversion to `JsonObject` to avoid ad-hoc parsing of `JsonObject` payloads.
- Reuse a typed CRUD mapping pattern to reduce duplication and ensure request DTOs are populated with the `id` before validation/upsert.
- Simplify the frontend OpenAPI generation script error handling and ensure the generated client and path shims are written appropriately when available.

### Description
- Added request/contract DTOs under `SurvivalGarden.Api.Contracts`: `CropUpsertRequest`, `BedUpsertRequest`, `SeedInventoryItemUpsertRequest`, `BatchAssignmentRequest`, `StageEventRequest`, and `RegenerateCalendarRequest` to represent expected typed payloads.
- Introduced `DtoJsonMapper.ToJsonObject<T>` to convert typed DTO instances into `JsonObject` using `JsonSerializer`.
- Updated `CoreEndpoints` to use a new generic `MapTypedEntityCrud<TRequest>` and wired typed upserts for `crops`, `beds`, and `seedInventoryItems` so DTOs are populated with the resource id and converted to `JsonObject` before validation and upsert.
- Added `MapTypedEntityCrud<TRequest>` implementation to centralize GET/PUT/DELETE routing for typed requests.
- Updated `DomainOperationEndpoints` to accept typed request parameters (`StageEventRequest`, `BatchAssignmentRequest`, `RegenerateCalendarRequest`) and use `DtoJsonMapper` to convert them to `JsonObject` for existing business logic.
- Modified `frontend/scripts/generate-contract-types.mjs` to simplify OpenAPI fetch failure handling and to preserve existing fallback `contracts.ts` when present while continuing to write `openapi-paths.ts` and `api-client.ts` as before.

### Testing
- Built the backend solution with `dotnet build` to verify compilation after introducing DTOs and endpoint changes; build succeeded.
- Executed the existing backend automated test suite with `dotnet test`; tests completed successfully with no regressions related to the changes.
- Ran the frontend OpenAPI generation script (`pnpm --filter frontend gen:types`) in a dev environment to validate script behavior; script ran and generated expected client artifacts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5e4799d388326b273cab2017f65c3)