### PR TITLE
Add schema validation for high-impact workflowAdapter reads

### DIFF
--- a/frontend/src/data/workflowAdapter.test.ts
+++ b/frontend/src/data/workflowAdapter.test.ts
@@ -10,6 +10,92 @@ import {
 
 const originalFetch = globalThis.fetch;
 
+
+const validBed = {
+  bedId: 'bed-1',
+  gardenId: 'garden-1',
+  name: 'Bed 1',
+  type: 'vegetable_bed',
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: '2024-01-02T00:00:00Z',
+};
+
+const validSegment = {
+  segmentId: 'segment-1',
+  name: 'Segment 1',
+  width: 10,
+  height: 5,
+  originReference: 'nw_corner',
+  beds: [{ ...validBed, x: 0, y: 0, width: 2, height: 1 }],
+  paths: [],
+};
+
+const validCrop = {
+  cropId: 'crop-1',
+  name: 'Carrot',
+  scientificName: 'Daucus carota',
+  aliases: ['Garden carrot', 'Nantes carrot'],
+  isUserDefined: true,
+  category: 'root',
+  companionsGood: ['onion'],
+  companionsAvoid: ['dill'],
+  rules: {
+    sowing: {
+      sequence: 1,
+      windows: [{ startMonth: 3, startWeek: 2, endMonth: 4, endWeek: 3 }],
+      notes: 'Direct sow',
+    },
+    transplant: {
+      sequence: 2,
+      windows: [{ startMonth: 4, startWeek: 4, endMonth: 5, endWeek: 2 }],
+      notes: 'Thin as needed',
+    },
+    harvest: {
+      sequence: 3,
+      windows: [{ startMonth: 6, startWeek: 1, endMonth: 9, endWeek: 4 }],
+      notes: 'Pull when ready',
+    },
+    storage: {
+      sequence: 4,
+      windows: [{ startMonth: 9, startWeek: 1, endMonth: 12, endWeek: 4 }],
+      notes: 'Cool and humid',
+    },
+  },
+  nutritionProfile: [{ nutrient: 'fiber', value: 2.8, unit: 'g', source: 'USDA', assumptions: 'raw' }],
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: '2024-01-02T00:00:00Z',
+};
+
+const validCropPlan = {
+  planId: 'plan-1',
+  segmentId: 'segment-1',
+  cropId: 'crop-1',
+  bedId: 'bed-1',
+  seasonYear: 2024,
+  plannedWindows: {
+    sowing: [{ startMonth: 3, startWeek: 2, endMonth: 4, endWeek: 3 }],
+    harvest: [{ startMonth: 6, startWeek: 1, endMonth: 9, endWeek: 4 }],
+  },
+  expectedYield: {
+    amount: 12,
+    unit: 'kg',
+  },
+  notes: 'Main spring bed',
+  placements: [{ type: 'points', points: [{ x: 0.1, y: 0.1 }, { x: 0.2, y: 0.1 }] }],
+};
+
+const validSeedInventoryItem = {
+  seedInventoryItemId: 'seed-item-1',
+  cultivarId: 'cultivar-1',
+  cropId: 'crop-1',
+  variety: 'Nantes',
+  quantity: 120,
+  unit: 'seeds',
+  status: 'available',
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: '2024-01-02T00:00:00Z',
+};
+
 afterEach(() => {
   vi.unstubAllEnvs();
   vi.restoreAllMocks();
@@ -154,6 +240,72 @@ describe('workflow adapter transport', () => {
       3,
       'http://localhost:5142/api/seedInventoryItems',
       expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+
+  it('validates high-impact backend payloads and returns typed values when valid', async () => {
+    vi.stubEnv('VITE_BACKEND_API_BASE_URL', 'http://localhost:5142');
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => [validBed] } as Response)
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => validBed } as Response)
+      .mockResolvedValueOnce({ ok: true, json: async () => [validSegment] } as Response)
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => validSegment } as Response)
+      .mockResolvedValueOnce({ ok: true, json: async () => [validCrop] } as Response)
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => validCrop } as Response)
+      .mockResolvedValueOnce({ ok: true, json: async () => [validCropPlan] } as Response)
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => validCropPlan } as Response)
+      .mockResolvedValueOnce({ ok: true, json: async () => [validSeedInventoryItem] } as Response)
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => validSeedInventoryItem } as Response);
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    await expect(workflowAdapter.bedsSegments.listBeds()).resolves.toEqual([validBed]);
+    await expect(workflowAdapter.bedsSegments.getBed(validBed.bedId)).resolves.toEqual(validBed);
+    await expect(workflowAdapter.bedsSegments.listSegments()).resolves.toEqual([validSegment]);
+    await expect(workflowAdapter.bedsSegments.getSegment(validSegment.segmentId)).resolves.toEqual(validSegment);
+    await expect(workflowAdapter.taxonomy.listCrops()).resolves.toEqual([validCrop]);
+    await expect(workflowAdapter.taxonomy.getCrop(validCrop.cropId)).resolves.toEqual(validCrop);
+    await expect(workflowAdapter.taxonomy.listCropPlans()).resolves.toEqual([validCropPlan]);
+    await expect(workflowAdapter.taxonomy.getCropPlan(validCropPlan.planId)).resolves.toEqual(validCropPlan);
+    await expect(workflowAdapter.inventory.listSeedInventoryItems()).resolves.toEqual([validSeedInventoryItem]);
+    await expect(workflowAdapter.inventory.getSeedInventoryItem(validSeedInventoryItem.seedInventoryItemId)).resolves.toEqual(validSeedInventoryItem);
+  });
+
+  it('throws explicit contract mismatch errors when backend payload shape is invalid', async () => {
+    vi.stubEnv('VITE_BACKEND_API_BASE_URL', 'http://localhost:5142');
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => [{ bedId: 'bed-1' }] } as Response)
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ bedId: 'bed-1' }) } as Response);
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    await expect(workflowAdapter.bedsSegments.listBeds()).rejects.toThrowError(
+      /Backend contract mismatch for bedsSegments\.listBeds\[0\]/,
+    );
+    await expect(workflowAdapter.bedsSegments.getBed('bed-1')).rejects.toThrowError(
+      /Backend contract mismatch for bedsSegments\.getBed/,
+    );
+  });
+
+  it('preserves existing status/error handling semantics for high-impact get methods', async () => {
+    vi.stubEnv('VITE_BACKEND_API_BASE_URL', 'http://localhost:5142');
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ status: 404, ok: false } as Response)
+      .mockResolvedValueOnce({
+        status: 422,
+        ok: false,
+        json: async () => ({ errors: [{ path: '/cropId', message: 'required' }] }),
+      } as Response);
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    await expect(workflowAdapter.taxonomy.getCrop('missing-crop')).resolves.toBeNull();
+    await expect(workflowAdapter.taxonomy.getCrop('invalid-crop')).rejects.toThrowError(
+      'validation_failed: /cropId: required',
     );
   });
 

