### PR TITLE
docs: add live contract verification guide and automation script

### DIFF
--- a/docs/live-contract-verification.md
+++ b/docs/live-contract-verification.md
@@ -1,0 +1,146 @@
+# Live contract verification
+
+This runbook verifies that the frontend-generated API contract still matches a live backend instance and that backend-mode routing works end-to-end.
+
+## Prerequisites
+
+- `dotnet` (for backend)
+- `pnpm` + Node.js (for frontend)
+- `python3` (to host fetched OpenAPI artifact at `openapi-v1.json`)
+- `curl`
+
+## 1) Start backend
+
+From repository root:
+
+```bash
+dotnet run --project backend/SurvivalGarden.Api/SurvivalGarden.Api.csproj --urls http://127.0.0.1:5142
+```
+
+Keep this terminal running for the next steps.
+
+## 2) Fetch backend OpenAPI as `openapi-v1.json`
+
+In a separate terminal:
+
+```bash
+mkdir -p .artifacts/openapi
+curl -fsSL http://127.0.0.1:5142/openapi/v1.json -o .artifacts/openapi/openapi-v1.json
+```
+
+Optionally validate that the file is available over HTTP (same shape CI uses):
+
+```bash
+python3 -m http.server 5178 --directory .artifacts/openapi
+# then open: http://127.0.0.1:5178/openapi-v1.json
+```
+
+## 3) Regenerate frontend types with `BACKEND_OPENAPI_URL`
+
+```bash
+BACKEND_OPENAPI_URL=http://127.0.0.1:5178/openapi-v1.json \
+REQUIRE_BACKEND_OPENAPI=1 \
+pnpm --dir frontend gen:types
+```
+
+## 4) Diff check generated files (drift detection)
+
+```bash
+git diff --exit-code -- \
+  frontend/src/generated/contracts.ts \
+  frontend/src/generated/openapi-paths.ts \
+  frontend/src/generated/api-client.ts
+```
+
+## 5) Run typecheck + tests
+
+```bash
+pnpm --dir frontend typecheck
+pnpm --dir frontend test
+```
+
+For quick backend-routing verification only:
+
+```bash
+pnpm --dir frontend exec vitest run \
+  src/data/index.cutoverRouting.test.ts \
+  src/data/repos/workflowRouting.test.ts
+```
+
+## 6) Run frontend in backend mode
+
+```bash
+VITE_FRONTEND_MODE=backend \
+VITE_BACKEND_API_BASE_URL=http://127.0.0.1:5142 \
+pnpm --dir frontend dev
+```
+
+## 7) Manual smoke test checklist (backend mode)
+
+Use the running frontend (`pnpm --dir frontend dev`) with DevTools Network tab open.
+
+### Beds
+
+1. Create one Bed.
+2. Update that Bed (for example name/notes).
+3. Delete that Bed.
+
+Verify expected network activity:
+
+- `POST /api/beds` includes created Bed payload.
+- `PUT /api/beds/{id}` includes updated fields.
+- `DELETE /api/beds/{id}` returns success and the UI list updates.
+
+### Crops
+
+1. Create one Crop.
+2. Update that Crop.
+3. Delete that Crop.
+
+Verify expected network activity:
+
+- `POST /api/crops`
+- `PUT /api/crops/{id}`
+- `DELETE /api/crops/{id}`
+
+### Seed inventory
+
+1. Create one SeedInventoryItem (if needed for delete path).
+2. Delete one SeedInventoryItem.
+
+Verify expected network activity:
+
+- `DELETE /api/seed-inventory/{id}`
+
+### DevTools payload checks
+
+For each create/update/delete request above:
+
+- Confirm request `Content-Type` is JSON when a body is present.
+- Confirm request/response payload fields match generated contract expectations (required fields present, no unexpected shape changes).
+- Confirm HTTP status is success (`2xx`) and no contract mismatch errors appear in UI/console.
+
+## Pass/fail criteria
+
+### Pass
+
+- `gen:types` succeeds against `BACKEND_OPENAPI_URL`.
+- Generated files have no git diff after regeneration.
+- Selected backend-routing tests pass.
+- Full `typecheck` + `test` pass.
+- Manual Bed/Crop/SeedInventoryItem smoke actions succeed with expected backend requests.
+
+### Fail: contract drift
+
+Any of these indicates drift between checked-in generated frontend artifacts and live backend contract:
+
+- `gen:types` modifies one or more generated files.
+- `git diff --exit-code` fails on generated files.
+
+### Fail: runtime schema mismatch
+
+Any of these indicates payload/runtime mismatch despite compile-time generation:
+
+- Backend-mode operations fail with contract validation errors (for example, "Backend contract mismatch ...").
+- Browser Network responses show missing required fields or incompatible types for entities used by the UI.
+- Manual smoke CRUD operations fail (`4xx/5xx`) due to schema/shape incompatibility.

