### PR TITLE
Clarify Crop Type vs Cultivar schema semantics

### DIFF
--- a/frontend/src/contracts/crop.schema.json
+++ b/frontend/src/contracts/crop.schema.json
@@ -5,7 +5,6 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "speciesId",
     "createdAt",
     "updatedAt"
   ],

--- a/frontend/src/contracts/crop.schema.json
+++ b/frontend/src/contracts/crop.schema.json
@@ -5,6 +5,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "speciesId",
     "createdAt",
     "updatedAt"
   ],
@@ -26,14 +27,6 @@
           "properties": {
             "commonName": {}
           }
-        },
-        {
-          "required": [
-            "cultivar"
-          ],
-          "properties": {
-            "cultivar": {}
-          }
         }
       ]
     }
@@ -53,13 +46,13 @@
       "type": "string",
       "minLength": 1,
       "maxLength": 120,
-      "description": "Legacy migration alias for crop type naming; use name for crop type display labels."
+      "description": "Deprecated migration-only alias for legacy cultivar text that was previously stored on crop records."
     },
     "cultivarGroup": {
       "type": "string",
       "minLength": 1,
       "maxLength": 120,
-      "description": "Optional informational cultivar group label associated with this crop type."
+      "description": "Deprecated migration-only alias for legacy cultivar-group metadata; crop types should not carry cultivar semantics."
     },
     "speciesId": {
       "$ref": "#/$defs/id",

--- a/frontend/src/contracts/crop.schema.json
+++ b/frontend/src/contracts/crop.schema.json
@@ -5,6 +5,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "speciesId",
     "createdAt",
     "updatedAt"
   ],

--- a/frontend/src/contracts/crop.schema.test.ts
+++ b/frontend/src/contracts/crop.schema.test.ts
@@ -87,6 +87,7 @@ describe('crop.schema.json', () => {
     const payload = {
       cropId: 'crop_partial',
       name: 'Partial Crop',
+      speciesId: 'species_partial',
       createdAt: '2026-01-01T00:00:00Z',
       updatedAt: '2026-01-01T00:00:00Z',
     };
@@ -99,6 +100,7 @@ describe('crop.schema.json', () => {
     const payload = {
       id: 'crop_garlic_unknown_variety',
       commonName: 'Garlic',
+      speciesId: 'species_garlic',
       createdAt: '2026-01-01T01:00:00+01:00',
       updatedAt: '2026-01-01T01:00:00+01:00',
       rules: {

--- a/frontend/src/data/validation/index.test.ts
+++ b/frontend/src/data/validation/index.test.ts
@@ -87,6 +87,7 @@ const validSpecies = {
 const validCrop = {
   cropId: 'crop-1',
   name: 'Carrot',
+  speciesId: 'species_carrot',
   scientificName: 'Daucus carota',
   aliases: ['Garden carrot', 'Nantes carrot'],
   isUserDefined: true,
@@ -159,6 +160,7 @@ const validCrop = {
 const validPartialCrop = {
   cropId: 'crop-partial',
   name: 'Partial Crop',
+  speciesId: 'species_carrot',
   createdAt: '2024-01-03T00:00:00Z',
   updatedAt: '2024-01-03T00:00:00Z',
 };

--- a/frontend/src/data/workflowAdapter.test.ts
+++ b/frontend/src/data/workflowAdapter.test.ts
@@ -330,6 +330,7 @@ describe('workflow adapter transport', () => {
     await workflowAdapter.taxonomy.upsertCrop({
       cropId: 'crop 1',
       name: 'Potato',
+      speciesId: 'species_potato',
       companionsGood: [],
       companionsAvoid: [],
       rules: {

--- a/frontend/src/data/workflowAdapter.test.ts
+++ b/frontend/src/data/workflowAdapter.test.ts
@@ -33,6 +33,7 @@ const validSegment = {
 const validCrop = {
   cropId: 'crop-1',
   name: 'Carrot',
+  speciesId: 'species_carrot',
   scientificName: 'Daucus carota',
   aliases: ['Garden carrot', 'Nantes carrot'],
   isUserDefined: true,

--- a/frontend/src/generated/contracts.ts
+++ b/frontend/src/generated/contracts.ts
@@ -209,7 +209,7 @@ export interface Crop {
   name: string;
   cultivar?: string;
   cultivarGroup?: string;
-  speciesId: string;
+  speciesId?: string;
   species?: {
     id?: string;
     commonName: string;

--- a/frontend/src/generated/contracts.ts
+++ b/frontend/src/generated/contracts.ts
@@ -209,7 +209,7 @@ export interface Crop {
   name: string;
   cultivar?: string;
   cultivarGroup?: string;
-  speciesId?: string;
+  speciesId: string;
   species?: {
     id?: string;
     commonName: string;


### PR DESCRIPTION
### Motivation
- Crop records were carrying cultivar-like semantics, creating ambiguity between Crop (middle taxonomy layer) and Cultivar (named reusable variety) at the contract level.
- Contracts and generated types must unambiguously treat `crop` as a Crop Type and ensure required parent linkage to `species` via `speciesId` to prevent schema drift and UI/validation confusion.

### Description
- Updated `frontend/src/contracts/crop.schema.json` to require `speciesId`, removed the `cultivar` option from the `anyOf` identifier requirements, and changed `cultivar`/`cultivarGroup` descriptions to mark them as deprecated migration-only aliases.
- Updated generated TypeScript `frontend/src/generated/contracts.ts` so `Crop.speciesId` is a required `string` (changed from optional to required).
- Changes are presentation/contract-only and do not alter domain logic, persistence, or scoring.

### Testing
- No automated tests were executed as part of this patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e76e1a6c58832685e0f8e05ae98b92)