--- a/frontend/src/data/workflowAdapter.ts
+++ b/frontend/src/data/workflowAdapter.ts
@@ -1,4 +1,6 @@
 import type { AppState, Batch, Bed, Crop, CropPlan, SeedInventoryItem, Segment } from '../contracts';
+import { assertValid } from './validation';
+import type { SchemaName, SchemaTypeMap } from './validation';
 import type { BackendApiPath } from '../generated/api-client';
 
 export type WorkflowFeature = 'batches' | 'tasks' | 'bedsSegments' | 'taxonomy' | 'inventory';
@@ -174,6 +176,32 @@ const fetchJson = async <T>(path: string, init?: RequestInit): Promise<T> => {
   return response.json() as Promise<T>;
 };
 
+
+const buildContractMismatchError = (contractName: string, error: unknown): Error => {
+  const details = error instanceof Error ? `: ${error.message}` : '';
+  return new Error(`Backend contract mismatch for ${contractName}${details}`);
+};
+
+const assertContract = <T extends SchemaName>(contractName: string, schemaName: T, payload: unknown): SchemaTypeMap[T] => {
+  try {
+    return assertValid(schemaName, payload);
+  } catch (error) {
+    throw buildContractMismatchError(contractName, error);
+  }
+};
+
+const assertContractList = <T extends SchemaName>(
+  contractName: string,
+  schemaName: T,
+  payload: unknown,
+): SchemaTypeMap[T][] => {
+  if (!Array.isArray(payload)) {
+    throw buildContractMismatchError(contractName, new Error('expected array payload'));
+  }
+
+  return payload.map((item, index) => assertContract(`${contractName}[${index}]`, schemaName, item));
+};
+
 export const workflowAdapter = {
   batches: {
     transitionStage: async (batchId: string, nextStage: string, occurredAt: string): Promise<Batch> =>
@@ -225,7 +253,8 @@ export const workflowAdapter = {
     },
   },
   bedsSegments: {
-    listBeds: async (): Promise<Bed[]> => fetchJson<Bed[]>(backendPath('/api/beds'), { method: 'GET' }),
+    listBeds: async (): Promise<Bed[]> =>
+      assertContractList('bedsSegments.listBeds', 'bed', await fetchJson<unknown>(backendPath('/api/beds'), { method: 'GET' })),
     getBed: async (bedId: string): Promise<Bed | null> => {
       const response = await fetch(toBackendApiUrl(`/api/beds/${encodeURIComponent(bedId)}`), { method: 'GET' });
       if (response.status === 404) {
@@ -234,7 +263,7 @@ export const workflowAdapter = {
       if (!response.ok) {
         throw new Error(await parseBackendError(response));
       }
-      return response.json() as Promise<Bed>;
+      return assertContract('bedsSegments.getBed', 'bed', await response.json());
     },
     upsertBed: async (bed: Bed): Promise<Bed> =>
       fetchJson<Bed>(`/api/beds/${encodeURIComponent(bed.bedId)}`, {
@@ -251,7 +280,8 @@ export const workflowAdapter = {
         throw new Error(await parseBackendError(response));
       }
     },
-    listSegments: async (): Promise<Segment[]> => fetchJson<Segment[]>(backendPath('/api/segments'), { method: 'GET' }),
+    listSegments: async (): Promise<Segment[]> =>
+      assertContractList('bedsSegments.listSegments', 'segment', await fetchJson<unknown>(backendPath('/api/segments'), { method: 'GET' })),
     getSegment: async (segmentId: string): Promise<Segment | null> => {
       const response = await fetch(toBackendApiUrl(`/api/segments/${encodeURIComponent(segmentId)}`), { method: 'GET' });
       if (response.status === 404) {
@@ -260,7 +290,7 @@ export const workflowAdapter = {
       if (!response.ok) {
         throw new Error(await parseBackendError(response));
       }
-      return response.json() as Promise<Segment>;
+      return assertContract('bedsSegments.getSegment', 'segment', await response.json());
     },
     upsertSegment: async (segment: Segment): Promise<Segment> =>
       fetchJson<Segment>(`/api/segments/${encodeURIComponent(segment.segmentId)}`, {
@@ -279,7 +309,8 @@ export const workflowAdapter = {
     },
   },
   taxonomy: {
-    listCrops: async (): Promise<Crop[]> => fetchJson<Crop[]>(backendPath('/api/crops'), { method: 'GET' }),
+    listCrops: async (): Promise<Crop[]> =>
+      assertContractList('taxonomy.listCrops', 'crop', await fetchJson<unknown>(backendPath('/api/crops'), { method: 'GET' })),
     getCrop: async (cropId: string): Promise<Crop | null> => {
       const response = await fetch(toBackendApiUrl(`/api/crops/${encodeURIComponent(cropId)}`), { method: 'GET' });
       if (response.status === 404) {
@@ -288,7 +319,7 @@ export const workflowAdapter = {
       if (!response.ok) {
         throw new Error(await parseBackendError(response));
       }
-      return response.json() as Promise<Crop>;
+      return assertContract('taxonomy.getCrop', 'crop', await response.json());
     },
     upsertCrop: async (crop: Crop): Promise<Crop> =>
       fetchJson<Crop>(`/api/crops/${encodeURIComponent(crop.cropId)}`, {
@@ -305,7 +336,8 @@ export const workflowAdapter = {
         throw new Error(await parseBackendError(response));
       }
     },
-    listCropPlans: async (): Promise<CropPlan[]> => fetchJson<CropPlan[]>(backendPath('/api/cropPlans'), { method: 'GET' }),
+    listCropPlans: async (): Promise<CropPlan[]> =>
+      assertContractList('taxonomy.listCropPlans', 'cropPlan', await fetchJson<unknown>(backendPath('/api/cropPlans'), { method: 'GET' })),
     getCropPlan: async (planId: string): Promise<CropPlan | null> => {
       const response = await fetch(toBackendApiUrl(`/api/cropPlans/${encodeURIComponent(planId)}`), { method: 'GET' });
       if (response.status === 404) {
@@ -314,7 +346,7 @@ export const workflowAdapter = {
       if (!response.ok) {
         throw new Error(await parseBackendError(response));
       }
-      return response.json() as Promise<CropPlan>;
+      return assertContract('taxonomy.getCropPlan', 'cropPlan', await response.json());
     },
     upsertCropPlan: async (cropPlan: CropPlan): Promise<CropPlan> =>
       fetchJson<CropPlan>(`/api/cropPlans/${encodeURIComponent(cropPlan.planId)}`, {
@@ -334,7 +366,11 @@ export const workflowAdapter = {
   },
   inventory: {
     listSeedInventoryItems: async (): Promise<SeedInventoryItem[]> =>
-      fetchJson<SeedInventoryItem[]>(backendPath('/api/seedInventoryItems'), { method: 'GET' }),
+      assertContractList(
+        'inventory.listSeedInventoryItems',
+        'seedInventoryItem',
+        await fetchJson<unknown>(backendPath('/api/seedInventoryItems'), { method: 'GET' }),
+      ),
     getSeedInventoryItem: async (seedInventoryItemId: string): Promise<SeedInventoryItem | null> => {
       const response = await fetch(
         toBackendApiUrl(`/api/seedInventoryItems/${encodeURIComponent(seedInventoryItemId)}`),
@@ -346,7 +382,7 @@ export const workflowAdapter = {
       if (!response.ok) {
         throw new Error(await parseBackendError(response));
       }
-      return response.json() as Promise<SeedInventoryItem>;
+      return assertContract('inventory.getSeedInventoryItem', 'seedInventoryItem', await response.json());
     },
     upsertSeedInventoryItem: async (seedInventoryItem: SeedInventoryItem): Promise<SeedInventoryItem> =>
       fetchJson<SeedInventoryItem>(`/api/seedInventoryItems/${encodeURIComponent(seedInventoryItem.seedInventoryItemId)}`, {


### PR DESCRIPTION
### Motivation
- Reduce risk from backend contract regressions by validating backend read responses before they are consumed by the frontend.
- Target high-impact adapters where malformed responses can silently corrupt app state: beds/segments, taxonomy, and inventory.

### Description
- Introduced a thin validation layer in `frontend/src/data/workflowAdapter.ts` with helpers `buildContractMismatchError`, `assertContract`, and `assertContractList` that call existing `assertValid` from `frontend/src/data/validation/index.ts` and wrap failures as clear `Backend contract mismatch for ...` errors.
- Applied validation to these read methods: `bedsSegments.listBeds`, `bedsSegments.getBed`, `bedsSegments.listSegments`, `bedsSegments.getSegment`, `taxonomy.listCrops`, `taxonomy.getCrop`, `taxonomy.listCropPlans`, `taxonomy.getCropPlan`, `inventory.listSeedInventoryItems`, and `inventory.getSeedInventoryItem`.
- Kept existing HTTP/status semantics intact by preserving 404 handling (`get*` returns `null`) and keeping non-OK responses routed through `parseBackendError` (no change to 204/no-content behavior).
- Added/expanded tests in `frontend/src/data/workflowAdapter.test.ts` with fixtures and cases that exercise valid responses, invalid payloads (contract-mismatch), and existing status/error handling.

### Testing
- Ran the adapter test file with `npm test -- --run src/data/workflowAdapter.test.ts`, and the test run completed with all tests passing: `Test Files 1 passed (1)` and `Tests 16 passed (16)`.
- Tests cover: valid payloads are accepted and returned, invalid payloads throw contract-mismatch errors, and existing 404/validation-error parsing semantics are preserved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7353be60c83268a1692d79a759e90)