--- a/scripts/verify-live-contract.sh
+++ b/scripts/verify-live-contract.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BACKEND_BASE_URL="${BACKEND_BASE_URL:-http://127.0.0.1:5142}"
+OPENAPI_ARTIFACT_DIR="${OPENAPI_ARTIFACT_DIR:-.artifacts/openapi}"
+OPENAPI_HOST="${OPENAPI_HOST:-127.0.0.1}"
+OPENAPI_PORT="${OPENAPI_PORT:-5178}"
+SELECTED_TESTS=(
+  "src/data/index.cutoverRouting.test.ts"
+  "src/data/repos/workflowRouting.test.ts"
+)
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "error: required command not found: $1" >&2
+    exit 1
+  fi
+}
+
+require_cmd curl
+require_cmd python3
+require_cmd pnpm
+require_cmd git
+
+mkdir -p "$OPENAPI_ARTIFACT_DIR"
+
+OPENAPI_FETCH_URL="${BACKEND_BASE_URL%/}/openapi/v1.json"
+OPENAPI_FILE="$OPENAPI_ARTIFACT_DIR/openapi-v1.json"
+OPENAPI_SERVE_URL="http://${OPENAPI_HOST}:${OPENAPI_PORT}/openapi-v1.json"
+
+echo "[1/4] Fetching backend OpenAPI: $OPENAPI_FETCH_URL"
+curl -fsSL "$OPENAPI_FETCH_URL" -o "$OPENAPI_FILE"
+echo "Saved: $OPENAPI_FILE"
+
+echo "[2/4] Serving fetched OpenAPI at: $OPENAPI_SERVE_URL"
+python3 -m http.server "$OPENAPI_PORT" --bind "$OPENAPI_HOST" --directory "$OPENAPI_ARTIFACT_DIR" >/tmp/survivalgarden-openapi-server.log 2>&1 &
+OPENAPI_SERVER_PID=$!
+cleanup() {
+  if kill -0 "$OPENAPI_SERVER_PID" >/dev/null 2>&1; then
+    kill "$OPENAPI_SERVER_PID" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+# Give server a short warm-up window.
+sleep 1
+
+echo "[3/4] Regenerating frontend generated contract files"
+BACKEND_OPENAPI_URL="$OPENAPI_SERVE_URL" REQUIRE_BACKEND_OPENAPI=1 pnpm --dir frontend gen:types
+
+echo "Checking generated file drift"
+git diff --exit-code -- \
+  frontend/src/generated/contracts.ts \
+  frontend/src/generated/openapi-paths.ts \
+  frontend/src/generated/api-client.ts
+
+echo "[4/4] Running selected backend-routing tests"
+pnpm --dir frontend exec vitest run "${SELECTED_TESTS[@]}"
+
+echo "✅ Live contract verification passed."


### PR DESCRIPTION
### Motivation

- Provide a repeatable, copy-paste runbook to verify frontend-generated contract types against a running backend and to surface contract drift early.
- Automate the common regenerate/diff/test workflow so engineers can quickly validate live OpenAPI output and backend-routing behavior.

### Description

- Add `docs/live-contract-verification.md` with exact commands to start the backend, fetch `openapi-v1.json`, host the artifact, regenerate frontend types with `BACKEND_OPENAPI_URL`, run `typecheck`/`test`, run the frontend in backend mode, and a manual smoke-test checklist for Bed/Crop/SeedInventoryItem CRUD with expected network checks.  
- Add `scripts/verify-live-contract.sh` which fetches the backend OpenAPI to `.artifacts/openapi/openapi-v1.json`, hosts it via `python3 -m http.server`, runs `BACKEND_OPENAPI_URL=... REQUIRE_BACKEND_OPENAPI=1 pnpm --dir frontend gen:types`, runs a `git diff --exit-code` check on generated files, and executes selected backend-routing vitest tests.  
- The script is configurable via environment variables (`BACKEND_BASE_URL`, `OPENAPI_ARTIFACT_DIR`, `OPENAPI_HOST`, `OPENAPI_PORT`) and is executable (`chmod +x`).

### Testing

- Verified script syntax with `bash -n scripts/verify-live-contract.sh` and it passed.  
- Ran the selected frontend backend-routing tests with `pnpm --dir frontend exec vitest run src/data/index.cutoverRouting.test.ts src/data/repos/workflowRouting.test.ts` and the test files passed.  
- Executing `./scripts/verify-live-contract.sh` failed as expected in an environment without a running backend at `http://127.0.0.1:5142`, demonstrating the script correctly surfaces a missing backend during the OpenAPI fetch step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e738523b6c8326bee3e11c2d916397)