### PR TITLE
Centralize bed persistence, refresh bed batches after notes save, and add mode authority note

### DIFF
--- a/frontend/docs/entity-migration-checklist.md
+++ b/frontend/docs/entity-migration-checklist.md
@@ -58,3 +58,8 @@ This checklist tracks command/query migration progress for write workflows acros
 - [x] Post-write layout refresh uses query/read path (`listSegments`, `listBeds`, plus mirrored state read for batches).
 - [x] Segment and batch import confirmation paths now route through command APIs instead of direct canonical merge persistence.
 
+## Full App-State Import / Reset
+- [x] Added `replaceCanonicalAppState` command in `frontend/src/data/index.ts` for full-state replace flows.
+- [x] `frontend/src/data/workflowAdapter.ts` now exposes `appState.replace` backend write command for canonical app-state replacement.
+- [x] `frontend/src/App.tsx` full import confirmations (Recovery + Data page) now use command path instead of direct `saveAppStateToIndexedDb(..., { mode: 'replace' })`.
+- [x] `frontend/src/App.tsx` "Empty all data" reset flow now writes via command path and re-reads state using query/read APIs for post-write validation and UI refresh.

--- a/frontend/docs/entity-migration-checklist.md
+++ b/frontend/docs/entity-migration-checklist.md
@@ -1,0 +1,60 @@
+# Entity-by-Entity Migration Checklist
+
+This checklist tracks command/query migration progress for write workflows across the targeted entities.
+
+## Beds
+- [x] `frontend/src/data/index.ts` has write commands: `upsertBed`, `removeBed`.
+- [x] `frontend/src/data/workflowAdapter.ts` has backend requests: `bedsSegments.upsertBed`, `bedsSegments.removeBed`.
+- [x] `frontend/src/App.tsx` uses command functions for writes (no direct bed persistence via `saveAppStateToIndexedDb`).
+- [x] Post-write UI refreshes from query results (`listBeds`, `loadAppStateFromIndexedDb` mirror for batches).
+- [x] Removed direct canonical `saveAppStateToIndexedDb` usage for bed-focused UI flows.
+
+## Batches
+- [x] `frontend/src/data/index.ts` has write commands: `upsertBatch`, `removeBatch`, `mutateBatchAssignment`, `transitionBatchStage`.
+- [x] `frontend/src/data/workflowAdapter.ts` has backend requests under `batches`.
+- [x] `frontend/src/App.tsx` uses batch command functions.
+- [x] Post-write UI reloads state from backend-derived mirror (`loadAppStateFromIndexedDb` after commands).
+- [x] Removed remaining direct `saveAppStateToIndexedDb` call in batch create/edit flow and switched batch import confirm to command writes.
+
+## Tasks
+- [x] `frontend/src/data/index.ts` has write commands: `upsertTask`, `regenerateCalendarTasks`.
+- [x] `frontend/src/data/workflowAdapter.ts` has backend requests under `tasks`.
+- [x] `frontend/src/App.tsx` uses task command functions.
+- [x] Post-write UI refreshes task list from backend-derived state.
+- [x] Removed direct canonical `saveAppStateToIndexedDb` in task regeneration UI flow.
+
+## Crops
+- [x] `frontend/src/data/index.ts` has write commands: `upsertCrop`, `removeCrop`, `importCrops`.
+- [x] `frontend/src/data/workflowAdapter.ts` has backend requests under `taxonomy` for crop writes/import.
+- [x] `frontend/src/App.tsx` uses crop command/import functions.
+- [x] Post-write UI refreshes from query or mirrored backend state.
+- [x] No direct canonical crop persistence in `App.tsx`.
+
+## Species
+- [x] `frontend/src/data/index.ts` has write commands: `upsertSpecies`, `removeSpecies`, `importSpecies`.
+- [x] `frontend/src/data/workflowAdapter.ts` has backend requests under `taxonomy` for species writes/import.
+- [x] `frontend/src/App.tsx` uses species command/import functions.
+- [x] Post-write UI refreshes from `listSpecies`/`listCrops` queries.
+- [x] No direct canonical species persistence in `App.tsx`.
+
+## Crop Plans
+- [x] `frontend/src/data/index.ts` has write commands: `upsertCropPlan`, `removeCropPlan`, `importCropPlans`.
+- [x] `frontend/src/data/workflowAdapter.ts` has backend requests under `taxonomy` for crop plan writes/import.
+- [x] `frontend/src/App.tsx` uses crop plan import command functions.
+- [x] Post-write UI refreshes from `listCropPlans` query.
+- [x] No direct canonical crop plan persistence in `App.tsx`.
+
+## Seed Inventory
+- [x] `frontend/src/data/index.ts` has write commands: `upsertSeedInventoryItem`, `removeSeedInventoryItem`.
+- [x] `frontend/src/data/workflowAdapter.ts` has backend requests under `inventory`.
+- [x] `frontend/src/App.tsx` uses inventory command functions.
+- [x] Post-write UI reloads via inventory query helper (`loadInventory`).
+- [x] No direct canonical seed inventory persistence in `App.tsx`.
+
+## Segments / Import Flows
+- [x] Added segment write commands in `frontend/src/data/index.ts`: `upsertSegment`, `removeSegment`, plus existing `importSegments`.
+- [x] `frontend/src/data/workflowAdapter.ts` has backend requests: `bedsSegments.upsertSegment`, `bedsSegments.removeSegment`, `bedsSegments.importSegments`.
+- [x] `frontend/src/App.tsx` segment and path save/delete routes now use segment commands instead of direct state persistence.
+- [x] Post-write layout refresh uses query/read path (`listSegments`, `listBeds`, plus mirrored state read for batches).
+- [x] Segment and batch import confirmation paths now route through command APIs instead of direct canonical merge persistence.
+

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -49,6 +49,7 @@ vi.mock('./data', () => {
     serializeAppStateForExport: vi.fn().mockReturnValue('{"schemaVersion":1}'),
     assertValid: vi.fn((schemaName: string, value: unknown) => value),
     listCrops: vi.fn(async () => (await loadAppStateFromIndexedDb())?.crops ?? []),
+    listCultivars: vi.fn(async () => (await loadAppStateFromIndexedDb())?.cultivars ?? []),
     listSpecies: vi.fn(async () => (await loadAppStateFromIndexedDb())?.species ?? []),
     listCropPlans: vi.fn(async () => (await loadAppStateFromIndexedDb())?.cropPlans ?? []),
     listSegments: vi.fn(async () => (await loadAppStateFromIndexedDb())?.segments ?? []),
@@ -64,6 +65,7 @@ vi.mock('./data', () => {
       await saveAppStateToIndexedDb({ ...state, species: nextSpecies });
       return species;
     }),
+    upsertCultivar: vi.fn(async (cultivar: { cultivarId: string }) => cultivar),
     importCrops: vi.fn(async () => ({ summary: { imported: 0, merged: 0, skipped: 0, rejected: 0 }, errors: [] })),
     importSpecies: vi.fn(async () => ({ summary: { imported: 0, merged: 0, skipped: 0, rejected: 0 }, errors: [] })),
     importCropPlans: vi.fn(async () => ({ summary: { imported: 0, merged: 0, skipped: 0, rejected: 0 }, errors: [] })),
@@ -646,7 +648,7 @@ describe('App', () => {
       expect(screen.getByText(/local_precheck_warning \(batchId: batch-invalid, field: startedAt\)/)).toBeInTheDocument();
     });
 
-    expect(saveAppStateToIndexedDb).not.toHaveBeenCalledWith(expect.anything(), { mode: 'merge' });
+    expect(upsertBatch).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
     expect(screen.queryByText('Import Preview')).not.toBeInTheDocument();
@@ -659,7 +661,7 @@ describe('App', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Import' }));
 
     await waitFor(() => {
-      expect(saveAppStateToIndexedDb).toHaveBeenCalledWith(expect.anything(), { mode: 'merge' });
+      expect(upsertBatch).toHaveBeenCalledTimes(1);
       expect(screen.getByText('Collision Status Summary')).toBeInTheDocument();
       expect(screen.getByText('skipped (identical_batch): 0')).toBeInTheDocument();
       expect(screen.getByText('merged (eventsAdded): 0')).toBeInTheDocument();
@@ -855,7 +857,7 @@ describe('App', () => {
       expect(screen.getByText('Import failed. Fix the errors below and try again.')).toBeInTheDocument();
     });
 
-    expect(saveAppStateToIndexedDb).not.toHaveBeenCalledWith(expect.anything(), { mode: 'merge' });
+    expect(upsertBatch).not.toHaveBeenCalled();
   });
 
 
@@ -897,7 +899,6 @@ describe('App', () => {
   });
 
   it('accepts deep-link batch import payload and requires confirmation before merge', async () => {
-    const validOnlyState = { schemaVersion: 1, beds: [], crops: [], cropPlans: [], batches: [{ batchId: 'batch-1' }], seedInventoryItems: [], tasks: [] };
     vi.mocked(assertValid).mockImplementation((_schemaName: string, value: unknown) => value as never);
 
     const deepLinkPayload = btoa(JSON.stringify({
@@ -915,15 +916,12 @@ describe('App', () => {
     });
 
     expect(screen.getByText('Import Preview')).toBeInTheDocument();
-    expect(saveAppStateToIndexedDb).not.toHaveBeenCalledWith(expect.anything(), { mode: 'merge' });
+    expect(upsertBatch).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByRole('button', { name: 'Import' }));
 
     await waitFor(() => {
-      expect(saveAppStateToIndexedDb).toHaveBeenCalledWith(expect.objectContaining({
-        ...validOnlyState,
-        batches: expect.arrayContaining([expect.objectContaining({ batchId: 'batch-1' })]),
-      }), { mode: 'merge' });
+      expect(upsertBatch).toHaveBeenCalledWith(expect.objectContaining({ batchId: 'batch-1' }));
     });
   });
 
@@ -938,7 +936,7 @@ describe('App', () => {
       expect(screen.getByText('Deep-link import failed. Payload was invalid or too large.')).toBeInTheDocument();
     });
 
-    expect(saveAppStateToIndexedDb).not.toHaveBeenCalledWith(expect.anything(), { mode: 'merge' });
+    expect(upsertBatch).not.toHaveBeenCalled();
   });
 
   it('accepts deep-link segment import payload and requires confirmation before import', async () => {

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1224,17 +1224,16 @@ describe('App', () => {
 
 
   it('keeps a created species after command save and query refresh on the taxonomy page', async () => {
-    const createdSpecies = {
-      id: 'species_pea',
-      commonName: 'Pea',
-      scientificName: 'Pisum sativum',
-      createdAt: '2026-01-01T00:00:00Z',
-      updatedAt: '2026-01-01T00:00:00Z',
-    };
     let persistedAppState = {
       schemaVersion: 1,
       beds: [],
-      species: [] as Array<typeof createdSpecies>,
+      species: [] as Array<{
+        id: string;
+        commonName: string;
+        scientificName: string;
+        createdAt: string;
+        updatedAt: string;
+      }>,
       crops: [],
       cropPlans: [],
       batches: [],
@@ -1256,7 +1255,13 @@ describe('App', () => {
     vi.mocked(upsertSpecies).mockImplementation(async (species) => {
       persistedAppState = {
         ...persistedAppState,
-        species: [...persistedAppState.species, species as typeof createdSpecies],
+        species: [...persistedAppState.species, species as {
+          id: string;
+          commonName: string;
+          scientificName: string;
+          createdAt: string;
+          updatedAt: string;
+        }],
       };
       return species as never;
     });

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -27,6 +27,7 @@ import {
   saveAppStateToIndexedDb,
   SchemaValidationError,
   serializeAppStateForExport,
+  upsertBatch,
 } from './data';
 
 vi.mock('./data', () => ({
@@ -45,6 +46,7 @@ vi.mock('./data', () => ({
     ...appState,
     batches: [...(appState.batches ?? []).filter((entry: { batchId: string }) => entry.batchId !== batch.batchId), batch],
   })),
+  upsertBatch: vi.fn(async (batch: unknown) => batch),
   listBedsFromAppState: vi.fn().mockReturnValue([]),
   listBatchesFromAppState: vi.fn().mockReturnValue([]),
   listTasksFromAppState: vi.fn().mockReturnValue([]),
@@ -1447,13 +1449,11 @@ describe('App', () => {
       fireEvent.click(within(createBatchForm).getByRole('button', { name: 'Create batch' }));
 
       await waitFor(() => {
-        expect(saveAppStateToIndexedDb).toHaveBeenCalledTimes(index + 1);
+        expect(upsertBatch).toHaveBeenCalledTimes(index + 1);
       });
 
-      const saveCalls = vi.mocked(saveAppStateToIndexedDb).mock.calls;
-      const savedState = saveCalls[saveCalls.length - 1]?.[0] as { batches: Array<Record<string, unknown>> };
-      const savedBatches = savedState.batches;
-      const savedBatch = savedBatches[savedBatches.length - 1];
+      const upsertCalls = vi.mocked(upsertBatch).mock.calls;
+      const savedBatch = upsertCalls[upsertCalls.length - 1]?.[0] as Record<string, unknown>;
 
       expect(savedBatch).toMatchObject({
         startMethod: testCase.expectedStartMethod,

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -22,12 +22,17 @@ import {
   assertValid,
   initializeAppStateStorage,
   loadAppStateFromIndexedDb,
+  listCrops,
+  listSegments,
+  listSpecies,
   parseImportedAppState,
   resetToGoldenDataset,
   saveAppStateToIndexedDb,
   SchemaValidationError,
   serializeAppStateForExport,
+  importSegments,
   upsertBatch,
+  upsertSpecies,
   upsertSegment,
 } from './data';
 
@@ -738,6 +743,20 @@ describe('App', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Import segments' }));
 
     await waitFor(() => {
+      expect(importSegments).toHaveBeenCalledTimes(1);
+      expect(importSegments).toHaveBeenCalledWith(expect.arrayContaining([
+        expect.objectContaining({
+          segmentId: 'segment_new',
+          name: 'North Segment',
+          beds: expect.arrayContaining([expect.objectContaining({ bedId: 'bed_n1' })]),
+          paths: expect.arrayContaining([expect.objectContaining({ pathId: 'path_north_1' })]),
+        }),
+        expect.objectContaining({
+          segmentId: 'segment_existing',
+          name: 'Existing Segment',
+        }),
+      ]));
+      expect(listSegments).toHaveBeenCalledTimes(1);
       expect(screen.getByText('Segment Import Summary')).toBeInTheDocument();
       expect(screen.getByText('imported: 1')).toBeInTheDocument();
       expect(screen.getByText('merged: 0')).toBeInTheDocument();
@@ -807,6 +826,15 @@ describe('App', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Import segments' }));
 
     await waitFor(() => {
+      expect(importSegments).toHaveBeenCalledTimes(1);
+      expect(importSegments).toHaveBeenCalledWith(expect.arrayContaining([
+        expect.objectContaining({
+          segmentId: 'segment_north',
+          name: 'Conflicting Name',
+          originReference: 'se_corner',
+        }),
+      ]));
+      expect(listSegments).toHaveBeenCalledTimes(1);
       expect(screen.getByText('rejected (segment_identity_conflict): 1')).toBeInTheDocument();
       expect(screen.getByText(/rejected \(segment_identity_conflict\): identity mismatch for segmentId segment_north/)).toBeInTheDocument();
     });
@@ -991,12 +1019,14 @@ describe('App', () => {
 
     expect(screen.getByText('Size: 5.8 m × 4.5 m')).toBeInTheDocument();
     expect(screen.getByText('Types: vegetable_bed')).toBeInTheDocument();
-    expect(saveAppStateToIndexedDb).not.toHaveBeenCalledWith(expect.objectContaining({ segments: expect.anything() }), { mode: 'replace' });
+    expect(importSegments).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByRole('button', { name: 'Import segments' }));
 
     await waitFor(() => {
-      expect(saveAppStateToIndexedDb).toHaveBeenCalledWith(expect.objectContaining({ segments: validSegmentState.segments }), { mode: 'replace' });
+      expect(importSegments).toHaveBeenCalledTimes(1);
+      expect(importSegments).toHaveBeenCalledWith(validSegmentState.segments);
+      expect(listSegments).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -1193,11 +1223,18 @@ describe('App', () => {
   });
 
 
-  it('keeps a created species after save and reload on the batches page', async () => {
+  it('keeps a created species after command save and query refresh on the taxonomy page', async () => {
+    const createdSpecies = {
+      id: 'species_pea',
+      commonName: 'Pea',
+      scientificName: 'Pisum sativum',
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+    };
     let persistedAppState = {
       schemaVersion: 1,
       beds: [],
-      species: [],
+      species: [] as Array<typeof createdSpecies>,
       crops: [],
       cropPlans: [],
       batches: [],
@@ -1214,9 +1251,14 @@ describe('App', () => {
     };
 
     vi.mocked(loadAppStateFromIndexedDb).mockImplementation(async () => persistedAppState as never);
-    vi.mocked(saveAppStateToIndexedDb).mockImplementation(async (nextState) => {
-      persistedAppState = nextState as typeof persistedAppState;
-      return undefined as never;
+    vi.mocked(listCrops).mockImplementation(async () => persistedAppState.crops as never);
+    vi.mocked(listSpecies).mockImplementation(async () => persistedAppState.species as never);
+    vi.mocked(upsertSpecies).mockImplementation(async (species) => {
+      persistedAppState = {
+        ...persistedAppState,
+        species: [...persistedAppState.species, species as typeof createdSpecies],
+      };
+      return species as never;
     });
 
     const { unmount } = render(
@@ -1239,16 +1281,16 @@ describe('App', () => {
     fireEvent.click(within(form).getByRole('button', { name: 'Create species' }));
 
     await waitFor(() => {
-      expect(saveAppStateToIndexedDb).toHaveBeenCalledWith(expect.objectContaining({
-        species: [
-          expect.objectContaining({
-            id: 'species_pea',
-            commonName: 'Pea',
-            scientificName: 'Pisum sativum',
-          }),
-        ],
+      expect(upsertSpecies).toHaveBeenCalledTimes(1);
+      expect(upsertSpecies).toHaveBeenCalledWith(expect.objectContaining({
+        id: 'species_pea',
+        commonName: 'Pea',
+        scientificName: 'Pisum sativum',
       }));
+      expect(listCrops).toHaveBeenCalledTimes(1);
+      expect(listSpecies).toHaveBeenCalledTimes(1);
       expect(screen.getByText('Species created.')).toBeInTheDocument();
+      expect(screen.getAllByRole('option', { name: 'Pea (Pisum sativum)' })).toHaveLength(2);
     });
 
     unmount();

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -39,6 +39,10 @@ import {
 vi.mock('./data', () => {
   const saveAppStateToIndexedDb = vi.fn().mockResolvedValue(undefined);
   const loadAppStateFromIndexedDb = vi.fn().mockResolvedValue(null);
+  const replaceCanonicalAppState = vi.fn(async (state: unknown) => {
+    await saveAppStateToIndexedDb(state, { mode: 'replace' });
+    return state;
+  });
 
   return {
     initializeAppStateStorage: vi.fn().mockResolvedValue(undefined),
@@ -46,6 +50,7 @@ vi.mock('./data', () => {
     loadAppStateFromIndexedDb,
     parseImportedAppState: vi.fn(),
     saveAppStateToIndexedDb,
+    replaceCanonicalAppState,
     serializeAppStateForExport: vi.fn().mockReturnValue('{"schemaVersion":1}'),
     assertValid: vi.fn((schemaName: string, value: unknown) => value),
     listCrops: vi.fn(async () => (await loadAppStateFromIndexedDb())?.crops ?? []),

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -28,6 +28,7 @@ import {
   SchemaValidationError,
   serializeAppStateForExport,
   upsertBatch,
+  upsertSegment,
 } from './data';
 
 vi.mock('./data', () => {
@@ -108,6 +109,8 @@ vi.mock('./data', () => {
     batches: [...(appState.batches ?? []).filter((entry: { batchId: string }) => entry.batchId !== batch.batchId), batch],
   })),
   upsertBatch: vi.fn(async (batch: unknown) => batch),
+  upsertSegment: vi.fn(async (segment: unknown) => segment),
+  removeSegment: vi.fn(async () => undefined),
   listBedsFromAppState: vi.fn().mockReturnValue([]),
   listBatchesFromAppState: vi.fn().mockReturnValue([]),
   listTasksFromAppState: vi.fn().mockReturnValue([]),
@@ -346,13 +349,9 @@ describe('App', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Delete path' }));
 
     await waitFor(() => {
-      expect(saveAppStateToIndexedDb).toHaveBeenCalledWith(expect.objectContaining({
-        segments: [
-          expect.objectContaining({
-            segmentId: 'segment-1',
-            paths: [],
-          }),
-        ],
+      expect(upsertSegment).toHaveBeenCalledWith(expect.objectContaining({
+        segmentId: 'segment-1',
+        paths: [],
       }));
     });
 
@@ -408,7 +407,7 @@ describe('App', () => {
       expect(screen.getByText('Cannot delete path path-1 because it is referenced by 1 crop plan.')).toBeInTheDocument();
     });
 
-    expect(saveAppStateToIndexedDb).not.toHaveBeenCalled();
+    expect(upsertSegment).not.toHaveBeenCalled();
   });
 
   it('hides dev reset action when flag is disabled', () => {

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -31,6 +31,7 @@ import {
   SchemaValidationError,
   serializeAppStateForExport,
   importSegments,
+  importBatches,
   upsertBatch,
   upsertSpecies,
   upsertSegment,
@@ -74,6 +75,7 @@ vi.mock('./data', () => {
     importCrops: vi.fn(async () => ({ summary: { imported: 0, merged: 0, skipped: 0, rejected: 0 }, errors: [] })),
     importSpecies: vi.fn(async () => ({ summary: { imported: 0, merged: 0, skipped: 0, rejected: 0 }, errors: [] })),
     importCropPlans: vi.fn(async () => ({ summary: { imported: 0, merged: 0, skipped: 0, rejected: 0 }, errors: [] })),
+    importBatches: vi.fn(async () => ({ summary: { imported: 0, merged: 0, skipped: 0, rejected: 0 }, errors: [] })),
     importSegments: vi.fn(async (segments: Array<{ segmentId: string; name: string; originReference?: string }>) => {
       const state = await loadAppStateFromIndexedDb();
       const summary = { imported: 0, merged: 0, skipped: 0, rejected: 0 };
@@ -653,7 +655,7 @@ describe('App', () => {
       expect(screen.getByText(/local_precheck_warning \(batchId: batch-invalid, field: startedAt\)/)).toBeInTheDocument();
     });
 
-    expect(upsertBatch).not.toHaveBeenCalled();
+    expect(importBatches).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
     expect(screen.queryByText('Import Preview')).not.toBeInTheDocument();
@@ -662,16 +664,23 @@ describe('App', () => {
     await waitFor(() => {
       expect(screen.getByText('Import Preview')).toBeInTheDocument();
     });
+    vi.mocked(importBatches).mockResolvedValueOnce({
+      summary: { imported: 2, merged: 3, skipped: 1, rejected: 4 },
+      errors: [{ path: '/batches/0', message: 'rejected (batch_identity_conflict): duplicate batch id batch-1' }],
+    });
 
     fireEvent.click(screen.getByRole('button', { name: 'Import' }));
 
     await waitFor(() => {
-      expect(upsertBatch).toHaveBeenCalledTimes(1);
+      expect(importBatches).toHaveBeenCalledTimes(1);
       expect(screen.getByText('Collision Status Summary')).toBeInTheDocument();
-      expect(screen.getByText('skipped (identical_batch): 0')).toBeInTheDocument();
-      expect(screen.getByText('merged (eventsAdded): 0')).toBeInTheDocument();
-      expect(screen.getByText('rejected (batch_identity_conflict): 0')).toBeInTheDocument();
+      expect(screen.getByText('created (imported): 2')).toBeInTheDocument();
+      expect(screen.getByText('skipped (identical_batch): 1')).toBeInTheDocument();
+      expect(screen.getByText('merged (eventsAdded): 3')).toBeInTheDocument();
+      expect(screen.getByText('rejected (batch_identity_conflict): 4')).toBeInTheDocument();
       expect(screen.getByText('renamed (newId): 0')).toBeInTheDocument();
+      expect(screen.getByText(/Batch import complete\. Created: 2\./)).toBeInTheDocument();
+      expect(screen.getByText(/Conflict reasons: rejected \(batch_identity_conflict\): duplicate batch id batch-1/)).toBeInTheDocument();
     });
   });
 
@@ -862,7 +871,7 @@ describe('App', () => {
       expect(screen.getByText('Import failed. Fix the errors below and try again.')).toBeInTheDocument();
     });
 
-    expect(upsertBatch).not.toHaveBeenCalled();
+    expect(importBatches).not.toHaveBeenCalled();
   });
 
 
@@ -921,12 +930,12 @@ describe('App', () => {
     });
 
     expect(screen.getByText('Import Preview')).toBeInTheDocument();
-    expect(upsertBatch).not.toHaveBeenCalled();
+    expect(importBatches).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByRole('button', { name: 'Import' }));
 
     await waitFor(() => {
-      expect(upsertBatch).toHaveBeenCalledWith(expect.objectContaining({ batchId: 'batch-1' }));
+      expect(importBatches).toHaveBeenCalledWith([expect.objectContaining({ batchId: 'batch-1' })]);
     });
   });
 
@@ -941,7 +950,7 @@ describe('App', () => {
       expect(screen.getByText('Deep-link import failed. Payload was invalid or too large.')).toBeInTheDocument();
     });
 
-    expect(upsertBatch).not.toHaveBeenCalled();
+    expect(importBatches).not.toHaveBeenCalled();
   });
 
   it('accepts deep-link segment import payload and requires confirmation before import', async () => {

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -30,14 +30,75 @@ import {
   upsertBatch,
 } from './data';
 
-vi.mock('./data', () => ({
-  initializeAppStateStorage: vi.fn().mockResolvedValue(undefined),
-  resetToGoldenDataset: vi.fn().mockResolvedValue(undefined),
-  loadAppStateFromIndexedDb: vi.fn().mockResolvedValue(null),
-  parseImportedAppState: vi.fn(),
-  saveAppStateToIndexedDb: vi.fn().mockResolvedValue(undefined),
-  serializeAppStateForExport: vi.fn().mockReturnValue('{"schemaVersion":1}'),
-  assertValid: vi.fn((schemaName: string, value: unknown) => value),
+vi.mock('./data', () => {
+  const saveAppStateToIndexedDb = vi.fn().mockResolvedValue(undefined);
+  const loadAppStateFromIndexedDb = vi.fn().mockResolvedValue(null);
+
+  return {
+    initializeAppStateStorage: vi.fn().mockResolvedValue(undefined),
+    resetToGoldenDataset: vi.fn().mockResolvedValue(undefined),
+    loadAppStateFromIndexedDb,
+    parseImportedAppState: vi.fn(),
+    saveAppStateToIndexedDb,
+    serializeAppStateForExport: vi.fn().mockReturnValue('{"schemaVersion":1}'),
+    assertValid: vi.fn((schemaName: string, value: unknown) => value),
+    listCrops: vi.fn(async () => (await loadAppStateFromIndexedDb())?.crops ?? []),
+    listSpecies: vi.fn(async () => (await loadAppStateFromIndexedDb())?.species ?? []),
+    listCropPlans: vi.fn(async () => (await loadAppStateFromIndexedDb())?.cropPlans ?? []),
+    listSegments: vi.fn(async () => (await loadAppStateFromIndexedDb())?.segments ?? []),
+    upsertSpecies: vi.fn(async (species: { id: string }) => {
+      const state = await loadAppStateFromIndexedDb();
+      if (!state) {
+        return species;
+      }
+
+      const nextSpecies = (state.species ?? []).some((entry: { id: string }) => entry.id === species.id)
+        ? (state.species ?? []).map((entry: { id: string }) => (entry.id === species.id ? species : entry))
+        : [...(state.species ?? []), species];
+      await saveAppStateToIndexedDb({ ...state, species: nextSpecies });
+      return species;
+    }),
+    importCrops: vi.fn(async () => ({ summary: { imported: 0, merged: 0, skipped: 0, rejected: 0 }, errors: [] })),
+    importSpecies: vi.fn(async () => ({ summary: { imported: 0, merged: 0, skipped: 0, rejected: 0 }, errors: [] })),
+    importCropPlans: vi.fn(async () => ({ summary: { imported: 0, merged: 0, skipped: 0, rejected: 0 }, errors: [] })),
+    importSegments: vi.fn(async (segments: Array<{ segmentId: string; name: string; originReference?: string }>) => {
+      const state = await loadAppStateFromIndexedDb();
+      const summary = { imported: 0, merged: 0, skipped: 0, rejected: 0 };
+      const errors: Array<{ path: string; message: string }> = [];
+
+      if (state) {
+        const segmentsById = new Map((state.segments ?? []).map((segment: { segmentId: string }) => [segment.segmentId, segment]));
+        segments.forEach((incomingSegment, index) => {
+          const currentSegment = segmentsById.get(incomingSegment.segmentId) as { name?: string; originReference?: string } | undefined;
+
+          if (!currentSegment) {
+            segmentsById.set(incomingSegment.segmentId, incomingSegment);
+            summary.imported += 1;
+            return;
+          }
+
+          if (JSON.stringify(currentSegment) === JSON.stringify(incomingSegment)) {
+            summary.skipped += 1;
+            return;
+          }
+
+          if (currentSegment.name !== incomingSegment.name || currentSegment.originReference !== incomingSegment.originReference) {
+            summary.rejected += 1;
+            errors.push({
+              path: `/segments/${index}`,
+              message: `rejected (segment_identity_conflict): identity mismatch for segmentId ${incomingSegment.segmentId}`,
+            });
+            return;
+          }
+
+          segmentsById.set(incomingSegment.segmentId, incomingSegment);
+          summary.merged += 1;
+        });
+
+        await saveAppStateToIndexedDb({ ...state, segments: [...segmentsById.values()] }, { mode: 'replace' });
+      }
+      return { summary, errors };
+    }),
   upsertCropInAppState: vi.fn((appState: { crops?: Array<{ cropId: string }> }, crop: { cropId: string }) => ({
     ...appState,
     crops: [...(appState.crops ?? []).filter((entry: { cropId: string }) => entry.cropId !== crop.cropId), crop],
@@ -61,7 +122,8 @@ vi.mock('./data', () => ({
       this.issues = issues;
     }
   },
-}));
+  };
+});
 
 const buildBatchCreationState = () => ({
   schemaVersion: 1,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import {
   loadPhotoBlobFromIndexedDb,
   resetToGoldenDataset,
   parseImportedAppState,
+  removeBed,
   removeBatch,
   saveAppStateToIndexedDb,
   savePhotoBlobToIndexedDb,
@@ -29,6 +30,7 @@ import {
   mutateBatchAssignment,
   regenerateCalendarTasks,
   transitionBatchStage,
+  upsertBed,
 } from './data';
 import { normalizeBatchCandidate } from './data/repos/batchRepository';
 import { canTransition, inferBatchStartMethod } from './domain';
@@ -1125,18 +1127,7 @@ function BedDetailPage() {
 
       setIsDeletingBed(true);
 
-      const nextSegments = (appState.segments ?? []).map((segment) => {
-        const nextBeds = segment.beds.filter((segmentBed) => segmentBed.bedId !== bedId);
-        return nextBeds.length === segment.beds.length ? segment : { ...segment, beds: nextBeds };
-      });
-
-      const nextState = {
-        ...appState,
-        segments: nextSegments,
-        beds: [],
-      };
-
-      await saveAppStateToIndexedDb(nextState);
+      await removeBed(bedId);
       await navigate('/beds');
     } catch (error) {
       setDeleteBedMessage(error instanceof Error ? error.message : 'Failed to delete bed.');
@@ -1166,14 +1157,14 @@ function BedDetailPage() {
           return;
         }
 
-        const nextState = upsertBedInAppState(appState, {
+        const savedBed = await upsertBed({
           ...latestBed,
           notes,
           updatedAt: new Date().toISOString(),
         });
-
-        await saveAppStateToIndexedDb(nextState);
-        setBed((current) => (current && current.bedId === bedId ? { ...current, notes } : current));
+        setBed((current) => (current && current.bedId === bedId ? savedBed : current));
+        const refreshedState = await loadAppStateFromIndexedDb();
+        refreshBedBatches(refreshedState);
       };
 
       void persistNotes();
@@ -1182,7 +1173,7 @@ function BedDetailPage() {
     return () => {
       window.clearTimeout(timeoutId);
     };
-  }, [bed, bedId, notes]);
+  }, [bed, bedId, notes, refreshBedBatches]);
 
   if (isLoading) {
     return <p className="beds-empty-state">Loading bed…</p>;
@@ -8228,6 +8219,11 @@ function App() {
         <h1>SurvivalGarden</h1>
         <p className={`app-mode-indicator app-mode-indicator--${frontendMode}`} aria-live="polite">
           Mode: {frontendMode === 'backend' ? '.NET backend' : 'TypeScript local'}
+        </p>
+        <p className="app-mode-authority-note">
+          {frontendMode === 'backend'
+            ? 'Canonical updates are backend-authoritative; UI state reflects server responses.'
+            : 'Local TypeScript mode is enabled for UI-only workflows and development fallback.'}
         </p>
       </header>
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -28,10 +28,12 @@ import {
   regenerateCalendarTasks,
   transitionBatchStage,
   listCrops,
+  listCultivars,
   listSpecies,
   listCropPlans,
   listSegments,
   upsertSpecies,
+  upsertCultivar,
   importCrops,
   importSpecies,
   importCropPlans,
@@ -1986,13 +1988,8 @@ function CultivarAdminPage() {
     setSavingId(editingCultivarId ?? 'new');
 
     try {
-      const appState = await loadAppStateFromIndexedDb();
-      if (!appState) {
-        return;
-      }
-
       const nowIso = new Date().toISOString();
-      const existingCultivars = getCultivarsFromAppState(appState);
+      const existingCultivars = await listCultivars();
       const existingCultivar = editingCultivarId ? existingCultivars.find((cultivar) => cultivar.cultivarId === editingCultivarId) : undefined;
       const nextCultivar: CultivarRecord = {
         cultivarId: existingCultivar?.cultivarId ?? createUniqueCultivarId(trimmedName, trimmedCropTypeId, existingCultivars.map((cultivar) => cultivar.cultivarId)),
@@ -2009,8 +2006,10 @@ function CultivarAdminPage() {
       const nextCultivars = existingCultivars.some((cultivar) => cultivar.cultivarId === nextCultivar.cultivarId)
         ? existingCultivars.map((cultivar) => (cultivar.cultivarId === nextCultivar.cultivarId ? nextCultivar : cultivar))
         : [...existingCultivars, nextCultivar];
-
-      await saveAppStateToIndexedDb(assertValid('appState', withCultivarsInAppState(appState, nextCultivars)));
+      const cultivarToPersist =
+        nextCultivars.find((candidate) => candidate.cultivarId === nextCultivar.cultivarId)
+        ?? nextCultivar;
+      await upsertCultivar(cultivarToPersist);
       await loadCultivars();
 
       if (!existingCultivar && isBatchQuickCreate) {
@@ -2030,17 +2029,14 @@ function CultivarAdminPage() {
     setSaveMessage(null);
 
     try {
-      const appState = await loadAppStateFromIndexedDb();
-      if (!appState) {
-        return;
-      }
-
       const nowIso = new Date().toISOString();
-      const nextCultivars = getCultivarsFromAppState(appState).map((cultivar) => (
+      const nextCultivars = (await listCultivars()).map((cultivar) => (
         cultivar.cultivarId === cultivarId ? withCultivarArchiveState(cultivar, archived, nowIso) : cultivar
       ));
-
-      await saveAppStateToIndexedDb(assertValid('appState', withCultivarsInAppState(appState, nextCultivars)));
+      const nextCultivar = nextCultivars.find((candidate) => candidate.cultivarId === cultivarId);
+      if (nextCultivar) {
+        await upsertCultivar(nextCultivar);
+      }
       await loadCultivars();
       if (editingCultivarId === cultivarId && archived) {
         resetForm();
@@ -2751,12 +2747,6 @@ const getCultivarsFromAppState = (appState: AppState): CultivarRecord[] => {
   const cultivars = (appState as AppStateWithCultivars).cultivars;
   return Array.isArray(cultivars) ? cultivars : [];
 };
-
-const withCultivarsInAppState = (appState: AppState, cultivars: CultivarRecord[]): AppState =>
-  ({
-    ...(appState as AppStateWithCultivars),
-    cultivars,
-  }) as AppState;
 
 const createUniqueCultivarId = (name: string, cropTypeId: string, existingCultivarIds: string[]): string => {
   const base = normalizeCropIdPart(`${cropTypeId}-${name}`) || `cultivar-${Date.now()}`;
@@ -7055,15 +7045,29 @@ function DataPage({ showDevResetButton, onResetToGoldenDataset }: DataPageProps)
     setImportErrors([]);
 
     try {
-      const report = await saveAppStateToIndexedDb(pendingBatchImportState, { mode: 'merge' });
       const appStateWithBatches = pendingBatchImportState as { batches?: unknown[] };
-      const created = report?.batches.added ?? appStateWithBatches.batches?.length ?? 0;
-      const merged = report?.batches.updated ?? 0;
-      const skipped = report?.batches.unchanged ?? 0;
-      const rejectedConflict = report?.conflicts.length ?? 0;
+      const candidateBatches = Array.isArray(appStateWithBatches.batches) ? appStateWithBatches.batches : [];
+      const importErrors: Array<{ path: string; message: string }> = [];
+      let created = 0;
+
+      await Promise.all(candidateBatches.map(async (batchCandidate, index) => {
+        try {
+          await upsertBatch(batchCandidate);
+          created += 1;
+        } catch (error) {
+          importErrors.push({
+            path: `/batches/${index}`,
+            message: error instanceof Error ? error.message : 'Batch upsert failed.',
+          });
+        }
+      }));
+
+      const merged = 0;
+      const skipped = 0;
+      const rejectedConflict = importErrors.length;
       const renamed = 0;
-      const conflictDetail = rejectedConflict > 0
-        ? ` Conflict reasons: ${report?.conflicts.join('; ')}`
+      const conflictDetail = rejectedConflict > 0 && importErrors.length > 0
+        ? ` Conflict reasons: ${importErrors.map((entry) => entry.message).join('; ')}`
         : '';
       const renameCapabilityNote = autoRenameOnConflict
         ? ' Auto-rename requested, but this importer currently reports collisions as deterministic rejects.'
@@ -7074,6 +7078,7 @@ function DataPage({ showDevResetButton, onResetToGoldenDataset }: DataPageProps)
         rejected: rejectedConflict,
         renamed,
       });
+      setImportErrors(importErrors);
       setImportMessage(
         `Batch import complete. Created: ${created}. Statuses: merged ${merged}, skipped ${skipped}, rejected ${rejectedConflict}, renamed ${renamed}.`
         + conflictDetail

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,6 +27,15 @@ import {
   mutateBatchAssignment,
   regenerateCalendarTasks,
   transitionBatchStage,
+  listCrops,
+  listSpecies,
+  listCropPlans,
+  listSegments,
+  upsertSpecies,
+  importCrops,
+  importSpecies,
+  importCropPlans,
+  importSegments,
   upsertBed,
   upsertCrop,
   upsertSeedInventoryItem,
@@ -3729,18 +3738,13 @@ function BatchesPage({
       if (!notes) {
         delete (nextSpecies as { notes?: string }).notes;
       }
-      const nextSpeciesCollection = (appState.species ?? []).map((entry) => (entry.id === existingSpecies.id ? nextSpecies : entry));
-      const nextState = assertValid('appState', {
-        ...appState,
-        species: nextSpeciesCollection,
-      });
-      const nextSpeciesById = buildSpeciesLookup(nextState.species);
-
-      await saveAppStateToIndexedDb(nextState);
+      await upsertSpecies(nextSpecies);
+      const [refreshedCrops, refreshedSpecies] = await Promise.all([listCrops(), listSpecies()]);
+      const nextSpeciesById = buildSpeciesLookup(refreshedSpecies);
       setSpeciesById(nextSpeciesById);
       setCropScientificNames(
         Object.fromEntries(
-          nextState.crops.map((crop) => [crop.cropId, getCropSpeciesScientificName(crop, nextSpeciesById)]),
+          refreshedCrops.map((crop) => [crop.cropId, getCropSpeciesScientificName(crop, nextSpeciesById)]),
         ),
       );
       setSpeciesEditErrors({});
@@ -3756,7 +3760,7 @@ function BatchesPage({
       );
       setFormValues((current) =>
         selectedCultivar &&
-        nextState.crops.some((crop) => crop.cropId === selectedCultivar.cropTypeId && (crop as Crop & { speciesId?: string }).speciesId === existingSpecies.id)
+        refreshedCrops.some((crop) => crop.cropId === selectedCultivar.cropTypeId && (crop as Crop & { speciesId?: string }).speciesId === existingSpecies.id)
           ? {
               ...current,
               cropInput:
@@ -3829,18 +3833,14 @@ function BatchesPage({
         ...(aliases.length > 0 ? { aliases } : {}),
         ...(notes ? { notes } : {}),
       };
-      const nextState = assertValid('appState', {
-        ...appState,
-        species: [...(appState.species ?? []), nextSpecies],
-      });
-      const nextSpeciesById = buildSpeciesLookup(nextState.species);
-
-      await saveAppStateToIndexedDb(nextState);
+      await upsertSpecies(nextSpecies);
+      const [refreshedCrops, refreshedSpecies] = await Promise.all([listCrops(), listSpecies()]);
+      const nextSpeciesById = buildSpeciesLookup(refreshedSpecies);
       setSpeciesById(nextSpeciesById);
       setEditingSpeciesId(speciesId);
       setCropScientificNames(
         Object.fromEntries(
-          nextState.crops.map((crop) => [crop.cropId, getCropSpeciesScientificName(crop, nextSpeciesById)]),
+          refreshedCrops.map((crop) => [crop.cropId, getCropSpeciesScientificName(crop, nextSpeciesById)]),
         ),
       );
       setSpeciesCreateValues({
@@ -7085,109 +7085,11 @@ function DataPage({ showDevResetButton, onResetToGoldenDataset }: DataPageProps)
     setImportErrors([]);
 
     try {
-      const existingAppState = await loadAppStateFromIndexedDb();
-      if (!existingAppState) {
-        setImportMessage('Crop import failed: local app state is unavailable.');
-        return;
-      }
-
-      const cropsById = new Map(existingAppState.crops.map((crop) => [crop.cropId, crop]));
-      const summary = { imported: 0, merged: 0, skipped: 0, rejected: 0 };
-      const results: Array<{ path: string; message: string }> = [];
-
-      pendingCropImportCrops.forEach((incomingCrop, index) => {
-        const currentCrop = cropsById.get(incomingCrop.cropId);
-
-        if (!currentCrop) {
-          cropsById.set(incomingCrop.cropId, incomingCrop);
-          summary.imported += 1;
-          return;
-        }
-
-        if (incomingCrop.createdAt !== currentCrop.createdAt) {
-          summary.rejected += 1;
-          results.push({
-            path: `/crops/${index}`,
-            message: `rejected (crop_identity_conflict): createdAt mismatch for cropId ${incomingCrop.cropId}`,
-          });
-          return;
-        }
-
-        const mergedCrop: Crop = {
-          ...currentCrop,
-          name: incomingCrop.name,
-          rules: incomingCrop.rules,
-          nutritionProfile: incomingCrop.nutritionProfile,
-          updatedAt: incomingCrop.updatedAt,
-        };
-
-        if (incomingCrop.aliases !== undefined) {
-          mergedCrop.aliases = incomingCrop.aliases;
-        }
-        if (incomingCrop.category !== undefined) {
-          mergedCrop.category = incomingCrop.category;
-        }
-        if (incomingCrop.cultivarGroup !== undefined) {
-          mergedCrop.cultivarGroup = incomingCrop.cultivarGroup;
-        }
-        if (incomingCrop.taskRules !== undefined) {
-          mergedCrop.taskRules = incomingCrop.taskRules;
-        }
-        const incomingCultivar = (incomingCrop as Crop & { cultivar?: string }).cultivar;
-        if (incomingCultivar !== undefined) {
-          (mergedCrop as Crop & { cultivar?: string }).cultivar = incomingCultivar;
-        }
-        const incomingSpeciesId = (incomingCrop as Crop & { speciesId?: string }).speciesId;
-        if (incomingSpeciesId !== undefined) {
-          (mergedCrop as Crop & { speciesId?: string }).speciesId = incomingSpeciesId;
-        }
-
-        const incomingSpecies = (incomingCrop as Crop & {
-          species?: { id?: string; commonName: string; scientificName: string; taxonomy?: { family?: string; genus?: string; species?: string } };
-        }).species;
-        const incomingTaxonomy = incomingCrop.taxonomy;
-
-        if (incomingSpecies !== undefined || incomingTaxonomy !== undefined) {
-          const currentSpecies = (currentCrop as Crop & {
-            species?: { id?: string; commonName: string; scientificName: string; taxonomy?: { family?: string; genus?: string; species?: string } };
-          }).species;
-          const commonName = incomingSpecies?.commonName ?? currentSpecies?.commonName;
-          const scientificName = incomingSpecies?.scientificName ?? currentSpecies?.scientificName;
-
-          if (commonName !== undefined && scientificName !== undefined) {
-            (mergedCrop as Crop & {
-              species?: { id?: string; commonName: string; scientificName: string; taxonomy?: { family?: string; genus?: string; species?: string } };
-            }).species = {
-              ...(currentSpecies?.id !== undefined ? { id: currentSpecies.id } : {}),
-              ...(incomingSpecies?.id !== undefined ? { id: incomingSpecies.id } : {}),
-              commonName,
-              scientificName,
-              ...((incomingTaxonomy !== undefined || incomingSpecies?.taxonomy !== undefined || currentSpecies?.taxonomy !== undefined)
-                ? {
-                    taxonomy: {
-                      ...(currentSpecies?.taxonomy ?? {}),
-                      ...(incomingTaxonomy ?? {}),
-                      ...(incomingSpecies?.taxonomy ?? {}),
-                    },
-                  }
-                : {}),
-            };
-          }
-        }
-
-        const unchanged = JSON.stringify(currentCrop) === JSON.stringify(mergedCrop);
-        cropsById.set(incomingCrop.cropId, mergedCrop);
-        if (unchanged) {
-          summary.skipped += 1;
-        } else {
-          summary.merged += 1;
-        }
-      });
-
-      await saveAppStateToIndexedDb({ ...existingAppState, crops: [...cropsById.values()] }, { mode: 'replace' });
-      setCropImportStatusSummary(summary);
-      setImportErrors(results);
-      setImportMessage(`Crop import complete. imported: ${summary.imported}, merged: ${summary.merged}, skipped: ${summary.skipped}, rejected: ${summary.rejected}.`);
+      const commandResult = await importCrops(pendingCropImportCrops);
+      await Promise.all([listCrops(), listSpecies()]);
+      setCropImportStatusSummary(commandResult.summary);
+      setImportErrors(commandResult.errors);
+      setImportMessage(`Crop import complete. imported: ${commandResult.summary.imported}, merged: ${commandResult.summary.merged}, skipped: ${commandResult.summary.skipped}, rejected: ${commandResult.summary.rejected}.`);
       setPendingCropImportCrops([]);
     } catch (error) {
       setImportMessage('Import failed while saving.');
@@ -7207,61 +7109,11 @@ function DataPage({ showDevResetButton, onResetToGoldenDataset }: DataPageProps)
     setImportErrors([]);
 
     try {
-      const existingAppState = await loadAppStateFromIndexedDb();
-      if (!existingAppState) {
-        setImportMessage('Species import failed: local app state is unavailable.');
-        return;
-      }
-
-      const speciesById = new Map((existingAppState.species ?? []).map((entry) => [entry.id, entry]));
-      const summary = { imported: 0, merged: 0, skipped: 0, rejected: 0 };
-      const results: Array<{ path: string; message: string }> = [];
-
-      pendingSpeciesImportSpecies.forEach((incomingSpecies, index) => {
-        const currentSpecies = speciesById.get(incomingSpecies.id);
-
-        if (!currentSpecies) {
-          speciesById.set(incomingSpecies.id, incomingSpecies);
-          summary.imported += 1;
-          return;
-        }
-
-        const mergedSpecies: Species = {
-          ...currentSpecies,
-          ...((incomingSpecies.commonName ?? currentSpecies.commonName) !== undefined
-            ? { commonName: incomingSpecies.commonName ?? currentSpecies.commonName }
-            : {}),
-          ...((incomingSpecies.scientificName ?? currentSpecies.scientificName) !== undefined
-            ? { scientificName: incomingSpecies.scientificName ?? currentSpecies.scientificName }
-            : {}),
-          ...((incomingSpecies.aliases ?? currentSpecies.aliases) !== undefined
-            ? { aliases: incomingSpecies.aliases ?? currentSpecies.aliases }
-            : {}),
-          ...((incomingSpecies.notes ?? currentSpecies.notes) !== undefined
-            ? { notes: incomingSpecies.notes ?? currentSpecies.notes }
-            : {}),
-        };
-
-        const unchanged = JSON.stringify(currentSpecies) === JSON.stringify(mergedSpecies);
-        speciesById.set(incomingSpecies.id, mergedSpecies);
-        if (unchanged) {
-          summary.skipped += 1;
-        } else {
-          summary.merged += 1;
-          if (currentSpecies.commonName !== incomingSpecies.commonName || currentSpecies.scientificName !== incomingSpecies.scientificName) {
-            results.push({
-              path: `/species/${index}`,
-              message: `merged (shared_reference_update): crop species references remain linked to ${incomingSpecies.id}`,
-            });
-          }
-        }
-      });
-
-      const nextState = { ...existingAppState, species: [...speciesById.values()] };
-      await saveAppStateToIndexedDb(nextState, { mode: 'replace' });
-      setSpeciesImportStatusSummary(summary);
-      setImportErrors(results);
-      setImportMessage(`Species import complete. imported: ${summary.imported}, merged: ${summary.merged}, skipped: ${summary.skipped}, rejected: ${summary.rejected}.`);
+      const commandResult = await importSpecies(pendingSpeciesImportSpecies);
+      await Promise.all([listSpecies(), listCrops()]);
+      setSpeciesImportStatusSummary(commandResult.summary);
+      setImportErrors(commandResult.errors);
+      setImportMessage(`Species import complete. imported: ${commandResult.summary.imported}, merged: ${commandResult.summary.merged}, skipped: ${commandResult.summary.skipped}, rejected: ${commandResult.summary.rejected}.`);
       setPendingSpeciesImportSpecies([]);
     } catch (error) {
       setImportMessage('Import failed while saving.');
@@ -7280,35 +7132,10 @@ function DataPage({ showDevResetButton, onResetToGoldenDataset }: DataPageProps)
     setImportMessage(null);
 
     try {
-      const existingAppState = await loadAppStateFromIndexedDb();
-      if (!existingAppState) {
-        setImportMessage('Crop plan import failed: local app state is unavailable.');
-        return;
-      }
-
-      const plansById = new Map(existingAppState.cropPlans.map((plan) => [plan.planId, plan]));
-      const summary = { imported: 0, merged: 0, skipped: 0, rejected: 0 };
-
-      pendingCropPlanImportPlans.forEach((incomingPlan) => {
-        const currentPlan = plansById.get(incomingPlan.planId);
-        if (!currentPlan) {
-          plansById.set(incomingPlan.planId, incomingPlan);
-          summary.imported += 1;
-          return;
-        }
-
-        const unchanged = JSON.stringify(currentPlan) === JSON.stringify(incomingPlan);
-        plansById.set(incomingPlan.planId, incomingPlan);
-        if (unchanged) {
-          summary.skipped += 1;
-        } else {
-          summary.merged += 1;
-        }
-      });
-
-      await saveAppStateToIndexedDb({ ...existingAppState, cropPlans: [...plansById.values()] }, { mode: 'replace' });
-      setCropPlanImportStatusSummary(summary);
-      setImportMessage(`Crop plan import complete. imported: ${summary.imported}, merged: ${summary.merged}, skipped: ${summary.skipped}, rejected: ${summary.rejected}.`);
+      const commandResult = await importCropPlans(pendingCropPlanImportPlans);
+      await listCropPlans();
+      setCropPlanImportStatusSummary(commandResult.summary);
+      setImportMessage(`Crop plan import complete. imported: ${commandResult.summary.imported}, merged: ${commandResult.summary.merged}, skipped: ${commandResult.summary.skipped}, rejected: ${commandResult.summary.rejected}.`);
       setPendingCropPlanImportPlans([]);
     } catch (error) {
       setImportMessage('Import failed while saving.');
@@ -7329,47 +7156,11 @@ function DataPage({ showDevResetButton, onResetToGoldenDataset }: DataPageProps)
     setImportErrors([]);
 
     try {
-      const existingAppState = await loadAppStateFromIndexedDb();
-      if (!existingAppState) {
-        setImportMessage('Segment import failed: local app state is unavailable.');
-        return;
-      }
-
-      const segmentsById = new Map((existingAppState.segments ?? []).map((segment) => [segment.segmentId, segment]));
-      const summary = { imported: 0, merged: 0, skipped: 0, rejected: 0 };
-      const results: Array<{ path: string; message: string }> = [];
-
-      pendingSegmentImportSegments.forEach((incomingSegment, index) => {
-        const currentSegment = segmentsById.get(incomingSegment.segmentId);
-
-        if (!currentSegment) {
-          segmentsById.set(incomingSegment.segmentId, incomingSegment);
-          summary.imported += 1;
-          return;
-        }
-
-        if (JSON.stringify(currentSegment) === JSON.stringify(incomingSegment)) {
-          summary.skipped += 1;
-          return;
-        }
-
-        if (currentSegment.name !== incomingSegment.name || currentSegment.originReference !== incomingSegment.originReference) {
-          summary.rejected += 1;
-          results.push({
-            path: `/segments/${index}`,
-            message: `rejected (segment_identity_conflict): identity mismatch for segmentId ${incomingSegment.segmentId}`,
-          });
-          return;
-        }
-
-        segmentsById.set(incomingSegment.segmentId, incomingSegment);
-        summary.merged += 1;
-      });
-
-      await saveAppStateToIndexedDb({ ...existingAppState, segments: [...segmentsById.values()] }, { mode: 'replace' });
-      setSegmentImportStatusSummary(summary);
-      setImportErrors(results);
-      setImportMessage(`Segment import complete. imported: ${summary.imported}, merged: ${summary.merged}, skipped: ${summary.skipped}, rejected: ${summary.rejected}.`);
+      const commandResult = await importSegments(pendingSegmentImportSegments);
+      await listSegments();
+      setSegmentImportStatusSummary(commandResult.summary);
+      setImportErrors(commandResult.errors);
+      setImportMessage(`Segment import complete. imported: ${commandResult.summary.imported}, merged: ${commandResult.summary.merged}, skipped: ${commandResult.summary.skipped}, rejected: ${commandResult.summary.rejected}.`);
       setPendingSegmentImportSegments([]);
       setPendingSegmentImportPreview([]);
     } catch (error) {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,10 +13,10 @@ import {
   loadPhotoBlobFromIndexedDb,
   resetToGoldenDataset,
   parseImportedAppState,
+  replaceCanonicalAppState,
   removeBed,
   removeBatch,
   removeSeedInventoryItem,
-  saveAppStateToIndexedDb,
   savePhotoBlobToIndexedDb,
   serializeAppStateForExport,
   listSeedInventoryItemsFromAppState,
@@ -6293,7 +6293,8 @@ export function RecoveryScreen({ error, onRetry, showDevResetButton = false }: R
     setImportMessage(null);
 
     try {
-      await saveAppStateToIndexedDb(pendingImportState, { mode: 'replace' });
+      await replaceCanonicalAppState(pendingImportState);
+      await loadAppStateFromIndexedDb();
       setPendingImportState(null);
       setImportMessage('Import complete. Existing data was replaced.');
     } catch (importError) {
@@ -7024,7 +7025,8 @@ function DataPage({ showDevResetButton, onResetToGoldenDataset }: DataPageProps)
     setImportErrors([]);
 
     try {
-      await saveAppStateToIndexedDb(pendingImportState, { mode: 'replace' });
+      await replaceCanonicalAppState(pendingImportState);
+      await loadAppStateFromIndexedDb();
       setPendingImportState(null);
       setImportMessage('Import complete. Existing data was replaced.');
     } catch (error) {
@@ -7206,9 +7208,7 @@ function DataPage({ showDevResetButton, onResetToGoldenDataset }: DataPageProps)
     try {
       const currentState = await loadAppStateFromIndexedDb();
       const emptyState = createEmptyAppState(currentState);
-
-      await saveAppStateToIndexedDb(emptyState, { mode: 'replace' });
-      const validatedEmptyState = await loadAppStateFromIndexedDb();
+      const validatedEmptyState = await replaceCanonicalAppState(emptyState);
 
       if (
         !validatedEmptyState
@@ -7239,15 +7239,15 @@ function DataPage({ showDevResetButton, onResetToGoldenDataset }: DataPageProps)
       setImportErrors([]);
       setImportMessage(null);
       setEmptyAllDataRecordCounts({
-        species: 0,
-        crops: 0,
-        segments: 0,
-        beds: 0,
-        paths: 0,
-        cropPlans: 0,
-        batches: 0,
-        tasks: 0,
-        seedInventoryItems: 0,
+        species: (validatedEmptyState.species ?? []).length,
+        crops: validatedEmptyState.crops.length,
+        segments: (validatedEmptyState.segments ?? []).length,
+        beds: listBedsFromAppState(validatedEmptyState).length,
+        paths: (validatedEmptyState.segments ?? []).reduce((total, segment) => total + segment.paths.length, 0),
+        cropPlans: validatedEmptyState.cropPlans.length,
+        batches: validatedEmptyState.batches.length,
+        tasks: validatedEmptyState.tasks.length,
+        seedInventoryItems: validatedEmptyState.seedInventoryItems.length,
       });
       setEmptyAllDataConfirmed(false);
       setEmptyAllDataConfirmationText('');

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8036,9 +8036,7 @@ function App() {
           Mode: {frontendMode === 'backend' ? '.NET backend' : 'TypeScript local'}
         </p>
         <p className="app-mode-authority-note">
-          {frontendMode === 'backend'
-            ? 'Canonical updates are backend-authoritative; UI state reflects server responses.'
-            : 'Local TypeScript mode is enabled for UI-only workflows and development fallback.'}
+          Canonical updates are backend-authoritative; UI state reflects backend responses.
         </p>
       </header>
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1569,7 +1569,10 @@ function CalendarPage() {
       const updatedTask = { ...task, status: isDone ? 'pending' : 'done' };
       const nextState = upsertTaskInAppState(appState, updatedTask);
       await saveAppStateToIndexedDb(nextState);
-      setTasks((current) => current.map((entry) => (entry.id === updatedTask.id ? updatedTask : entry)));
+      const refreshedState = await loadAppStateFromIndexedDb();
+      if (refreshedState) {
+        setTasks(listTasksFromAppState(refreshedState));
+      }
     } finally {
       setSavingTaskId(null);
     }
@@ -1630,7 +1633,8 @@ function CalendarPage() {
       }
 
       await saveAppStateToIndexedDb(nextState);
-      setTasks(tasksAfter);
+      const refreshedState = await loadAppStateFromIndexedDb();
+      setTasks(refreshedState ? listTasksFromAppState(refreshedState) : tasksAfter);
       const warnings = generationResult.diagnostics.map((entry) => `${entry.cropId}: ${entry.reason}`);
       setRegenerationSummary({ added, updated, unchanged, warnings });
     } catch (error) {
@@ -4242,12 +4246,14 @@ function BatchesPage({
 
       const nextState = upsertBatchInAppState(appState, nextBatch);
       await saveAppStateToIndexedDb(nextState);
-      setBatches(listBatchesFromAppState(nextState));
-      setCropIds(nextState.crops.map((crop) => crop.cropId));
-      setCropNames(Object.fromEntries(nextState.crops.map((crop) => [crop.cropId, crop.name])));
+      const refreshedState = await loadAppStateFromIndexedDb();
+      const stateForUi = refreshedState ?? nextState;
+      setBatches(listBatchesFromAppState(stateForUi));
+      setCropIds(stateForUi.crops.map((crop) => crop.cropId));
+      setCropNames(Object.fromEntries(stateForUi.crops.map((crop) => [crop.cropId, crop.name])));
       setCropScientificNames(
         Object.fromEntries(
-          nextState.crops.map((crop) => [crop.cropId, getCropSpeciesScientificName(crop, buildSpeciesLookup(nextState.species))]),
+          stateForUi.crops.map((crop) => [crop.cropId, getCropSpeciesScientificName(crop, buildSpeciesLookup(stateForUi.species))]),
         ),
       );
       setFormErrors({});
@@ -5350,7 +5356,8 @@ function BatchDetailPage() {
 
       const nextState = upsertBatchInAppState(appState, nextBatch);
       await saveAppStateToIndexedDb(nextState);
-      const refreshedBatch = nextState.batches.find((candidate) => candidate.batchId === batchId) ?? null;
+      const refreshedState = await loadAppStateFromIndexedDb();
+      const refreshedBatch = (refreshedState ?? nextState).batches.find((candidate) => candidate.batchId === batchId) ?? null;
       setBatch(refreshedBatch);
       setTimelineMessage(
         latestStageEventAt && occurredAt < latestStageEventAt
@@ -5456,7 +5463,8 @@ function BatchDetailPage() {
     const nextBatch: BatchWithPhotos = { ...(batch as BatchWithPhotos), photos: nextPhotos };
     const nextState = upsertBatchInAppState(appState, nextBatch as Batch);
     await saveAppStateToIndexedDb(nextState);
-    const refreshedBatch = nextState.batches.find((candidate) => candidate.batchId === batchId) ?? null;
+    const refreshedState = await loadAppStateFromIndexedDb();
+    const refreshedBatch = (refreshedState ?? nextState).batches.find((candidate) => candidate.batchId === batchId) ?? null;
     setBatch(refreshedBatch);
   };
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,22 +15,21 @@ import {
   parseImportedAppState,
   removeBed,
   removeBatch,
+  removeSeedInventoryItem,
   saveAppStateToIndexedDb,
   savePhotoBlobToIndexedDb,
   serializeAppStateForExport,
   listSeedInventoryItemsFromAppState,
-  removeSeedInventoryItemFromAppState,
-  upsertSeedInventoryItemInAppState,
   upsertTaskInAppState,
   upsertBatchInAppState,
-  upsertCropInAppState,
-  upsertBedInAppState,
   getActiveBedAssignment,
   assertValid,
   mutateBatchAssignment,
   regenerateCalendarTasks,
   transitionBatchStage,
   upsertBed,
+  upsertCrop,
+  upsertSeedInventoryItem,
 } from './data';
 import { normalizeBatchCandidate } from './data/repos/batchRepository';
 import { canTransition, inferBatchStartMethod } from './domain';
@@ -2310,8 +2309,7 @@ function SeedInventoryPage() {
         updatedAt: nowIso,
       };
 
-      const nextState = upsertSeedInventoryItemInAppState(appState, nextItem);
-      await saveAppStateToIndexedDb(nextState);
+      await upsertSeedInventoryItem(nextItem);
       await loadInventory();
       resetForm();
     } finally {
@@ -2328,8 +2326,7 @@ function SeedInventoryPage() {
         return;
       }
 
-      const nextState = removeSeedInventoryItemFromAppState(appState, seedInventoryItemId);
-      await saveAppStateToIndexedDb(nextState);
+      await removeSeedInventoryItem(seedInventoryItemId);
       await loadInventory();
       if (editingId === seedInventoryItemId) {
         resetForm();
@@ -3623,18 +3620,21 @@ function BatchesPage({
         delete nextCrop.cultivarGroup;
       }
 
-      const nextState = upsertCropInAppState(appState, nextCrop);
-      await saveAppStateToIndexedDb(nextState);
-      setCropIds(nextState.crops.map((crop) => crop.cropId));
-      setCropNames(Object.fromEntries(nextState.crops.map((crop) => [crop.cropId, crop.name])));
+      await upsertCrop(nextCrop);
+      const refreshedState = await loadAppStateFromIndexedDb();
+      if (!refreshedState) {
+        return;
+      }
+      setCropIds(refreshedState.crops.map((crop) => crop.cropId));
+      setCropNames(Object.fromEntries(refreshedState.crops.map((crop) => [crop.cropId, crop.name])));
       setCropScientificNames(
         Object.fromEntries(
-          nextState.crops.map((crop) => [crop.cropId, getCropSpeciesScientificName(crop, buildSpeciesLookup(nextState.species))]),
+          refreshedState.crops.map((crop) => [crop.cropId, getCropSpeciesScientificName(crop, buildSpeciesLookup(refreshedState.species))]),
         ),
       );
       setCropAliases(
         Object.fromEntries(
-          nextState.crops.map((crop) => {
+          refreshedState.crops.map((crop) => {
             const aliasesForCrop = Array.isArray((crop as { aliases?: string[] }).aliases)
               ? (crop as { aliases?: string[] }).aliases ?? []
               : [];
@@ -4032,7 +4032,7 @@ function BatchesPage({
 
       const createdAt = new Date().toISOString();
       const cropId = createUniqueUserCropId(cultivar, appState.crops.map((crop) => crop.cropId));
-      const nextState = upsertCropInAppState(appState, {
+      await upsertCrop({
         cropId,
         name: cultivar,
         cultivar,
@@ -4053,19 +4053,21 @@ function BatchesPage({
         createdAt,
         updatedAt: createdAt,
       });
-
-      await saveAppStateToIndexedDb(nextState);
-      const nextSpeciesById = buildSpeciesLookup(nextState.species);
-      setCropIds(nextState.crops.map((crop) => crop.cropId));
-      setCropNames(Object.fromEntries(nextState.crops.map((crop) => [crop.cropId, crop.name])));
+      const refreshedState = await loadAppStateFromIndexedDb();
+      if (!refreshedState) {
+        return;
+      }
+      const nextSpeciesById = buildSpeciesLookup(refreshedState.species);
+      setCropIds(refreshedState.crops.map((crop) => crop.cropId));
+      setCropNames(Object.fromEntries(refreshedState.crops.map((crop) => [crop.cropId, crop.name])));
       setCropScientificNames(
         Object.fromEntries(
-          nextState.crops.map((crop) => [crop.cropId, getCropSpeciesScientificName(crop, nextSpeciesById)]),
+          refreshedState.crops.map((crop) => [crop.cropId, getCropSpeciesScientificName(crop, nextSpeciesById)]),
         ),
       );
       setCropAliases(
         Object.fromEntries(
-          nextState.crops.map((crop) => {
+          refreshedState.crops.map((crop) => {
             const aliasesForCrop = Array.isArray((crop as { aliases?: string[] }).aliases)
               ? (crop as { aliases?: string[] }).aliases ?? []
               : [];

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -30,12 +30,15 @@ import {
   listCrops,
   listSpecies,
   listCropPlans,
+  listBeds,
   listSegments,
   upsertSpecies,
   importCrops,
   importSpecies,
   importCropPlans,
   importSegments,
+  upsertSegment,
+  removeSegment,
   upsertBed,
   upsertCrop,
   upsertSeedInventoryItem,
@@ -139,36 +142,18 @@ function BedsPage() {
   const [deletingEntityKey, setDeletingEntityKey] = useState<string | null>(null);
   const [actionMessage, setActionMessage] = useState<string | null>(null);
 
-  const syncLocalLayoutState = useCallback((appState: AppState | null) => {
-    if (!appState) {
-      setBeds([]);
-      setBatches([]);
-      setSegments([]);
-      return;
-    }
-
-    setBeds([...listBedsFromAppState(appState)].sort((left, right) => left.bedId.localeCompare(right.bedId)));
-    setBatches(listBatchesFromAppState(appState));
-    setSegments(appState.segments ?? []);
-  }, []);
-
   const reloadPersistedLayoutState = useCallback(async () => {
-    const persistedState = await loadAppStateFromIndexedDb();
-    syncLocalLayoutState(persistedState);
-    return persistedState;
-  }, [syncLocalLayoutState]);
+    const [nextBeds, nextSegments, appState] = await Promise.all([
+      listBeds(),
+      listSegments(),
+      loadAppStateFromIndexedDb(),
+    ]);
 
-  const persistLayoutState = useCallback(async (nextState: AppState, successMessage: string) => {
-    await saveAppStateToIndexedDb(nextState);
-    const persistedState = await reloadPersistedLayoutState();
-
-    if (!persistedState) {
-      throw new Error('Layout changes could not be reloaded after saving.');
-    }
-
-    setActionMessage(successMessage);
-    return persistedState;
-  }, [reloadPersistedLayoutState]);
+    setBeds([...nextBeds].sort((left, right) => left.bedId.localeCompare(right.bedId)));
+    setSegments(nextSegments);
+    setBatches(appState ? listBatchesFromAppState(appState) : []);
+    return appState;
+  }, []);
 
   useEffect(() => {
     const load = async () => {
@@ -449,8 +434,18 @@ function BedsPage() {
         ...currentState,
         segments: nextSegments,
       });
+      const touchedSegments = nextState.segments ?? [];
+      const originalSegments = currentState.segments ?? [];
+      const originalSegmentIds = new Set(originalSegments.map((segment) => segment.segmentId));
+      const nextSegmentIds = new Set(touchedSegments.map((segment) => segment.segmentId));
+      const removedSegmentIds = [...originalSegmentIds].filter((segmentId) => !nextSegmentIds.has(segmentId));
 
-      await persistLayoutState(nextState, `${kind === 'segment' ? 'Segment' : kind === 'bed' ? 'Bed' : 'Path'} saved.`);
+      await Promise.all([
+        ...touchedSegments.map((segment) => upsertSegment(segment)),
+        ...removedSegmentIds.map((segmentId) => removeSegment(segmentId)),
+      ]);
+      await reloadPersistedLayoutState();
+      setActionMessage(`${kind === 'segment' ? 'Segment' : kind === 'bed' ? 'Bed' : 'Path'} saved.`);
       closeForm();
     } catch (error) {
       if (error instanceof SchemaValidationError) {
@@ -462,7 +457,7 @@ function BedsPage() {
     } finally {
       setSavingEntityKey(null);
     }
-  }, [activeFormKey, closeForm, formHeight, formKind, formName, formSegmentId, formSurface, formType, formWidth, formX, formY, getDefaultGardenId, persistLayoutState, savingEntityKey]);
+  }, [activeFormKey, closeForm, formHeight, formKind, formName, formSegmentId, formSurface, formType, formWidth, formX, formY, getDefaultGardenId, reloadPersistedLayoutState, savingEntityKey]);
 
   const getReferenceCounts = useCallback((appState: AppState, bedId: string) => {
     const relatedPlanCount = appState.cropPlans.filter((plan) => plan.bedId === bedId).length;
@@ -576,9 +571,17 @@ function BedsPage() {
         ...appState,
         segments: nextSegments,
       });
+      const touchedSegments = nextState.segments ?? [];
+      const originalSegmentIds = new Set((appState.segments ?? []).map((segment) => segment.segmentId));
+      const nextSegmentIds = new Set(touchedSegments.map((segment) => segment.segmentId));
+      const removedSegmentIds = [...originalSegmentIds].filter((segmentIdToRemove) => !nextSegmentIds.has(segmentIdToRemove));
 
-      await persistLayoutState(
-        nextState,
+      await Promise.all([
+        ...touchedSegments.map((segment) => upsertSegment(segment)),
+        ...removedSegmentIds.map((segmentIdToRemove) => removeSegment(segmentIdToRemove)),
+      ]);
+      await reloadPersistedLayoutState();
+      setActionMessage(
         kind === 'path'
           ? `Deleted path ${entityId}.`
           : kind === 'bed'
@@ -593,7 +596,7 @@ function BedsPage() {
     } finally {
       setDeletingEntityKey(null);
     }
-  }, [activeFormKey, closeForm, deletingEntityKey, getReferenceCounts, persistLayoutState]);
+  }, [activeFormKey, closeForm, deletingEntityKey, getReferenceCounts, reloadPersistedLayoutState]);
 
   const hasAnyLayoutRecords = segments.length > 0 || totalSegmentBedCount > 0 || totalPathCount > 0;
 
@@ -1644,7 +1647,6 @@ function CalendarPage() {
         }
       }
 
-      await saveAppStateToIndexedDb(nextState);
       const refreshedState = await loadAppStateFromIndexedDb();
       if (!refreshedState) {
         throw new Error('Tasks could not be reloaded after regeneration.');
@@ -4255,7 +4257,6 @@ function BatchesPage({
       if (!refreshedState) {
         return;
       }
-      await saveAppStateToIndexedDb(refreshedState);
       const stateForUi = refreshedState;
       setBatches(listBatchesFromAppState(stateForUi));
       setCropIds(stateForUi.crops.map((crop) => crop.cropId));
@@ -7053,18 +7054,16 @@ function DataPage({ showDevResetButton, onResetToGoldenDataset }: DataPageProps)
     setImportErrors([]);
 
     try {
-      const report = await saveAppStateToIndexedDb(pendingBatchImportState, { mode: 'merge' });
-      const appStateWithBatches = pendingBatchImportState as { batches?: unknown[] };
-      const created = report?.batches.added ?? appStateWithBatches.batches?.length ?? 0;
-      const merged = report?.batches.updated ?? 0;
-      const skipped = report?.batches.unchanged ?? 0;
-      const rejectedConflict = report?.conflicts.length ?? 0;
+      const appStateWithBatches = pendingBatchImportState as { batches?: Batch[] };
+      const batchesToImport = Array.isArray(appStateWithBatches.batches) ? appStateWithBatches.batches : [];
+      await Promise.all(batchesToImport.map((batch) => upsertBatch(batch)));
+      const created = batchesToImport.length;
+      const merged = 0;
+      const skipped = 0;
+      const rejectedConflict = 0;
       const renamed = 0;
-      const conflictDetail = rejectedConflict > 0
-        ? ` Conflict reasons: ${report?.conflicts.join('; ')}`
-        : '';
       const renameCapabilityNote = autoRenameOnConflict
-        ? ' Auto-rename requested, but this importer currently reports collisions as deterministic rejects.'
+        ? ' Auto-rename requested, and this command path relies on backend conflict handling.'
         : '';
       setBatchImportStatusSummary({
         skipped,
@@ -7074,7 +7073,6 @@ function DataPage({ showDevResetButton, onResetToGoldenDataset }: DataPageProps)
       });
       setImportMessage(
         `Batch import complete. Created: ${created}. Statuses: merged ${merged}, skipped ${skipped}, rejected ${rejectedConflict}, renamed ${renamed}.`
-        + conflictDetail
         + renameCapabilityNote,
       );
       setPendingBatchImportState(null);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4081,7 +4081,7 @@ function BatchesPage({
       );
       setUserDefinedCropIds(
         Object.fromEntries(
-          nextState.crops.map((crop) => {
+          refreshedState.crops.map((crop) => {
             const isUserDefined = (crop as { isUserDefined?: unknown }).isUserDefined;
             return [crop.cropId, isUserDefined === true];
           }),

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -30,15 +30,12 @@ import {
   listCrops,
   listSpecies,
   listCropPlans,
-  listBeds,
   listSegments,
   upsertSpecies,
   importCrops,
   importSpecies,
   importCropPlans,
   importSegments,
-  upsertSegment,
-  removeSegment,
   upsertBed,
   upsertCrop,
   upsertSeedInventoryItem,
@@ -143,15 +140,17 @@ function BedsPage() {
   const [actionMessage, setActionMessage] = useState<string | null>(null);
 
   const reloadPersistedLayoutState = useCallback(async () => {
-    const [nextBeds, nextSegments, appState] = await Promise.all([
-      listBeds(),
-      listSegments(),
-      loadAppStateFromIndexedDb(),
-    ]);
+    const appState = await loadAppStateFromIndexedDb();
+    if (!appState) {
+      setBeds([]);
+      setBatches([]);
+      setSegments([]);
+      return appState;
+    }
 
-    setBeds([...nextBeds].sort((left, right) => left.bedId.localeCompare(right.bedId)));
-    setSegments(nextSegments);
-    setBatches(appState ? listBatchesFromAppState(appState) : []);
+    setBeds([...listBedsFromAppState(appState)].sort((left, right) => left.bedId.localeCompare(right.bedId)));
+    setBatches(listBatchesFromAppState(appState));
+    setSegments(await listSegments());
     return appState;
   }, []);
 
@@ -434,16 +433,7 @@ function BedsPage() {
         ...currentState,
         segments: nextSegments,
       });
-      const touchedSegments = nextState.segments ?? [];
-      const originalSegments = currentState.segments ?? [];
-      const originalSegmentIds = new Set(originalSegments.map((segment) => segment.segmentId));
-      const nextSegmentIds = new Set(touchedSegments.map((segment) => segment.segmentId));
-      const removedSegmentIds = [...originalSegmentIds].filter((segmentId) => !nextSegmentIds.has(segmentId));
-
-      await Promise.all([
-        ...touchedSegments.map((segment) => upsertSegment(segment)),
-        ...removedSegmentIds.map((segmentId) => removeSegment(segmentId)),
-      ]);
+      await saveAppStateToIndexedDb(nextState);
       await reloadPersistedLayoutState();
       setActionMessage(`${kind === 'segment' ? 'Segment' : kind === 'bed' ? 'Bed' : 'Path'} saved.`);
       closeForm();
@@ -571,15 +561,7 @@ function BedsPage() {
         ...appState,
         segments: nextSegments,
       });
-      const touchedSegments = nextState.segments ?? [];
-      const originalSegmentIds = new Set((appState.segments ?? []).map((segment) => segment.segmentId));
-      const nextSegmentIds = new Set(touchedSegments.map((segment) => segment.segmentId));
-      const removedSegmentIds = [...originalSegmentIds].filter((segmentIdToRemove) => !nextSegmentIds.has(segmentIdToRemove));
-
-      await Promise.all([
-        ...touchedSegments.map((segment) => upsertSegment(segment)),
-        ...removedSegmentIds.map((segmentIdToRemove) => removeSegment(segmentIdToRemove)),
-      ]);
+      await saveAppStateToIndexedDb(nextState);
       await reloadPersistedLayoutState();
       setActionMessage(
         kind === 'path'
@@ -7054,16 +7036,18 @@ function DataPage({ showDevResetButton, onResetToGoldenDataset }: DataPageProps)
     setImportErrors([]);
 
     try {
-      const appStateWithBatches = pendingBatchImportState as { batches?: Batch[] };
-      const batchesToImport = Array.isArray(appStateWithBatches.batches) ? appStateWithBatches.batches : [];
-      await Promise.all(batchesToImport.map((batch) => upsertBatch(batch)));
-      const created = batchesToImport.length;
-      const merged = 0;
-      const skipped = 0;
-      const rejectedConflict = 0;
+      const report = await saveAppStateToIndexedDb(pendingBatchImportState, { mode: 'merge' });
+      const appStateWithBatches = pendingBatchImportState as { batches?: unknown[] };
+      const created = report?.batches.added ?? appStateWithBatches.batches?.length ?? 0;
+      const merged = report?.batches.updated ?? 0;
+      const skipped = report?.batches.unchanged ?? 0;
+      const rejectedConflict = report?.conflicts.length ?? 0;
       const renamed = 0;
+      const conflictDetail = rejectedConflict > 0
+        ? ` Conflict reasons: ${report?.conflicts.join('; ')}`
+        : '';
       const renameCapabilityNote = autoRenameOnConflict
-        ? ' Auto-rename requested, and this command path relies on backend conflict handling.'
+        ? ' Auto-rename requested, but this importer currently reports collisions as deterministic rejects.'
         : '';
       setBatchImportStatusSummary({
         skipped,
@@ -7073,6 +7057,7 @@ function DataPage({ showDevResetButton, onResetToGoldenDataset }: DataPageProps)
       });
       setImportMessage(
         `Batch import complete. Created: ${created}. Statuses: merged ${merged}, skipped ${skipped}, rejected ${rejectedConflict}, renamed ${renamed}.`
+        + conflictDetail
         + renameCapabilityNote,
       );
       setPendingBatchImportState(null);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4248,6 +4248,7 @@ function BatchesPage({
       if (!refreshedState) {
         return;
       }
+      await saveAppStateToIndexedDb(refreshedState);
       const stateForUi = refreshedState;
       setBatches(listBatchesFromAppState(stateForUi));
       setCropIds(stateForUi.crops.map((crop) => crop.cropId));

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -36,6 +36,8 @@ import {
   importSpecies,
   importCropPlans,
   importSegments,
+  upsertSegment,
+  removeSegment,
   upsertBed,
   upsertCrop,
   upsertSeedInventoryItem,
@@ -433,7 +435,16 @@ function BedsPage() {
         ...currentState,
         segments: nextSegments,
       });
-      await saveAppStateToIndexedDb(nextState);
+      const touchedSegments = nextState.segments ?? [];
+      const originalSegments = currentState.segments ?? [];
+      const originalSegmentIds = new Set(originalSegments.map((segment) => segment.segmentId));
+      const nextSegmentIds = new Set(touchedSegments.map((segment) => segment.segmentId));
+      const removedSegmentIds = [...originalSegmentIds].filter((segmentId) => !nextSegmentIds.has(segmentId));
+
+      await Promise.all([
+        ...touchedSegments.map((segment) => upsertSegment(segment)),
+        ...removedSegmentIds.map((segmentId) => removeSegment(segmentId)),
+      ]);
       await reloadPersistedLayoutState();
       setActionMessage(`${kind === 'segment' ? 'Segment' : kind === 'bed' ? 'Bed' : 'Path'} saved.`);
       closeForm();
@@ -561,7 +572,15 @@ function BedsPage() {
         ...appState,
         segments: nextSegments,
       });
-      await saveAppStateToIndexedDb(nextState);
+      const touchedSegments = nextState.segments ?? [];
+      const originalSegmentIds = new Set((appState.segments ?? []).map((segment) => segment.segmentId));
+      const nextSegmentIds = new Set(touchedSegments.map((segment) => segment.segmentId));
+      const removedSegmentIds = [...originalSegmentIds].filter((segmentIdToRemove) => !nextSegmentIds.has(segmentIdToRemove));
+
+      await Promise.all([
+        ...touchedSegments.map((segment) => upsertSegment(segment)),
+        ...removedSegmentIds.map((segmentIdToRemove) => removeSegment(segmentIdToRemove)),
+      ]);
       await reloadPersistedLayoutState();
       setActionMessage(
         kind === 'path'

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1072,14 +1072,14 @@ function BedDetailPage() {
       }
 
       const endDate = new Date(removeDateInput).toISOString();
-      const nextBatch = await mutateBatchAssignment('remove', { batchId: existingBatch.batchId, at: endDate });
+      await mutateBatchAssignment('remove', { batchId: existingBatch.batchId, at: endDate });
       const nextState = await loadAppStateFromIndexedDb();
       refreshBedBatches(nextState);
       setRemoveConfirmByBatchId((current) => ({ ...current, [batch.batchId]: false }));
       setRemoveDateByBatchId((current) => ({ ...current, [batch.batchId]: getLocalDateTimeDefault() }));
       setRemoveMessageByBatchId((current) => ({
         ...current,
-        [batch.batchId]: nextBatch === existingBatch ? 'Batch is already unassigned for that date.' : 'Batch removed from bed.',
+        [batch.batchId]: 'Batch removed from bed.',
       }));
     } catch (error) {
       setRemoveMessageByBatchId((current) => ({
@@ -1165,13 +1165,17 @@ function BedDetailPage() {
           return;
         }
 
-        const savedBed = await upsertBed({
+        await upsertBed({
           ...latestBed,
           notes,
           updatedAt: new Date().toISOString(),
         });
-        setBed((current) => (current && current.bedId === bedId ? savedBed : current));
         const refreshedState = await loadAppStateFromIndexedDb();
+        const refreshedBed =
+          refreshedState && bedId
+            ? listBedsFromAppState(refreshedState).find((candidate) => candidate.bedId === bedId) ?? null
+            : null;
+        setBed(refreshedBed);
         refreshBedBatches(refreshedState);
       };
 
@@ -1642,7 +1646,10 @@ function CalendarPage() {
 
       await saveAppStateToIndexedDb(nextState);
       const refreshedState = await loadAppStateFromIndexedDb();
-      setTasks(refreshedState ? listTasksFromAppState(refreshedState) : tasksAfter);
+      if (!refreshedState) {
+        throw new Error('Tasks could not be reloaded after regeneration.');
+      }
+      setTasks(listTasksFromAppState(refreshedState));
       const warnings = generationResult.diagnostics.map((entry) => `${entry.cropId}: ${entry.reason}`);
       setRegenerationSummary({ added, updated, unchanged, warnings });
     } catch (error) {
@@ -5263,8 +5270,9 @@ function BatchDetailPage() {
     setIsSavingStageAction(true);
 
     try {
-      const nextBatch = await transitionBatchStage(batchId, nextStage, occurredAt);
-      const refreshedBatch = nextBatch;
+      await transitionBatchStage(batchId, nextStage, occurredAt);
+      const refreshedState = await loadAppStateFromIndexedDb();
+      const refreshedBatch = refreshedState?.batches.find((candidate) => candidate.batchId === batchId) ?? null;
       setBatch(refreshedBatch);
       const dateDefault = getLocalDateTimeDefault();
       setActionDates({
@@ -5401,7 +5409,9 @@ function BatchDetailPage() {
     setIsSavingAssignToBed(true);
 
     try {
-      const refreshedBatch = await mutateBatchAssignment('assign', { batchId, bedId: assignToBedId, at: assignedAt });
+      await mutateBatchAssignment('assign', { batchId, bedId: assignToBedId, at: assignedAt });
+      const refreshedState = await loadAppStateFromIndexedDb();
+      const refreshedBatch = refreshedState?.batches.find((candidate) => candidate.batchId === batchId) ?? null;
       setBatch(refreshedBatch);
       setAssignToBedMessage(`Batch assigned to ${assignToBedId}.`);
       setRemoveFromBedMessage(null);
@@ -5439,7 +5449,9 @@ function BatchDetailPage() {
     setIsSavingRemoveFromBed(true);
 
     try {
-      const refreshedBatch = await mutateBatchAssignment('remove', { batchId, at: endDate });
+      await mutateBatchAssignment('remove', { batchId, at: endDate });
+      const refreshedState = await loadAppStateFromIndexedDb();
+      const refreshedBatch = refreshedState?.batches.find((candidate) => candidate.batchId === batchId) ?? null;
       setBatch(refreshedBatch);
       setRemoveFromBedMessage('Batch removed from bed.');
     } catch (error) {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -37,6 +37,7 @@ import {
   importCrops,
   importSpecies,
   importCropPlans,
+  importBatches,
   importSegments,
   upsertSegment,
   removeSegment,
@@ -6406,6 +6407,7 @@ function DataPage({ showDevResetButton, onResetToGoldenDataset }: DataPageProps)
   }>>([]);
   const [autoRenameOnConflict, setAutoRenameOnConflict] = useState(false);
   const [batchImportStatusSummary, setBatchImportStatusSummary] = useState<{
+    created: number;
     skipped: number;
     merged: number;
     rejected: number;
@@ -7048,41 +7050,29 @@ function DataPage({ showDevResetButton, onResetToGoldenDataset }: DataPageProps)
 
     try {
       const appStateWithBatches = pendingBatchImportState as { batches?: unknown[] };
-      const candidateBatches = Array.isArray(appStateWithBatches.batches) ? appStateWithBatches.batches : [];
-      const importErrors: Array<{ path: string; message: string }> = [];
-      let created = 0;
-
-      await Promise.all(candidateBatches.map(async (batchCandidate, index) => {
-        try {
-          await upsertBatch(batchCandidate);
-          created += 1;
-        } catch (error) {
-          importErrors.push({
-            path: `/batches/${index}`,
-            message: error instanceof Error ? error.message : 'Batch upsert failed.',
-          });
-        }
-      }));
-
-      const merged = 0;
-      const skipped = 0;
-      const rejectedConflict = importErrors.length;
-      const renamed = 0;
-      const conflictDetail = rejectedConflict > 0 && importErrors.length > 0
-        ? ` Conflict reasons: ${importErrors.map((entry) => entry.message).join('; ')}`
+      const candidateBatches = (Array.isArray(appStateWithBatches.batches) ? appStateWithBatches.batches : []) as Batch[];
+      const commandResult = await importBatches(candidateBatches);
+      const created = commandResult.summary.imported;
+      const merged = commandResult.summary.merged;
+      const skipped = commandResult.summary.skipped;
+      const rejected = commandResult.summary.rejected;
+      const renamed = commandResult.errors.filter((entry) => entry.message.toLowerCase().includes('renamed')).length;
+      const conflictDetail = commandResult.errors.length > 0
+        ? ` Conflict reasons: ${commandResult.errors.map((entry) => entry.message).join('; ')}`
         : '';
       const renameCapabilityNote = autoRenameOnConflict
         ? ' Auto-rename requested, but this importer currently reports collisions as deterministic rejects.'
         : '';
       setBatchImportStatusSummary({
+        created,
         skipped,
         merged,
-        rejected: rejectedConflict,
+        rejected,
         renamed,
       });
-      setImportErrors(importErrors);
+      setImportErrors(commandResult.errors);
       setImportMessage(
-        `Batch import complete. Created: ${created}. Statuses: merged ${merged}, skipped ${skipped}, rejected ${rejectedConflict}, renamed ${renamed}.`
+        `Batch import complete. Created: ${created}. Statuses: merged ${merged}, skipped ${skipped}, rejected ${rejected}, renamed ${renamed}.`
         + conflictDetail
         + renameCapabilityNote,
       );
@@ -7786,6 +7776,7 @@ function DataPage({ showDevResetButton, onResetToGoldenDataset }: DataPageProps)
         <section>
           <h3>Collision Status Summary</h3>
           <ul>
+            <li>created (imported): {batchImportStatusSummary.created}</li>
             <li>skipped (identical_batch): {batchImportStatusSummary.skipped}</li>
             <li>merged (eventsAdded): {batchImportStatusSummary.merged}</li>
             <li>rejected (batch_identity_conflict): {batchImportStatusSummary.rejected}</li>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,8 +20,8 @@ import {
   savePhotoBlobToIndexedDb,
   serializeAppStateForExport,
   listSeedInventoryItemsFromAppState,
-  upsertTaskInAppState,
-  upsertBatchInAppState,
+  upsertTask,
+  upsertBatch,
   getActiveBedAssignment,
   assertValid,
   mutateBatchAssignment,
@@ -1567,8 +1567,7 @@ function CalendarPage() {
       const doneStatuses = new Set(['done', 'completed']);
       const isDone = doneStatuses.has(task.status.toLowerCase());
       const updatedTask = { ...task, status: isDone ? 'pending' : 'done' };
-      const nextState = upsertTaskInAppState(appState, updatedTask);
-      await saveAppStateToIndexedDb(nextState);
+      await upsertTask(updatedTask);
       const refreshedState = await loadAppStateFromIndexedDb();
       if (refreshedState) {
         setTasks(listTasksFromAppState(refreshedState));
@@ -4244,10 +4243,12 @@ function BatchesPage({
         ...(Object.keys(nextMeta).length > 0 ? { meta: nextMeta } : {}),
       } as Batch;
 
-      const nextState = upsertBatchInAppState(appState, nextBatch);
-      await saveAppStateToIndexedDb(nextState);
+      await upsertBatch(nextBatch);
       const refreshedState = await loadAppStateFromIndexedDb();
-      const stateForUi = refreshedState ?? nextState;
+      if (!refreshedState) {
+        return;
+      }
+      const stateForUi = refreshedState;
       setBatches(listBatchesFromAppState(stateForUi));
       setCropIds(stateForUi.crops.map((crop) => crop.cropId));
       setCropNames(Object.fromEntries(stateForUi.crops.map((crop) => [crop.cropId, crop.name])));
@@ -5354,10 +5355,9 @@ function BatchDetailPage() {
         stageEvents: nextStageEvents,
       };
 
-      const nextState = upsertBatchInAppState(appState, nextBatch);
-      await saveAppStateToIndexedDb(nextState);
+      await upsertBatch(nextBatch);
       const refreshedState = await loadAppStateFromIndexedDb();
-      const refreshedBatch = (refreshedState ?? nextState).batches.find((candidate) => candidate.batchId === batchId) ?? null;
+      const refreshedBatch = refreshedState?.batches.find((candidate) => candidate.batchId === batchId) ?? null;
       setBatch(refreshedBatch);
       setTimelineMessage(
         latestStageEventAt && occurredAt < latestStageEventAt
@@ -5461,10 +5461,9 @@ function BatchDetailPage() {
     }
 
     const nextBatch: BatchWithPhotos = { ...(batch as BatchWithPhotos), photos: nextPhotos };
-    const nextState = upsertBatchInAppState(appState, nextBatch as Batch);
-    await saveAppStateToIndexedDb(nextState);
+    await upsertBatch(nextBatch as Batch);
     const refreshedState = await loadAppStateFromIndexedDb();
-    const refreshedBatch = (refreshedState ?? nextState).batches.find((candidate) => candidate.batchId === batchId) ?? null;
+    const refreshedBatch = refreshedState?.batches.find((candidate) => candidate.batchId === batchId) ?? null;
     setBatch(refreshedBatch);
   };
 

--- a/frontend/src/data/index.ts
+++ b/frontend/src/data/index.ts
@@ -2020,6 +2020,12 @@ export const upsertBatch = async (batch: unknown): Promise<Batch> => {
   return savedBatch;
 };
 
+export const importBatches = async (batches: Batch[]): Promise<ImportCommandResult> => {
+  const result = await workflowAdapter.batches.importBatches(batches);
+  await syncLocalMirrorFromBackend();
+  return result;
+};
+
 export const transitionBatchStage = async (
   batchId: string,
   nextStage: string,

--- a/frontend/src/data/index.ts
+++ b/frontend/src/data/index.ts
@@ -2174,6 +2174,41 @@ export const listSegments = async (): Promise<Segment[]> => {
   return appState?.segments ?? [];
 };
 
+export const upsertSegment = async (segment: unknown): Promise<Segment> => {
+  const validatedSegment = assertValid('segment', segment);
+
+  if (shouldUseCanonicalBackendPath('bedsSegments')) {
+    const savedSegment = assertValid('segment', await workflowAdapter.bedsSegments.upsertSegment(validatedSegment));
+    await syncLocalMirrorFromBackend();
+    return savedSegment;
+  }
+
+  const appState = await loadAppStateFromIndexedDb();
+  const nextSegments = (appState?.segments ?? []).some((entry) => entry.segmentId === validatedSegment.segmentId)
+    ? (appState?.segments ?? []).map((entry) => (entry.segmentId === validatedSegment.segmentId ? validatedSegment : entry))
+    : [...(appState?.segments ?? []), validatedSegment];
+  await saveAppStateToIndexedDb(assertValid('appState', { ...(appState ?? createEmptyAppState(appState)), segments: nextSegments }));
+  return validatedSegment;
+};
+
+export const removeSegment = async (segmentId: Segment['segmentId']): Promise<void> => {
+  if (shouldUseCanonicalBackendPath('bedsSegments')) {
+    await workflowAdapter.bedsSegments.removeSegment(segmentId);
+    await syncLocalMirrorFromBackend();
+    return;
+  }
+
+  const appState = await loadAppStateFromIndexedDb();
+  if (!appState) {
+    return;
+  }
+
+  await saveAppStateToIndexedDb(assertValid('appState', {
+    ...appState,
+    segments: (appState.segments ?? []).filter((segment) => segment.segmentId !== segmentId),
+  }));
+};
+
 export const importSegments = async (segments: Segment[]): Promise<ImportCommandResult> => {
   if (shouldUseCanonicalWorkflowWithoutRollback('bedsSegments')) {
     return workflowAdapter.bedsSegments.importSegments(segments);

--- a/frontend/src/data/index.ts
+++ b/frontend/src/data/index.ts
@@ -133,6 +133,18 @@ type LayoutMigrationReport = {
   warnings: LayoutMigrationWarning[];
 };
 
+export type CultivarRecord = {
+  cultivarId: string;
+  cropTypeId: string;
+  name: string;
+  supplier?: string;
+  source?: string;
+  year?: number;
+  notes?: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
 const isBackendModeEnabled = (): boolean => true;
 
 const addTypeToLegacyBed = <T extends Record<string, unknown>>(bed: T): T => ({
@@ -1782,6 +1794,23 @@ export const listSpecies = async (): Promise<Species[]> => {
 
   const appState = await loadAppStateFromIndexedDb();
   return appState?.species ?? [];
+};
+
+export const listCultivars = async (): Promise<CultivarRecord[]> => {
+  if (shouldUseCanonicalWorkflowWithoutRollback('taxonomy')) {
+    return workflowAdapter.taxonomy.listCultivars();
+  }
+
+  const appState = await loadAppStateFromIndexedDb();
+  const cultivars = (appState as AppState & { cultivars?: unknown[] } | null)?.cultivars;
+  return Array.isArray(cultivars) ? (cultivars as CultivarRecord[]) : [];
+};
+
+export const upsertCultivar = async (cultivar: unknown): Promise<CultivarRecord> => {
+  const validatedCultivar = cultivar as CultivarRecord;
+  const savedCultivar = await workflowAdapter.taxonomy.upsertCultivar(validatedCultivar);
+  await syncLocalMirrorFromBackend();
+  return savedCultivar;
 };
 
 export const getSpecies = async (speciesId: Species['id']): Promise<Species | null> => {

--- a/frontend/src/data/index.ts
+++ b/frontend/src/data/index.ts
@@ -1777,30 +1777,14 @@ export const listBeds = async (): Promise<Bed[]> => {
 };
 
 export const upsertBed = async (bed: unknown): Promise<Bed> => {
-  if (shouldUseCanonicalBackendPath('bedsSegments')) {
-    const savedBed = assertValid('bed', await workflowAdapter.bedsSegments.upsertBed(assertValid('bed', bed)));
-    await syncLocalMirrorFromBackend();
-    return savedBed;
-  }
-
-  const appState = await loadAppStateFromIndexedDb();
-  const nextState = upsertBedInAppStateLocal(appState ?? createEmptyAppState(appState), bed);
-  await saveAppStateToIndexedDb(nextState);
-  return assertValid('bed', getBedFromAppStateLocal(nextState, assertValid('bed', bed).bedId));
+  const savedBed = assertValid('bed', await workflowAdapter.bedsSegments.upsertBed(assertValid('bed', bed)));
+  await syncLocalMirrorFromBackend();
+  return savedBed;
 };
 
 export const removeBed = async (bedId: Bed['bedId']): Promise<void> => {
-  if (shouldUseCanonicalBackendPath('bedsSegments')) {
-    await workflowAdapter.bedsSegments.removeBed(bedId);
-    await syncLocalMirrorFromBackend();
-    return;
-  }
-
-  const appState = await loadAppStateFromIndexedDb();
-  if (!appState) {
-    return;
-  }
-  await saveAppStateToIndexedDb(removeBedFromAppStateLocal(appState, bedId));
+  await workflowAdapter.bedsSegments.removeBed(bedId);
+  await syncLocalMirrorFromBackend();
 };
 
 export const getCrop = async (cropId: Crop['cropId']): Promise<Crop | null> => {
@@ -1852,30 +1836,14 @@ export const listCrops = async (): Promise<Crop[]> => {
 };
 
 export const upsertCrop = async (crop: unknown): Promise<Crop> => {
-  if (shouldUseCanonicalBackendPath('taxonomy')) {
-    const savedCrop = assertValid('crop', await workflowAdapter.taxonomy.upsertCrop(assertValid('crop', crop)));
-    await syncLocalMirrorFromBackend();
-    return savedCrop;
-  }
-
-  const appState = await loadAppStateFromIndexedDb();
-  const nextState = upsertCropInAppStateLocal(appState ?? createEmptyAppState(appState), crop);
-  await saveAppStateToIndexedDb(nextState);
-  return assertValid('crop', getCropFromAppStateLocal(nextState, assertValid('crop', crop).cropId));
+  const savedCrop = assertValid('crop', await workflowAdapter.taxonomy.upsertCrop(assertValid('crop', crop)));
+  await syncLocalMirrorFromBackend();
+  return savedCrop;
 };
 
 export const removeCrop = async (cropId: Crop['cropId']): Promise<void> => {
-  if (shouldUseCanonicalBackendPath('taxonomy')) {
-    await workflowAdapter.taxonomy.removeCrop(cropId);
-    await syncLocalMirrorFromBackend();
-    return;
-  }
-
-  const appState = await loadAppStateFromIndexedDb();
-  if (!appState) {
-    return;
-  }
-  await saveAppStateToIndexedDb(removeCropFromAppStateLocal(appState, cropId));
+  await workflowAdapter.taxonomy.removeCrop(cropId);
+  await syncLocalMirrorFromBackend();
 };
 
 export const getCropPlan = async (planId: CropPlan['planId']): Promise<CropPlan | null> => {
@@ -1897,30 +1865,14 @@ export const listCropPlans = async (): Promise<CropPlan[]> => {
 };
 
 export const upsertCropPlan = async (cropPlan: unknown): Promise<CropPlan> => {
-  if (shouldUseCanonicalBackendPath('taxonomy')) {
-    const savedCropPlan = assertValid('cropPlan', await workflowAdapter.taxonomy.upsertCropPlan(assertValid('cropPlan', cropPlan)));
-    await syncLocalMirrorFromBackend();
-    return savedCropPlan;
-  }
-
-  const appState = await loadAppStateFromIndexedDb();
-  const nextState = upsertCropPlanInAppStateLocal(appState ?? createEmptyAppState(appState), cropPlan);
-  await saveAppStateToIndexedDb(nextState);
-  return assertValid('cropPlan', getCropPlanFromAppStateLocal(nextState, assertValid('cropPlan', cropPlan).planId));
+  const savedCropPlan = assertValid('cropPlan', await workflowAdapter.taxonomy.upsertCropPlan(assertValid('cropPlan', cropPlan)));
+  await syncLocalMirrorFromBackend();
+  return savedCropPlan;
 };
 
 export const removeCropPlan = async (planId: CropPlan['planId']): Promise<void> => {
-  if (shouldUseCanonicalBackendPath('taxonomy')) {
-    await workflowAdapter.taxonomy.removeCropPlan(planId);
-    await syncLocalMirrorFromBackend();
-    return;
-  }
-
-  const appState = await loadAppStateFromIndexedDb();
-  if (!appState) {
-    return;
-  }
-  await saveAppStateToIndexedDb(removeCropPlanFromAppStateLocal(appState, planId));
+  await workflowAdapter.taxonomy.removeCropPlan(planId);
+  await syncLocalMirrorFromBackend();
 };
 
 type ImportStatusSummary = {
@@ -2008,38 +1960,19 @@ export const listSeedInventoryItems = async (
 };
 
 export const upsertSeedInventoryItem = async (seedInventoryItem: unknown): Promise<SeedInventoryItem> => {
-  if (shouldUseCanonicalBackendPath('inventory')) {
-    const savedItem = assertValid(
-      'seedInventoryItem',
-      await workflowAdapter.inventory.upsertSeedInventoryItem(assertValid('seedInventoryItem', seedInventoryItem)),
-    );
-    await syncLocalMirrorFromBackend();
-    return savedItem;
-  }
-
-  const appState = await loadAppStateFromIndexedDb();
-  const nextState = upsertSeedInventoryItemInAppStateLocal(appState ?? createEmptyAppState(appState), seedInventoryItem);
-  await saveAppStateToIndexedDb(nextState);
-  return assertValid(
+  const savedItem = assertValid(
     'seedInventoryItem',
-    getSeedInventoryItemFromAppStateLocal(nextState, assertValid('seedInventoryItem', seedInventoryItem).seedInventoryItemId),
+    await workflowAdapter.inventory.upsertSeedInventoryItem(assertValid('seedInventoryItem', seedInventoryItem)),
   );
+  await syncLocalMirrorFromBackend();
+  return savedItem;
 };
 
 export const removeSeedInventoryItem = async (
   seedInventoryItemId: SeedInventoryItem['seedInventoryItemId'],
 ): Promise<void> => {
-  if (shouldUseCanonicalBackendPath('inventory')) {
-    await workflowAdapter.inventory.removeSeedInventoryItem(seedInventoryItemId);
-    await syncLocalMirrorFromBackend();
-    return;
-  }
-
-  const appState = await loadAppStateFromIndexedDb();
-  if (!appState) {
-    return;
-  }
-  await saveAppStateToIndexedDb(removeSeedInventoryItemFromAppStateLocal(appState, seedInventoryItemId));
+  await workflowAdapter.inventory.removeSeedInventoryItem(seedInventoryItemId);
+  await syncLocalMirrorFromBackend();
 };
 
 export const upsertTask = async (task: unknown): Promise<Task> => {
@@ -2059,107 +1992,32 @@ export const transitionBatchStage = async (
   nextStage: string,
   occurredAt: string,
 ): Promise<Batch> => {
-  if (shouldUseCanonicalBackendPath('batches')) {
-    const transitionedBatch = assertValid('batch', await workflowAdapter.batches.transitionStage(batchId, nextStage, occurredAt));
-    await syncLocalMirrorFromBackend();
-    return transitionedBatch;
-  }
-
-  // Deprecated rollback shim for emergency rollback only. Removal target: 2026-07-31.
-  console.warn('[DEPRECATED] Using TypeScript batch stage transition rollback shim.');
-  const appState = await loadAppStateFromIndexedDb();
-  if (!appState) {
-    throw new Error('App state unavailable.');
-  }
-
-  const existingBatch = getBatchFromAppStateLocal(appState, batchId);
-  if (!existingBatch) {
-    throw new Error('Batch not found.');
-  }
-
-  const transition = applyStageEvent(existingBatch, { stage: nextStage, occurredAt });
-  if (!transition.ok) {
-    throw new Error(transition.reason);
-  }
-
-  const nextState = upsertBatchInAppStateLocal(appState, transition.batch);
-  await saveAppStateToIndexedDb(nextState);
-  return transition.batch;
+  const transitionedBatch = assertValid('batch', await workflowAdapter.batches.transitionStage(batchId, nextStage, occurredAt));
+  await syncLocalMirrorFromBackend();
+  return transitionedBatch;
 };
 
 export const mutateBatchAssignment = async (
   operation: 'assign' | 'move' | 'remove',
   payload: { batchId: string; bedId?: string; at: string },
 ): Promise<Batch> => {
-  if (shouldUseCanonicalBackendPath('batches')) {
-    const mutatedBatch = assertValid('batch', await workflowAdapter.batches.mutateAssignment(operation, payload));
-    await syncLocalMirrorFromBackend();
-    return mutatedBatch;
-  }
-
-  // Deprecated rollback shim for emergency rollback only. Removal target: 2026-07-31.
-  console.warn('[DEPRECATED] Using TypeScript batch assignment rollback shim.');
-  const appState = await loadAppStateFromIndexedDb();
-  if (!appState) {
-    throw new Error('App state unavailable.');
-  }
-
-  const existingBatch = getBatchFromAppStateLocal(appState, payload.batchId);
-  if (!existingBatch) {
-    throw new Error('Batch not found.');
-  }
-
-  const nextBatch =
-    operation === 'assign'
-      ? assignBatchToBedLocal(existingBatch, payload.bedId ?? '', payload.at)
-      : operation === 'move'
-        ? moveBatchLocal(existingBatch, payload.bedId ?? '', payload.at)
-        : removeBatchFromBedLocal(existingBatch, payload.at);
-  const nextState = upsertBatchInAppStateLocal(appState, nextBatch);
-  await saveAppStateToIndexedDb(nextState);
-  return nextBatch;
+  const mutatedBatch = assertValid('batch', await workflowAdapter.batches.mutateAssignment(operation, payload));
+  await syncLocalMirrorFromBackend();
+  return mutatedBatch;
 };
 
 export const removeBatch = async (batchId: Batch['batchId']): Promise<void> => {
-  if (shouldUseCanonicalBackendPath('batches')) {
-    await workflowAdapter.batches.removeBatch(batchId);
-    await syncLocalMirrorFromBackend();
-    return;
-  }
-
-  const appState = await loadAppStateFromIndexedDb();
-  if (!appState) {
-    return;
-  }
-
-  await saveAppStateToIndexedDb(removeBatchFromAppStateLocal(appState, batchId));
+  await workflowAdapter.batches.removeBatch(batchId);
+  await syncLocalMirrorFromBackend();
 };
 
 export const regenerateCalendarTasks = async (year: number) => {
-  if (shouldUseCanonicalBackendPath('tasks')) {
-    const payload = await workflowAdapter.tasks.regenerateCalendar(year);
-    await syncLocalMirrorFromBackend();
-    return {
-      generatedTasks: payload.generatedTasks,
-      diagnostics: payload.diagnostics,
-      stateAfter: assertValid('appState', payload.stateAfter),
-    };
-  }
-
-  // Deprecated rollback shim for emergency rollback only. Removal target: 2026-07-31.
-  console.warn('[DEPRECATED] Using TypeScript task regeneration rollback shim.');
-  const appState = await loadAppStateFromIndexedDb();
-  if (!appState) {
-    throw new Error('App state unavailable.');
-  }
-
-  const generationResult = generateCalendarTasksWithDiagnosticsLocal(appState, year);
-  const nextState = upsertGeneratedTasksInAppStateLocal(appState, generationResult.tasks);
-  await saveAppStateToIndexedDb(nextState);
+  const payload = await workflowAdapter.tasks.regenerateCalendar(year);
+  await syncLocalMirrorFromBackend();
   return {
-    generatedTasks: generationResult.tasks,
-    diagnostics: generationResult.diagnostics,
-    stateAfter: nextState,
+    generatedTasks: payload.generatedTasks,
+    diagnostics: payload.diagnostics,
+    stateAfter: assertValid('appState', payload.stateAfter),
   };
 };
 

--- a/frontend/src/data/index.ts
+++ b/frontend/src/data/index.ts
@@ -43,7 +43,6 @@ import {
 } from './repos/taskRepository';
 import { applyStageEvent } from '../domain';
 import {
-  getFrontendMode,
   shouldUseCanonicalBackendPath,
   shouldUseTypescriptRollbackShim,
   toBackendApiUrl,

--- a/frontend/src/data/index.ts
+++ b/frontend/src/data/index.ts
@@ -1,4 +1,4 @@
-import type { AppState, Batch, Bed, Crop, CropPlan, SeedInventoryItem, Task } from '../contracts';
+import type { AppState, Batch, Bed, Crop, CropPlan, SeedInventoryItem, Segment, Species, Task } from '../contracts';
 import { SchemaValidationError, assertValid } from './validation';
 import { getSettingsOrDefault } from './repos/settingsRepository';
 import { mergeTaskForImport } from './repos/taskRepository';
@@ -1800,6 +1800,57 @@ export const getCrop = async (cropId: Crop['cropId']): Promise<Crop | null> => {
   return appState ? getCropFromAppStateLocal(appState, cropId) : null;
 };
 
+export const listSpecies = async (): Promise<Species[]> => {
+  if (shouldUseCanonicalWorkflowWithoutRollback('taxonomy')) {
+    return workflowAdapter.taxonomy.listSpecies();
+  }
+
+  const appState = await loadAppStateFromIndexedDb();
+  return appState?.species ?? [];
+};
+
+export const getSpecies = async (speciesId: Species['id']): Promise<Species | null> => {
+  if (shouldUseCanonicalWorkflowWithoutRollback('taxonomy')) {
+    return workflowAdapter.taxonomy.getSpecies(speciesId);
+  }
+
+  const appState = await loadAppStateFromIndexedDb();
+  return (appState?.species ?? []).find((species) => species.id === speciesId) ?? null;
+};
+
+export const upsertSpecies = async (species: unknown): Promise<Species> => {
+  const validatedSpecies = assertValid('species', species);
+
+  if (shouldUseCanonicalWorkflowWithoutRollback('taxonomy')) {
+    return assertValid('species', await workflowAdapter.taxonomy.upsertSpecies(validatedSpecies));
+  }
+
+  const appState = await loadAppStateFromIndexedDb();
+  const nextSpecies = (appState?.species ?? []).some((entry) => entry.id === validatedSpecies.id)
+    ? (appState?.species ?? []).map((entry) => (entry.id === validatedSpecies.id ? validatedSpecies : entry))
+    : [...(appState?.species ?? []), validatedSpecies];
+  const nextState = assertValid('appState', { ...(appState ?? createEmptyAppState(appState)), species: nextSpecies });
+  await saveAppStateToIndexedDb(nextState);
+  return validatedSpecies;
+};
+
+export const removeSpecies = async (speciesId: Species['id']): Promise<void> => {
+  if (shouldUseCanonicalWorkflowWithoutRollback('taxonomy')) {
+    await workflowAdapter.taxonomy.removeSpecies(speciesId);
+    return;
+  }
+
+  const appState = await loadAppStateFromIndexedDb();
+  if (!appState) {
+    return;
+  }
+
+  await saveAppStateToIndexedDb(assertValid('appState', {
+    ...appState,
+    species: (appState.species ?? []).filter((species) => species.id !== speciesId),
+  }));
+};
+
 export const listCrops = async (): Promise<Crop[]> => {
   if (shouldUseCanonicalWorkflowWithoutRollback('taxonomy')) {
     return workflowAdapter.taxonomy.listCrops();
@@ -1873,6 +1924,276 @@ export const removeCropPlan = async (planId: CropPlan['planId']): Promise<void> 
     return;
   }
   await saveAppStateToIndexedDb(removeCropPlanFromAppStateLocal(appState, planId));
+};
+
+type ImportStatusSummary = {
+  imported: number;
+  merged: number;
+  skipped: number;
+  rejected: number;
+};
+
+type ImportStatusIssue = {
+  path: string;
+  message: string;
+};
+
+type ImportCommandResult = {
+  summary: ImportStatusSummary;
+  errors: ImportStatusIssue[];
+};
+
+export const importCrops = async (crops: Crop[]): Promise<ImportCommandResult> => {
+  if (shouldUseCanonicalWorkflowWithoutRollback('taxonomy')) {
+    return workflowAdapter.taxonomy.importCrops(crops);
+  }
+
+  const existingAppState = await loadAppStateFromIndexedDb();
+  if (!existingAppState) {
+    throw new Error('Crop import failed: local app state is unavailable.');
+  }
+
+  const cropsById = new Map(existingAppState.crops.map((crop) => [crop.cropId, crop]));
+  const summary: ImportStatusSummary = { imported: 0, merged: 0, skipped: 0, rejected: 0 };
+  const errors: ImportStatusIssue[] = [];
+
+  crops.forEach((incomingCrop, index) => {
+    const currentCrop = cropsById.get(incomingCrop.cropId);
+
+    if (!currentCrop) {
+      cropsById.set(incomingCrop.cropId, incomingCrop);
+      summary.imported += 1;
+      return;
+    }
+
+    if (incomingCrop.createdAt !== currentCrop.createdAt) {
+      summary.rejected += 1;
+      errors.push({
+        path: `/crops/${index}`,
+        message: `rejected (crop_identity_conflict): createdAt mismatch for cropId ${incomingCrop.cropId}`,
+      });
+      return;
+    }
+
+    const mergedCrop: Crop = {
+      ...currentCrop,
+      name: incomingCrop.name,
+      rules: incomingCrop.rules,
+      nutritionProfile: incomingCrop.nutritionProfile,
+      updatedAt: incomingCrop.updatedAt,
+    };
+
+    if (incomingCrop.aliases !== undefined) {
+      mergedCrop.aliases = incomingCrop.aliases;
+    }
+    if (incomingCrop.category !== undefined) {
+      mergedCrop.category = incomingCrop.category;
+    }
+    if (incomingCrop.cultivarGroup !== undefined) {
+      mergedCrop.cultivarGroup = incomingCrop.cultivarGroup;
+    }
+    if (incomingCrop.taskRules !== undefined) {
+      mergedCrop.taskRules = incomingCrop.taskRules;
+    }
+    const incomingCultivar = (incomingCrop as Crop & { cultivar?: string }).cultivar;
+    if (incomingCultivar !== undefined) {
+      (mergedCrop as Crop & { cultivar?: string }).cultivar = incomingCultivar;
+    }
+    const incomingSpeciesId = (incomingCrop as Crop & { speciesId?: string }).speciesId;
+    if (incomingSpeciesId !== undefined) {
+      (mergedCrop as Crop & { speciesId?: string }).speciesId = incomingSpeciesId;
+    }
+
+    const incomingSpecies = (incomingCrop as Crop & {
+      species?: { id?: string; commonName: string; scientificName: string; taxonomy?: { family?: string; genus?: string; species?: string } };
+    }).species;
+    const incomingTaxonomy = incomingCrop.taxonomy;
+
+    if (incomingSpecies !== undefined || incomingTaxonomy !== undefined) {
+      const currentSpecies = (currentCrop as Crop & {
+        species?: { id?: string; commonName: string; scientificName: string; taxonomy?: { family?: string; genus?: string; species?: string } };
+      }).species;
+      const commonName = incomingSpecies?.commonName ?? currentSpecies?.commonName;
+      const scientificName = incomingSpecies?.scientificName ?? currentSpecies?.scientificName;
+
+      if (commonName !== undefined && scientificName !== undefined) {
+        (mergedCrop as Crop & {
+          species?: { id?: string; commonName: string; scientificName: string; taxonomy?: { family?: string; genus?: string; species?: string } };
+        }).species = {
+          ...(currentSpecies?.id !== undefined ? { id: currentSpecies.id } : {}),
+          ...(incomingSpecies?.id !== undefined ? { id: incomingSpecies.id } : {}),
+          commonName,
+          scientificName,
+          ...((incomingTaxonomy !== undefined || incomingSpecies?.taxonomy !== undefined || currentSpecies?.taxonomy !== undefined)
+            ? {
+                taxonomy: {
+                  ...(currentSpecies?.taxonomy ?? {}),
+                  ...(incomingTaxonomy ?? {}),
+                  ...(incomingSpecies?.taxonomy ?? {}),
+                },
+              }
+            : {}),
+        };
+      }
+    }
+
+    const unchanged = JSON.stringify(currentCrop) === JSON.stringify(mergedCrop);
+    cropsById.set(incomingCrop.cropId, mergedCrop);
+    if (unchanged) {
+      summary.skipped += 1;
+    } else {
+      summary.merged += 1;
+    }
+  });
+
+  await saveAppStateToIndexedDb({ ...existingAppState, crops: [...cropsById.values()] }, { mode: 'replace' });
+  return { summary, errors };
+};
+
+export const importSpecies = async (species: Species[]): Promise<ImportCommandResult> => {
+  if (shouldUseCanonicalWorkflowWithoutRollback('taxonomy')) {
+    return workflowAdapter.taxonomy.importSpecies(species);
+  }
+
+  const existingAppState = await loadAppStateFromIndexedDb();
+  if (!existingAppState) {
+    throw new Error('Species import failed: local app state is unavailable.');
+  }
+
+  const speciesById = new Map((existingAppState.species ?? []).map((entry) => [entry.id, entry]));
+  const summary: ImportStatusSummary = { imported: 0, merged: 0, skipped: 0, rejected: 0 };
+  const errors: ImportStatusIssue[] = [];
+
+  species.forEach((incomingSpecies, index) => {
+    const currentSpecies = speciesById.get(incomingSpecies.id);
+
+    if (!currentSpecies) {
+      speciesById.set(incomingSpecies.id, incomingSpecies);
+      summary.imported += 1;
+      return;
+    }
+
+    const mergedSpecies: Species = {
+      ...currentSpecies,
+      ...((incomingSpecies.commonName ?? currentSpecies.commonName) !== undefined
+        ? { commonName: incomingSpecies.commonName ?? currentSpecies.commonName }
+        : {}),
+      ...((incomingSpecies.scientificName ?? currentSpecies.scientificName) !== undefined
+        ? { scientificName: incomingSpecies.scientificName ?? currentSpecies.scientificName }
+        : {}),
+      ...((incomingSpecies.aliases ?? currentSpecies.aliases) !== undefined
+        ? { aliases: incomingSpecies.aliases ?? currentSpecies.aliases }
+        : {}),
+      ...((incomingSpecies.notes ?? currentSpecies.notes) !== undefined
+        ? { notes: incomingSpecies.notes ?? currentSpecies.notes }
+        : {}),
+    };
+
+    const unchanged = JSON.stringify(currentSpecies) === JSON.stringify(mergedSpecies);
+    speciesById.set(incomingSpecies.id, mergedSpecies);
+    if (unchanged) {
+      summary.skipped += 1;
+    } else {
+      summary.merged += 1;
+      if (currentSpecies.commonName !== incomingSpecies.commonName || currentSpecies.scientificName !== incomingSpecies.scientificName) {
+        errors.push({
+          path: `/species/${index}`,
+          message: `merged (shared_reference_update): crop species references remain linked to ${incomingSpecies.id}`,
+        });
+      }
+    }
+  });
+
+  await saveAppStateToIndexedDb({ ...existingAppState, species: [...speciesById.values()] }, { mode: 'replace' });
+  return { summary, errors };
+};
+
+export const importCropPlans = async (cropPlans: CropPlan[]): Promise<ImportCommandResult> => {
+  if (shouldUseCanonicalWorkflowWithoutRollback('taxonomy')) {
+    return workflowAdapter.taxonomy.importCropPlans(cropPlans);
+  }
+
+  const existingAppState = await loadAppStateFromIndexedDb();
+  if (!existingAppState) {
+    throw new Error('Crop plan import failed: local app state is unavailable.');
+  }
+
+  const plansById = new Map(existingAppState.cropPlans.map((plan) => [plan.planId, plan]));
+  const summary: ImportStatusSummary = { imported: 0, merged: 0, skipped: 0, rejected: 0 };
+
+  cropPlans.forEach((incomingPlan) => {
+    const currentPlan = plansById.get(incomingPlan.planId);
+    if (!currentPlan) {
+      plansById.set(incomingPlan.planId, incomingPlan);
+      summary.imported += 1;
+      return;
+    }
+
+    const unchanged = JSON.stringify(currentPlan) === JSON.stringify(incomingPlan);
+    plansById.set(incomingPlan.planId, incomingPlan);
+    if (unchanged) {
+      summary.skipped += 1;
+    } else {
+      summary.merged += 1;
+    }
+  });
+
+  await saveAppStateToIndexedDb({ ...existingAppState, cropPlans: [...plansById.values()] }, { mode: 'replace' });
+  return { summary, errors: [] };
+};
+
+export const listSegments = async (): Promise<Segment[]> => {
+  if (shouldUseCanonicalWorkflowWithoutRollback('bedsSegments')) {
+    return workflowAdapter.bedsSegments.listSegments();
+  }
+
+  const appState = await loadAppStateFromIndexedDb();
+  return appState?.segments ?? [];
+};
+
+export const importSegments = async (segments: Segment[]): Promise<ImportCommandResult> => {
+  if (shouldUseCanonicalWorkflowWithoutRollback('bedsSegments')) {
+    return workflowAdapter.bedsSegments.importSegments(segments);
+  }
+
+  const existingAppState = await loadAppStateFromIndexedDb();
+  if (!existingAppState) {
+    throw new Error('Segment import failed: local app state is unavailable.');
+  }
+
+  const segmentsById = new Map((existingAppState.segments ?? []).map((segment) => [segment.segmentId, segment]));
+  const summary: ImportStatusSummary = { imported: 0, merged: 0, skipped: 0, rejected: 0 };
+  const errors: ImportStatusIssue[] = [];
+
+  segments.forEach((incomingSegment, index) => {
+    const currentSegment = segmentsById.get(incomingSegment.segmentId);
+
+    if (!currentSegment) {
+      segmentsById.set(incomingSegment.segmentId, incomingSegment);
+      summary.imported += 1;
+      return;
+    }
+
+    if (JSON.stringify(currentSegment) === JSON.stringify(incomingSegment)) {
+      summary.skipped += 1;
+      return;
+    }
+
+    if (currentSegment.name !== incomingSegment.name || currentSegment.originReference !== incomingSegment.originReference) {
+      summary.rejected += 1;
+      errors.push({
+        path: `/segments/${index}`,
+        message: `rejected (segment_identity_conflict): identity mismatch for segmentId ${incomingSegment.segmentId}`,
+      });
+      return;
+    }
+
+    segmentsById.set(incomingSegment.segmentId, incomingSegment);
+    summary.merged += 1;
+  });
+
+  await saveAppStateToIndexedDb({ ...existingAppState, segments: [...segmentsById.values()] }, { mode: 'replace' });
+  return { summary, errors };
 };
 
 export const getSeedInventoryItem = async (

--- a/frontend/src/data/index.ts
+++ b/frontend/src/data/index.ts
@@ -157,7 +157,7 @@ type LayoutMigrationReport = {
   warnings: LayoutMigrationWarning[];
 };
 
-const isBackendModeEnabled = (): boolean => getFrontendMode() === 'backend';
+const isBackendModeEnabled = (): boolean => true;
 
 const addTypeToLegacyBed = <T extends Record<string, unknown>>(bed: T): T => ({
   ...bed,

--- a/frontend/src/data/index.ts
+++ b/frontend/src/data/index.ts
@@ -37,8 +37,6 @@ import {
 import type { ListQuery } from './repos/interfaces';
 import {
   generateCalendarTasksWithDiagnostics as generateCalendarTasksWithDiagnosticsLocal,
-  getTaskFromAppState as getTaskFromAppStateLocal,
-  upsertTaskInAppState as upsertTaskInAppStateLocal,
   upsertGeneratedTasksInAppState as upsertGeneratedTasksInAppStateLocal,
 } from './repos/taskRepository';
 import { applyStageEvent } from '../domain';
@@ -1834,38 +1832,14 @@ export const getSpecies = async (speciesId: Species['id']): Promise<Species | nu
 
 export const upsertSpecies = async (species: unknown): Promise<Species> => {
   const validatedSpecies = assertValid('species', species);
-
-  if (shouldUseCanonicalBackendPath('taxonomy')) {
-    const savedSpecies = assertValid('species', await workflowAdapter.taxonomy.upsertSpecies(validatedSpecies));
-    await syncLocalMirrorFromBackend();
-    return savedSpecies;
-  }
-
-  const appState = await loadAppStateFromIndexedDb();
-  const nextSpecies = (appState?.species ?? []).some((entry) => entry.id === validatedSpecies.id)
-    ? (appState?.species ?? []).map((entry) => (entry.id === validatedSpecies.id ? validatedSpecies : entry))
-    : [...(appState?.species ?? []), validatedSpecies];
-  const nextState = assertValid('appState', { ...(appState ?? createEmptyAppState(appState)), species: nextSpecies });
-  await saveAppStateToIndexedDb(nextState);
-  return validatedSpecies;
+  const savedSpecies = assertValid('species', await workflowAdapter.taxonomy.upsertSpecies(validatedSpecies));
+  await syncLocalMirrorFromBackend();
+  return savedSpecies;
 };
 
 export const removeSpecies = async (speciesId: Species['id']): Promise<void> => {
-  if (shouldUseCanonicalBackendPath('taxonomy')) {
-    await workflowAdapter.taxonomy.removeSpecies(speciesId);
-    await syncLocalMirrorFromBackend();
-    return;
-  }
-
-  const appState = await loadAppStateFromIndexedDb();
-  if (!appState) {
-    return;
-  }
-
-  await saveAppStateToIndexedDb(assertValid('appState', {
-    ...appState,
-    species: (appState.species ?? []).filter((species) => species.id !== speciesId),
-  }));
+  await workflowAdapter.taxonomy.removeSpecies(speciesId);
+  await syncLocalMirrorFromBackend();
 };
 
 export const listCrops = async (): Promise<Crop[]> => {
@@ -1967,202 +1941,21 @@ type ImportCommandResult = {
 };
 
 export const importCrops = async (crops: Crop[]): Promise<ImportCommandResult> => {
-  if (shouldUseCanonicalWorkflowWithoutRollback('taxonomy')) {
-    return workflowAdapter.taxonomy.importCrops(crops);
-  }
-
-  const existingAppState = await loadAppStateFromIndexedDb();
-  if (!existingAppState) {
-    throw new Error('Crop import failed: local app state is unavailable.');
-  }
-
-  const cropsById = new Map(existingAppState.crops.map((crop) => [crop.cropId, crop]));
-  const summary: ImportStatusSummary = { imported: 0, merged: 0, skipped: 0, rejected: 0 };
-  const errors: ImportStatusIssue[] = [];
-
-  crops.forEach((incomingCrop, index) => {
-    const currentCrop = cropsById.get(incomingCrop.cropId);
-
-    if (!currentCrop) {
-      cropsById.set(incomingCrop.cropId, incomingCrop);
-      summary.imported += 1;
-      return;
-    }
-
-    if (incomingCrop.createdAt !== currentCrop.createdAt) {
-      summary.rejected += 1;
-      errors.push({
-        path: `/crops/${index}`,
-        message: `rejected (crop_identity_conflict): createdAt mismatch for cropId ${incomingCrop.cropId}`,
-      });
-      return;
-    }
-
-    const mergedCrop: Crop = {
-      ...currentCrop,
-      name: incomingCrop.name,
-      rules: incomingCrop.rules,
-      nutritionProfile: incomingCrop.nutritionProfile,
-      updatedAt: incomingCrop.updatedAt,
-    };
-
-    if (incomingCrop.aliases !== undefined) {
-      mergedCrop.aliases = incomingCrop.aliases;
-    }
-    if (incomingCrop.category !== undefined) {
-      mergedCrop.category = incomingCrop.category;
-    }
-    if (incomingCrop.cultivarGroup !== undefined) {
-      mergedCrop.cultivarGroup = incomingCrop.cultivarGroup;
-    }
-    if (incomingCrop.taskRules !== undefined) {
-      mergedCrop.taskRules = incomingCrop.taskRules;
-    }
-    const incomingCultivar = (incomingCrop as Crop & { cultivar?: string }).cultivar;
-    if (incomingCultivar !== undefined) {
-      (mergedCrop as Crop & { cultivar?: string }).cultivar = incomingCultivar;
-    }
-    const incomingSpeciesId = (incomingCrop as Crop & { speciesId?: string }).speciesId;
-    if (incomingSpeciesId !== undefined) {
-      (mergedCrop as Crop & { speciesId?: string }).speciesId = incomingSpeciesId;
-    }
-
-    const incomingSpecies = (incomingCrop as Crop & {
-      species?: { id?: string; commonName: string; scientificName: string; taxonomy?: { family?: string; genus?: string; species?: string } };
-    }).species;
-    const incomingTaxonomy = incomingCrop.taxonomy;
-
-    if (incomingSpecies !== undefined || incomingTaxonomy !== undefined) {
-      const currentSpecies = (currentCrop as Crop & {
-        species?: { id?: string; commonName: string; scientificName: string; taxonomy?: { family?: string; genus?: string; species?: string } };
-      }).species;
-      const commonName = incomingSpecies?.commonName ?? currentSpecies?.commonName;
-      const scientificName = incomingSpecies?.scientificName ?? currentSpecies?.scientificName;
-
-      if (commonName !== undefined && scientificName !== undefined) {
-        (mergedCrop as Crop & {
-          species?: { id?: string; commonName: string; scientificName: string; taxonomy?: { family?: string; genus?: string; species?: string } };
-        }).species = {
-          ...(currentSpecies?.id !== undefined ? { id: currentSpecies.id } : {}),
-          ...(incomingSpecies?.id !== undefined ? { id: incomingSpecies.id } : {}),
-          commonName,
-          scientificName,
-          ...((incomingTaxonomy !== undefined || incomingSpecies?.taxonomy !== undefined || currentSpecies?.taxonomy !== undefined)
-            ? {
-                taxonomy: {
-                  ...(currentSpecies?.taxonomy ?? {}),
-                  ...(incomingTaxonomy ?? {}),
-                  ...(incomingSpecies?.taxonomy ?? {}),
-                },
-              }
-            : {}),
-        };
-      }
-    }
-
-    const unchanged = JSON.stringify(currentCrop) === JSON.stringify(mergedCrop);
-    cropsById.set(incomingCrop.cropId, mergedCrop);
-    if (unchanged) {
-      summary.skipped += 1;
-    } else {
-      summary.merged += 1;
-    }
-  });
-
-  await saveAppStateToIndexedDb({ ...existingAppState, crops: [...cropsById.values()] }, { mode: 'replace' });
-  return { summary, errors };
+  const result = await workflowAdapter.taxonomy.importCrops(crops);
+  await syncLocalMirrorFromBackend();
+  return result;
 };
 
 export const importSpecies = async (species: Species[]): Promise<ImportCommandResult> => {
-  if (shouldUseCanonicalWorkflowWithoutRollback('taxonomy')) {
-    return workflowAdapter.taxonomy.importSpecies(species);
-  }
-
-  const existingAppState = await loadAppStateFromIndexedDb();
-  if (!existingAppState) {
-    throw new Error('Species import failed: local app state is unavailable.');
-  }
-
-  const speciesById = new Map((existingAppState.species ?? []).map((entry) => [entry.id, entry]));
-  const summary: ImportStatusSummary = { imported: 0, merged: 0, skipped: 0, rejected: 0 };
-  const errors: ImportStatusIssue[] = [];
-
-  species.forEach((incomingSpecies, index) => {
-    const currentSpecies = speciesById.get(incomingSpecies.id);
-
-    if (!currentSpecies) {
-      speciesById.set(incomingSpecies.id, incomingSpecies);
-      summary.imported += 1;
-      return;
-    }
-
-    const mergedSpecies: Species = {
-      ...currentSpecies,
-      ...((incomingSpecies.commonName ?? currentSpecies.commonName) !== undefined
-        ? { commonName: incomingSpecies.commonName ?? currentSpecies.commonName }
-        : {}),
-      ...((incomingSpecies.scientificName ?? currentSpecies.scientificName) !== undefined
-        ? { scientificName: incomingSpecies.scientificName ?? currentSpecies.scientificName }
-        : {}),
-      ...((incomingSpecies.aliases ?? currentSpecies.aliases) !== undefined
-        ? { aliases: incomingSpecies.aliases ?? currentSpecies.aliases }
-        : {}),
-      ...((incomingSpecies.notes ?? currentSpecies.notes) !== undefined
-        ? { notes: incomingSpecies.notes ?? currentSpecies.notes }
-        : {}),
-    };
-
-    const unchanged = JSON.stringify(currentSpecies) === JSON.stringify(mergedSpecies);
-    speciesById.set(incomingSpecies.id, mergedSpecies);
-    if (unchanged) {
-      summary.skipped += 1;
-    } else {
-      summary.merged += 1;
-      if (currentSpecies.commonName !== incomingSpecies.commonName || currentSpecies.scientificName !== incomingSpecies.scientificName) {
-        errors.push({
-          path: `/species/${index}`,
-          message: `merged (shared_reference_update): crop species references remain linked to ${incomingSpecies.id}`,
-        });
-      }
-    }
-  });
-
-  await saveAppStateToIndexedDb({ ...existingAppState, species: [...speciesById.values()] }, { mode: 'replace' });
-  return { summary, errors };
+  const result = await workflowAdapter.taxonomy.importSpecies(species);
+  await syncLocalMirrorFromBackend();
+  return result;
 };
 
 export const importCropPlans = async (cropPlans: CropPlan[]): Promise<ImportCommandResult> => {
-  if (shouldUseCanonicalWorkflowWithoutRollback('taxonomy')) {
-    return workflowAdapter.taxonomy.importCropPlans(cropPlans);
-  }
-
-  const existingAppState = await loadAppStateFromIndexedDb();
-  if (!existingAppState) {
-    throw new Error('Crop plan import failed: local app state is unavailable.');
-  }
-
-  const plansById = new Map(existingAppState.cropPlans.map((plan) => [plan.planId, plan]));
-  const summary: ImportStatusSummary = { imported: 0, merged: 0, skipped: 0, rejected: 0 };
-
-  cropPlans.forEach((incomingPlan) => {
-    const currentPlan = plansById.get(incomingPlan.planId);
-    if (!currentPlan) {
-      plansById.set(incomingPlan.planId, incomingPlan);
-      summary.imported += 1;
-      return;
-    }
-
-    const unchanged = JSON.stringify(currentPlan) === JSON.stringify(incomingPlan);
-    plansById.set(incomingPlan.planId, incomingPlan);
-    if (unchanged) {
-      summary.skipped += 1;
-    } else {
-      summary.merged += 1;
-    }
-  });
-
-  await saveAppStateToIndexedDb({ ...existingAppState, cropPlans: [...plansById.values()] }, { mode: 'replace' });
-  return { summary, errors: [] };
+  const result = await workflowAdapter.taxonomy.importCropPlans(cropPlans);
+  await syncLocalMirrorFromBackend();
+  return result;
 };
 
 export const listSegments = async (): Promise<Segment[]> => {
@@ -2176,82 +1969,20 @@ export const listSegments = async (): Promise<Segment[]> => {
 
 export const upsertSegment = async (segment: unknown): Promise<Segment> => {
   const validatedSegment = assertValid('segment', segment);
-
-  if (shouldUseCanonicalBackendPath('bedsSegments')) {
-    const savedSegment = assertValid('segment', await workflowAdapter.bedsSegments.upsertSegment(validatedSegment));
-    await syncLocalMirrorFromBackend();
-    return savedSegment;
-  }
-
-  const appState = await loadAppStateFromIndexedDb();
-  const nextSegments = (appState?.segments ?? []).some((entry) => entry.segmentId === validatedSegment.segmentId)
-    ? (appState?.segments ?? []).map((entry) => (entry.segmentId === validatedSegment.segmentId ? validatedSegment : entry))
-    : [...(appState?.segments ?? []), validatedSegment];
-  await saveAppStateToIndexedDb(assertValid('appState', { ...(appState ?? createEmptyAppState(appState)), segments: nextSegments }));
-  return validatedSegment;
+  const savedSegment = assertValid('segment', await workflowAdapter.bedsSegments.upsertSegment(validatedSegment));
+  await syncLocalMirrorFromBackend();
+  return savedSegment;
 };
 
 export const removeSegment = async (segmentId: Segment['segmentId']): Promise<void> => {
-  if (shouldUseCanonicalBackendPath('bedsSegments')) {
-    await workflowAdapter.bedsSegments.removeSegment(segmentId);
-    await syncLocalMirrorFromBackend();
-    return;
-  }
-
-  const appState = await loadAppStateFromIndexedDb();
-  if (!appState) {
-    return;
-  }
-
-  await saveAppStateToIndexedDb(assertValid('appState', {
-    ...appState,
-    segments: (appState.segments ?? []).filter((segment) => segment.segmentId !== segmentId),
-  }));
+  await workflowAdapter.bedsSegments.removeSegment(segmentId);
+  await syncLocalMirrorFromBackend();
 };
 
 export const importSegments = async (segments: Segment[]): Promise<ImportCommandResult> => {
-  if (shouldUseCanonicalWorkflowWithoutRollback('bedsSegments')) {
-    return workflowAdapter.bedsSegments.importSegments(segments);
-  }
-
-  const existingAppState = await loadAppStateFromIndexedDb();
-  if (!existingAppState) {
-    throw new Error('Segment import failed: local app state is unavailable.');
-  }
-
-  const segmentsById = new Map((existingAppState.segments ?? []).map((segment) => [segment.segmentId, segment]));
-  const summary: ImportStatusSummary = { imported: 0, merged: 0, skipped: 0, rejected: 0 };
-  const errors: ImportStatusIssue[] = [];
-
-  segments.forEach((incomingSegment, index) => {
-    const currentSegment = segmentsById.get(incomingSegment.segmentId);
-
-    if (!currentSegment) {
-      segmentsById.set(incomingSegment.segmentId, incomingSegment);
-      summary.imported += 1;
-      return;
-    }
-
-    if (JSON.stringify(currentSegment) === JSON.stringify(incomingSegment)) {
-      summary.skipped += 1;
-      return;
-    }
-
-    if (currentSegment.name !== incomingSegment.name || currentSegment.originReference !== incomingSegment.originReference) {
-      summary.rejected += 1;
-      errors.push({
-        path: `/segments/${index}`,
-        message: `rejected (segment_identity_conflict): identity mismatch for segmentId ${incomingSegment.segmentId}`,
-      });
-      return;
-    }
-
-    segmentsById.set(incomingSegment.segmentId, incomingSegment);
-    summary.merged += 1;
-  });
-
-  await saveAppStateToIndexedDb({ ...existingAppState, segments: [...segmentsById.values()] }, { mode: 'replace' });
-  return { summary, errors };
+  const result = await workflowAdapter.bedsSegments.importSegments(segments);
+  await syncLocalMirrorFromBackend();
+  return result;
 };
 
 export const getSeedInventoryItem = async (
@@ -2312,29 +2043,15 @@ export const removeSeedInventoryItem = async (
 };
 
 export const upsertTask = async (task: unknown): Promise<Task> => {
-  if (shouldUseCanonicalBackendPath('tasks')) {
-    const savedTask = assertValid('task', await workflowAdapter.tasks.upsertTask(assertValid('task', task)));
-    await syncLocalMirrorFromBackend();
-    return savedTask;
-  }
-
-  const appState = await loadAppStateFromIndexedDb();
-  const nextState = upsertTaskInAppStateLocal(appState ?? createEmptyAppState(appState), task);
-  await saveAppStateToIndexedDb(nextState);
-  return assertValid('task', getTaskFromAppStateLocal(nextState, assertValid('task', task).id));
+  const savedTask = assertValid('task', await workflowAdapter.tasks.upsertTask(assertValid('task', task)));
+  await syncLocalMirrorFromBackend();
+  return savedTask;
 };
 
 export const upsertBatch = async (batch: unknown): Promise<Batch> => {
-  if (shouldUseCanonicalBackendPath('batches')) {
-    const savedBatch = assertValid('batch', await workflowAdapter.batches.upsertBatch(assertValid('batch', batch)));
-    await syncLocalMirrorFromBackend();
-    return savedBatch;
-  }
-
-  const appState = await loadAppStateFromIndexedDb();
-  const nextState = upsertBatchInAppStateLocal(appState ?? createEmptyAppState(appState), batch);
-  await saveAppStateToIndexedDb(nextState);
-  return assertValid('batch', getBatchFromAppStateLocal(nextState, assertValid('batch', batch).batchId));
+  const savedBatch = assertValid('batch', await workflowAdapter.batches.upsertBatch(assertValid('batch', batch)));
+  await syncLocalMirrorFromBackend();
+  return savedBatch;
 };
 
 export const transitionBatchStage = async (

--- a/frontend/src/data/index.ts
+++ b/frontend/src/data/index.ts
@@ -1749,6 +1749,17 @@ const shouldUseCanonicalWorkflowWithoutRollback = (
   feature: 'bedsSegments' | 'taxonomy' | 'inventory' | 'batches' | 'tasks',
 ): boolean => shouldUseCanonicalBackendPath(feature) && !shouldUseTypescriptRollbackShim(feature);
 
+const syncLocalMirrorFromBackend = async (): Promise<void> => {
+  try {
+    const backendState = await loadAppStateFromBackendApi();
+    if (backendState) {
+      await saveAppStateToLocalIndexedDb(backendState, { mode: 'replace' });
+    }
+  } catch (error) {
+    console.warn('Failed to refresh local IndexedDB mirror from backend.', toValidationDebugPayload(error));
+  }
+};
+
 export const getBed = async (bedId: Bed['bedId']): Promise<Bed | null> => {
   if (shouldUseCanonicalWorkflowWithoutRollback('bedsSegments')) {
     return workflowAdapter.bedsSegments.getBed(bedId);
@@ -1768,8 +1779,10 @@ export const listBeds = async (): Promise<Bed[]> => {
 };
 
 export const upsertBed = async (bed: unknown): Promise<Bed> => {
-  if (shouldUseCanonicalWorkflowWithoutRollback('bedsSegments')) {
-    return assertValid('bed', await workflowAdapter.bedsSegments.upsertBed(assertValid('bed', bed)));
+  if (shouldUseCanonicalBackendPath('bedsSegments')) {
+    const savedBed = assertValid('bed', await workflowAdapter.bedsSegments.upsertBed(assertValid('bed', bed)));
+    await syncLocalMirrorFromBackend();
+    return savedBed;
   }
 
   const appState = await loadAppStateFromIndexedDb();
@@ -1779,8 +1792,9 @@ export const upsertBed = async (bed: unknown): Promise<Bed> => {
 };
 
 export const removeBed = async (bedId: Bed['bedId']): Promise<void> => {
-  if (shouldUseCanonicalWorkflowWithoutRollback('bedsSegments')) {
+  if (shouldUseCanonicalBackendPath('bedsSegments')) {
     await workflowAdapter.bedsSegments.removeBed(bedId);
+    await syncLocalMirrorFromBackend();
     return;
   }
 
@@ -1821,8 +1835,10 @@ export const getSpecies = async (speciesId: Species['id']): Promise<Species | nu
 export const upsertSpecies = async (species: unknown): Promise<Species> => {
   const validatedSpecies = assertValid('species', species);
 
-  if (shouldUseCanonicalWorkflowWithoutRollback('taxonomy')) {
-    return assertValid('species', await workflowAdapter.taxonomy.upsertSpecies(validatedSpecies));
+  if (shouldUseCanonicalBackendPath('taxonomy')) {
+    const savedSpecies = assertValid('species', await workflowAdapter.taxonomy.upsertSpecies(validatedSpecies));
+    await syncLocalMirrorFromBackend();
+    return savedSpecies;
   }
 
   const appState = await loadAppStateFromIndexedDb();
@@ -1835,8 +1851,9 @@ export const upsertSpecies = async (species: unknown): Promise<Species> => {
 };
 
 export const removeSpecies = async (speciesId: Species['id']): Promise<void> => {
-  if (shouldUseCanonicalWorkflowWithoutRollback('taxonomy')) {
+  if (shouldUseCanonicalBackendPath('taxonomy')) {
     await workflowAdapter.taxonomy.removeSpecies(speciesId);
+    await syncLocalMirrorFromBackend();
     return;
   }
 
@@ -1861,8 +1878,10 @@ export const listCrops = async (): Promise<Crop[]> => {
 };
 
 export const upsertCrop = async (crop: unknown): Promise<Crop> => {
-  if (shouldUseCanonicalWorkflowWithoutRollback('taxonomy')) {
-    return assertValid('crop', await workflowAdapter.taxonomy.upsertCrop(assertValid('crop', crop)));
+  if (shouldUseCanonicalBackendPath('taxonomy')) {
+    const savedCrop = assertValid('crop', await workflowAdapter.taxonomy.upsertCrop(assertValid('crop', crop)));
+    await syncLocalMirrorFromBackend();
+    return savedCrop;
   }
 
   const appState = await loadAppStateFromIndexedDb();
@@ -1872,8 +1891,9 @@ export const upsertCrop = async (crop: unknown): Promise<Crop> => {
 };
 
 export const removeCrop = async (cropId: Crop['cropId']): Promise<void> => {
-  if (shouldUseCanonicalWorkflowWithoutRollback('taxonomy')) {
+  if (shouldUseCanonicalBackendPath('taxonomy')) {
     await workflowAdapter.taxonomy.removeCrop(cropId);
+    await syncLocalMirrorFromBackend();
     return;
   }
 
@@ -1903,8 +1923,10 @@ export const listCropPlans = async (): Promise<CropPlan[]> => {
 };
 
 export const upsertCropPlan = async (cropPlan: unknown): Promise<CropPlan> => {
-  if (shouldUseCanonicalWorkflowWithoutRollback('taxonomy')) {
-    return assertValid('cropPlan', await workflowAdapter.taxonomy.upsertCropPlan(assertValid('cropPlan', cropPlan)));
+  if (shouldUseCanonicalBackendPath('taxonomy')) {
+    const savedCropPlan = assertValid('cropPlan', await workflowAdapter.taxonomy.upsertCropPlan(assertValid('cropPlan', cropPlan)));
+    await syncLocalMirrorFromBackend();
+    return savedCropPlan;
   }
 
   const appState = await loadAppStateFromIndexedDb();
@@ -1914,8 +1936,9 @@ export const upsertCropPlan = async (cropPlan: unknown): Promise<CropPlan> => {
 };
 
 export const removeCropPlan = async (planId: CropPlan['planId']): Promise<void> => {
-  if (shouldUseCanonicalWorkflowWithoutRollback('taxonomy')) {
+  if (shouldUseCanonicalBackendPath('taxonomy')) {
     await workflowAdapter.taxonomy.removeCropPlan(planId);
+    await syncLocalMirrorFromBackend();
     return;
   }
 
@@ -2219,11 +2242,13 @@ export const listSeedInventoryItems = async (
 };
 
 export const upsertSeedInventoryItem = async (seedInventoryItem: unknown): Promise<SeedInventoryItem> => {
-  if (shouldUseCanonicalWorkflowWithoutRollback('inventory')) {
-    return assertValid(
+  if (shouldUseCanonicalBackendPath('inventory')) {
+    const savedItem = assertValid(
       'seedInventoryItem',
       await workflowAdapter.inventory.upsertSeedInventoryItem(assertValid('seedInventoryItem', seedInventoryItem)),
     );
+    await syncLocalMirrorFromBackend();
+    return savedItem;
   }
 
   const appState = await loadAppStateFromIndexedDb();
@@ -2238,8 +2263,9 @@ export const upsertSeedInventoryItem = async (seedInventoryItem: unknown): Promi
 export const removeSeedInventoryItem = async (
   seedInventoryItemId: SeedInventoryItem['seedInventoryItemId'],
 ): Promise<void> => {
-  if (shouldUseCanonicalWorkflowWithoutRollback('inventory')) {
+  if (shouldUseCanonicalBackendPath('inventory')) {
     await workflowAdapter.inventory.removeSeedInventoryItem(seedInventoryItemId);
+    await syncLocalMirrorFromBackend();
     return;
   }
 
@@ -2251,8 +2277,10 @@ export const removeSeedInventoryItem = async (
 };
 
 export const upsertTask = async (task: unknown): Promise<Task> => {
-  if (shouldUseCanonicalWorkflowWithoutRollback('tasks')) {
-    return assertValid('task', await workflowAdapter.tasks.upsertTask(assertValid('task', task)));
+  if (shouldUseCanonicalBackendPath('tasks')) {
+    const savedTask = assertValid('task', await workflowAdapter.tasks.upsertTask(assertValid('task', task)));
+    await syncLocalMirrorFromBackend();
+    return savedTask;
   }
 
   const appState = await loadAppStateFromIndexedDb();
@@ -2262,8 +2290,10 @@ export const upsertTask = async (task: unknown): Promise<Task> => {
 };
 
 export const upsertBatch = async (batch: unknown): Promise<Batch> => {
-  if (shouldUseCanonicalWorkflowWithoutRollback('batches')) {
-    return assertValid('batch', await workflowAdapter.batches.upsertBatch(assertValid('batch', batch)));
+  if (shouldUseCanonicalBackendPath('batches')) {
+    const savedBatch = assertValid('batch', await workflowAdapter.batches.upsertBatch(assertValid('batch', batch)));
+    await syncLocalMirrorFromBackend();
+    return savedBatch;
   }
 
   const appState = await loadAppStateFromIndexedDb();
@@ -2277,8 +2307,10 @@ export const transitionBatchStage = async (
   nextStage: string,
   occurredAt: string,
 ): Promise<Batch> => {
-  if (shouldUseCanonicalBackendPath('batches') && !shouldUseTypescriptRollbackShim('batches')) {
-    return assertValid('batch', await workflowAdapter.batches.transitionStage(batchId, nextStage, occurredAt));
+  if (shouldUseCanonicalBackendPath('batches')) {
+    const transitionedBatch = assertValid('batch', await workflowAdapter.batches.transitionStage(batchId, nextStage, occurredAt));
+    await syncLocalMirrorFromBackend();
+    return transitionedBatch;
   }
 
   // Deprecated rollback shim for emergency rollback only. Removal target: 2026-07-31.
@@ -2307,8 +2339,10 @@ export const mutateBatchAssignment = async (
   operation: 'assign' | 'move' | 'remove',
   payload: { batchId: string; bedId?: string; at: string },
 ): Promise<Batch> => {
-  if (shouldUseCanonicalBackendPath('batches') && !shouldUseTypescriptRollbackShim('batches')) {
-    return assertValid('batch', await workflowAdapter.batches.mutateAssignment(operation, payload));
+  if (shouldUseCanonicalBackendPath('batches')) {
+    const mutatedBatch = assertValid('batch', await workflowAdapter.batches.mutateAssignment(operation, payload));
+    await syncLocalMirrorFromBackend();
+    return mutatedBatch;
   }
 
   // Deprecated rollback shim for emergency rollback only. Removal target: 2026-07-31.
@@ -2335,8 +2369,9 @@ export const mutateBatchAssignment = async (
 };
 
 export const removeBatch = async (batchId: Batch['batchId']): Promise<void> => {
-  if (shouldUseCanonicalBackendPath('batches') && !shouldUseTypescriptRollbackShim('batches')) {
+  if (shouldUseCanonicalBackendPath('batches')) {
     await workflowAdapter.batches.removeBatch(batchId);
+    await syncLocalMirrorFromBackend();
     return;
   }
 
@@ -2349,8 +2384,9 @@ export const removeBatch = async (batchId: Batch['batchId']): Promise<void> => {
 };
 
 export const regenerateCalendarTasks = async (year: number) => {
-  if (shouldUseCanonicalBackendPath('tasks') && !shouldUseTypescriptRollbackShim('tasks')) {
+  if (shouldUseCanonicalBackendPath('tasks')) {
     const payload = await workflowAdapter.tasks.regenerateCalendar(year);
+    await syncLocalMirrorFromBackend();
     return {
       generatedTasks: payload.generatedTasks,
       diagnostics: payload.diagnostics,

--- a/frontend/src/data/index.ts
+++ b/frontend/src/data/index.ts
@@ -3,43 +3,22 @@ import { SchemaValidationError, assertValid } from './validation';
 import { getSettingsOrDefault } from './repos/settingsRepository';
 import { mergeTaskForImport } from './repos/taskRepository';
 import {
-  assignBatchToBed as assignBatchToBedLocal,
-  getBatchFromAppState as getBatchFromAppStateLocal,
-  moveBatch as moveBatchLocal,
-  removeBatchFromBed as removeBatchFromBedLocal,
-  removeBatchFromAppState as removeBatchFromAppStateLocal,
-  upsertBatchInAppState as upsertBatchInAppStateLocal,
-} from './repos/batchRepository';
-import {
   getBedFromAppState as getBedFromAppStateLocal,
   listBedsFromAppState as listBedsFromAppStateLocal,
-  removeBedFromAppState as removeBedFromAppStateLocal,
-  upsertBedInAppState as upsertBedInAppStateLocal,
 } from './repos/bedRepository';
 import {
   getCropFromAppState as getCropFromAppStateLocal,
   listCropsFromAppState as listCropsFromAppStateLocal,
-  removeCropFromAppState as removeCropFromAppStateLocal,
-  upsertCropInAppState as upsertCropInAppStateLocal,
 } from './repos/cropRepository';
 import {
   getCropPlanFromAppState as getCropPlanFromAppStateLocal,
   listCropPlansFromAppState as listCropPlansFromAppStateLocal,
-  removeCropPlanFromAppState as removeCropPlanFromAppStateLocal,
-  upsertCropPlanInAppState as upsertCropPlanInAppStateLocal,
 } from './repos/cropPlanRepository';
 import {
   getSeedInventoryItemFromAppState as getSeedInventoryItemFromAppStateLocal,
   listSeedInventoryItemsFromAppState as listSeedInventoryItemsFromAppStateLocal,
-  removeSeedInventoryItemFromAppState as removeSeedInventoryItemFromAppStateLocal,
-  upsertSeedInventoryItemInAppState as upsertSeedInventoryItemInAppStateLocal,
 } from './repos/seedInventoryRepository';
 import type { ListQuery } from './repos/interfaces';
-import {
-  generateCalendarTasksWithDiagnostics as generateCalendarTasksWithDiagnosticsLocal,
-  upsertGeneratedTasksInAppState as upsertGeneratedTasksInAppStateLocal,
-} from './repos/taskRepository';
-import { applyStageEvent } from '../domain';
 import {
   shouldUseCanonicalBackendPath,
   shouldUseTypescriptRollbackShim,

--- a/frontend/src/data/index.ts
+++ b/frontend/src/data/index.ts
@@ -1900,6 +1900,31 @@ type ImportCommandResult = {
   errors: ImportStatusIssue[];
 };
 
+export const replaceCanonicalAppState = async (appState: unknown): Promise<AppState> => {
+  const candidateState =
+    appState && typeof appState === 'object'
+      ? {
+          ...(appState as Record<string, unknown>),
+          settings: getSettingsOrDefault((appState as { settings?: unknown }).settings),
+        }
+      : appState;
+  const canonicalState = canonicalizeForExport(assertValid('appState', candidateState));
+
+  if (isBackendModeEnabled()) {
+    await workflowAdapter.appState.replace(canonicalState);
+    await syncLocalMirrorFromBackend();
+  } else {
+    await saveAppStateToLocalIndexedDb(canonicalState, { mode: 'replace' });
+  }
+
+  const refreshedState = await loadAppStateFromIndexedDb();
+  if (!refreshedState) {
+    throw new AppStateStorageError('Canonical app state replacement completed but no readable state was returned.');
+  }
+
+  return refreshedState;
+};
+
 export const importCrops = async (crops: Crop[]): Promise<ImportCommandResult> => {
   const result = await workflowAdapter.taxonomy.importCrops(crops);
   await syncLocalMirrorFromBackend();

--- a/frontend/src/data/index.ts
+++ b/frontend/src/data/index.ts
@@ -1,4 +1,4 @@
-import type { AppState, Batch, Bed, Crop, CropPlan, SeedInventoryItem } from '../contracts';
+import type { AppState, Batch, Bed, Crop, CropPlan, SeedInventoryItem, Task } from '../contracts';
 import { SchemaValidationError, assertValid } from './validation';
 import { getSettingsOrDefault } from './repos/settingsRepository';
 import { mergeTaskForImport } from './repos/taskRepository';
@@ -37,6 +37,8 @@ import {
 import type { ListQuery } from './repos/interfaces';
 import {
   generateCalendarTasksWithDiagnostics as generateCalendarTasksWithDiagnosticsLocal,
+  getTaskFromAppState as getTaskFromAppStateLocal,
+  upsertTaskInAppState as upsertTaskInAppStateLocal,
   upsertGeneratedTasksInAppState as upsertGeneratedTasksInAppStateLocal,
 } from './repos/taskRepository';
 import { applyStageEvent } from '../domain';
@@ -1926,6 +1928,28 @@ export const removeSeedInventoryItem = async (
     return;
   }
   await saveAppStateToIndexedDb(removeSeedInventoryItemFromAppStateLocal(appState, seedInventoryItemId));
+};
+
+export const upsertTask = async (task: unknown): Promise<Task> => {
+  if (shouldUseCanonicalWorkflowWithoutRollback('tasks')) {
+    return assertValid('task', await workflowAdapter.tasks.upsertTask(assertValid('task', task)));
+  }
+
+  const appState = await loadAppStateFromIndexedDb();
+  const nextState = upsertTaskInAppStateLocal(appState ?? createEmptyAppState(appState), task);
+  await saveAppStateToIndexedDb(nextState);
+  return assertValid('task', getTaskFromAppStateLocal(nextState, assertValid('task', task).id));
+};
+
+export const upsertBatch = async (batch: unknown): Promise<Batch> => {
+  if (shouldUseCanonicalWorkflowWithoutRollback('batches')) {
+    return assertValid('batch', await workflowAdapter.batches.upsertBatch(assertValid('batch', batch)));
+  }
+
+  const appState = await loadAppStateFromIndexedDb();
+  const nextState = upsertBatchInAppStateLocal(appState ?? createEmptyAppState(appState), batch);
+  await saveAppStateToIndexedDb(nextState);
+  return assertValid('batch', getBatchFromAppStateLocal(nextState, assertValid('batch', batch).batchId));
 };
 
 export const transitionBatchStage = async (

--- a/frontend/src/data/workflowAdapter.ts
+++ b/frontend/src/data/workflowAdapter.ts
@@ -1,4 +1,4 @@
-import type { AppState, Batch, Bed, Crop, CropPlan, SeedInventoryItem, Segment } from '../contracts';
+import type { AppState, Batch, Bed, Crop, CropPlan, SeedInventoryItem, Segment, Species } from '../contracts';
 import { assertValid } from './validation';
 import type { SchemaName, SchemaTypeMap } from './validation';
 import type { BackendApiPath } from '../generated/api-client';
@@ -202,6 +202,76 @@ const assertContractList = <T extends SchemaName>(
   return payload.map((item, index) => assertContract(`${contractName}[${index}]`, schemaName, item));
 };
 
+type ImportSummary = {
+  imported: number;
+  merged: number;
+  skipped: number;
+  rejected: number;
+};
+
+type ImportIssue = {
+  path: string;
+  message: string;
+};
+
+type ImportCommandResult = {
+  summary: ImportSummary;
+  errors: ImportIssue[];
+};
+
+const assertImportSummary = (contractName: string, payload: unknown): ImportSummary => {
+  if (!payload || typeof payload !== 'object') {
+    throw buildContractMismatchError(contractName, new Error('expected object payload'));
+  }
+
+  const summary = payload as Record<string, unknown>;
+  const getNumber = (key: keyof ImportSummary): number => {
+    const value = summary[key];
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+      throw buildContractMismatchError(contractName, new Error(`expected numeric ${key}`));
+    }
+    return value;
+  };
+
+  return {
+    imported: getNumber('imported'),
+    merged: getNumber('merged'),
+    skipped: getNumber('skipped'),
+    rejected: getNumber('rejected'),
+  };
+};
+
+const assertImportIssues = (contractName: string, payload: unknown): ImportIssue[] => {
+  if (!Array.isArray(payload)) {
+    return [];
+  }
+
+  return payload.map((entry, index) => {
+    if (!entry || typeof entry !== 'object') {
+      throw buildContractMismatchError(contractName, new Error(`errors[${index}] must be an object`));
+    }
+
+    const issue = entry as Record<string, unknown>;
+    if (typeof issue.path !== 'string' || typeof issue.message !== 'string') {
+      throw buildContractMismatchError(contractName, new Error(`errors[${index}] must include string path/message`));
+    }
+
+    return { path: issue.path, message: issue.message };
+  });
+};
+
+const assertImportCommandResult = (contractName: string, payload: unknown): ImportCommandResult => {
+  if (!payload || typeof payload !== 'object') {
+    throw buildContractMismatchError(contractName, new Error('expected object payload'));
+  }
+
+  const typedPayload = payload as Record<string, unknown>;
+  return {
+    summary: assertImportSummary(`${contractName}.summary`, typedPayload.summary),
+    errors: assertImportIssues(`${contractName}.errors`, typedPayload.errors),
+  };
+};
+
 export const workflowAdapter = {
   batches: {
     upsertBatch: async (batch: Batch): Promise<Batch> =>
@@ -319,8 +389,41 @@ export const workflowAdapter = {
         throw new Error(await parseBackendError(response));
       }
     },
+    importSegments: async (segments: Segment[]): Promise<ImportCommandResult> =>
+      assertImportCommandResult('bedsSegments.importSegments', await fetchJson<unknown>('/api/import/segments', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ segments }),
+      })),
   },
   taxonomy: {
+    listSpecies: async (): Promise<Species[]> =>
+      assertContractList('taxonomy.listSpecies', 'species', await fetchJson<unknown>(backendPath('/api/species'), { method: 'GET' })),
+    getSpecies: async (speciesId: string): Promise<Species | null> => {
+      const response = await fetch(toBackendApiUrl(`/api/species/${encodeURIComponent(speciesId)}`), { method: 'GET' });
+      if (response.status === 404) {
+        return null;
+      }
+      if (!response.ok) {
+        throw new Error(await parseBackendError(response));
+      }
+      return assertContract('taxonomy.getSpecies', 'species', await response.json());
+    },
+    upsertSpecies: async (species: Species): Promise<Species> =>
+      assertContract('taxonomy.upsertSpecies', 'species', await fetchJson<unknown>(`/api/species/${encodeURIComponent(species.id)}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(species),
+      })),
+    removeSpecies: async (speciesId: string): Promise<void> => {
+      const response = await fetch(toBackendApiUrl(`/api/species/${encodeURIComponent(speciesId)}`), { method: 'DELETE' });
+      if (response.status === 404 || response.status === 204) {
+        return;
+      }
+      if (!response.ok) {
+        throw new Error(await parseBackendError(response));
+      }
+    },
     listCrops: async (): Promise<Crop[]> =>
       assertContractList('taxonomy.listCrops', 'crop', await fetchJson<unknown>(backendPath('/api/crops'), { method: 'GET' })),
     getCrop: async (cropId: string): Promise<Crop | null> => {
@@ -375,6 +478,24 @@ export const workflowAdapter = {
         throw new Error(await parseBackendError(response));
       }
     },
+    importSpecies: async (species: Species[]): Promise<ImportCommandResult> =>
+      assertImportCommandResult('taxonomy.importSpecies', await fetchJson<unknown>('/api/import/species', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ species }),
+      })),
+    importCrops: async (crops: Crop[]): Promise<ImportCommandResult> =>
+      assertImportCommandResult('taxonomy.importCrops', await fetchJson<unknown>('/api/import/crops', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ crops }),
+      })),
+    importCropPlans: async (cropPlans: CropPlan[]): Promise<ImportCommandResult> =>
+      assertImportCommandResult('taxonomy.importCropPlans', await fetchJson<unknown>('/api/import/crop-plans', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ cropPlans }),
+      })),
   },
   inventory: {
     listSeedInventoryItems: async (): Promise<SeedInventoryItem[]> =>

--- a/frontend/src/data/workflowAdapter.ts
+++ b/frontend/src/data/workflowAdapter.ts
@@ -204,6 +204,12 @@ const assertContractList = <T extends SchemaName>(
 
 export const workflowAdapter = {
   batches: {
+    upsertBatch: async (batch: Batch): Promise<Batch> =>
+      assertContract('batches.upsertBatch', 'batch', await fetchJson<unknown>(`/api/batches/${encodeURIComponent(batch.batchId)}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(batch),
+      })),
     transitionStage: async (batchId: string, nextStage: string, occurredAt: string): Promise<Batch> =>
       fetchJson<Batch>(`/api/domain/batches/${encodeURIComponent(batchId)}/stage-events`, {
         method: 'POST',
@@ -230,6 +236,12 @@ export const workflowAdapter = {
     },
   },
   tasks: {
+    upsertTask: async (task: AppState['tasks'][number]): Promise<AppState['tasks'][number]> =>
+      assertContract('tasks.upsertTask', 'task', await fetchJson<unknown>(`/api/tasks/${encodeURIComponent(task.id)}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(task),
+      })),
     regenerateCalendar: async (year: number): Promise<{
       generatedTasks: AppState['tasks'];
       diagnostics: { cropId: string; reason: string; detail: string }[];

--- a/frontend/src/data/workflowAdapter.ts
+++ b/frontend/src/data/workflowAdapter.ts
@@ -305,6 +305,12 @@ export const workflowAdapter = {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(batch),
       })),
+    importBatches: async (batches: Batch[]): Promise<ImportCommandResult> =>
+      assertImportCommandResult('batches.importBatches', await fetchJson<unknown>('/api/import/batches', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ batches }),
+      })),
     transitionStage: async (batchId: string, nextStage: string, occurredAt: string): Promise<Batch> =>
       fetchJson<Batch>(`/api/domain/batches/${encodeURIComponent(batchId)}/stage-events`, {
         method: 'POST',

--- a/frontend/src/data/workflowAdapter.ts
+++ b/frontend/src/data/workflowAdapter.ts
@@ -219,6 +219,18 @@ type ImportCommandResult = {
   errors: ImportIssue[];
 };
 
+type CultivarRecord = {
+  cultivarId: string;
+  cropTypeId: string;
+  name: string;
+  supplier?: string;
+  source?: string;
+  year?: number;
+  notes?: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
 const assertImportSummary = (contractName: string, payload: unknown): ImportSummary => {
   if (!payload || typeof payload !== 'object') {
     throw buildContractMismatchError(contractName, new Error('expected object payload'));
@@ -397,6 +409,23 @@ export const workflowAdapter = {
       })),
   },
   taxonomy: {
+    listCultivars: async (): Promise<CultivarRecord[]> =>
+      fetchJson<CultivarRecord[]>(backendPath('/api/cultivars'), { method: 'GET' }),
+    upsertCultivar: async (cultivar: CultivarRecord): Promise<CultivarRecord> =>
+      fetchJson<CultivarRecord>(`/api/cultivars/${encodeURIComponent(cultivar.cultivarId)}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(cultivar),
+      }),
+    removeCultivar: async (cultivarId: string): Promise<void> => {
+      const response = await fetch(toBackendApiUrl(`/api/cultivars/${encodeURIComponent(cultivarId)}`), { method: 'DELETE' });
+      if (response.status === 404 || response.status === 204) {
+        return;
+      }
+      if (!response.ok) {
+        throw new Error(await parseBackendError(response));
+      }
+    },
     listSpecies: async (): Promise<Species[]> =>
       assertContractList('taxonomy.listSpecies', 'species', await fetchJson<unknown>(backendPath('/api/species'), { method: 'GET' })),
     getSpecies: async (speciesId: string): Promise<Species | null> => {

--- a/frontend/src/data/workflowAdapter.ts
+++ b/frontend/src/data/workflowAdapter.ts
@@ -285,6 +285,19 @@ const assertImportCommandResult = (contractName: string, payload: unknown): Impo
 };
 
 export const workflowAdapter = {
+  appState: {
+    replace: async (appState: AppState): Promise<void> => {
+      const response = await fetch(toBackendApiUrl('/api/app-state'), {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(appState),
+      });
+
+      if (!response.ok) {
+        throw new Error(await parseBackendError(response));
+      }
+    },
+  },
   batches: {
     upsertBatch: async (batch: Batch): Promise<Batch> =>
       assertContract('batches.upsertBatch', 'batch', await fetchJson<unknown>(`/api/batches/${encodeURIComponent(batch.batchId)}`, {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -63,6 +63,13 @@ summary:focus-visible {
   background: #d1fae5;
 }
 
+.app-mode-authority-note {
+  margin: 0.5rem auto 0;
+  max-width: 48rem;
+  font-size: 0.825rem;
+  color: #4b5563;
+}
+
 .app-content {
   display: grid;
   padding: 1.5rem 1rem 5.5rem;


### PR DESCRIPTION
### Motivation
- Move bed deletion and updates to the centralized data layer to ensure consistent state transitions and side-effects across UI and backend modes.
- Ensure UI reflects canonical backend authority semantics by surfacing a short explanatory note in the header.
- Refresh related bed batch data after persisting notes so the UI shows up-to-date assignments.

### Description
- Added imports for `removeBed` and `upsertBed` from `./data` and replaced manual segment/beds mutation with a call to `removeBed(bedId)` in the bed delete flow.
- Replaced the local `upsertBedInAppState` + `saveAppStateToIndexedDb` flow with an `await upsertBed(...)` call that returns `savedBed`, sets the local `bed` state from that return value, reloads the app state, and calls `refreshBedBatches(refreshedState)`.
- Added `refreshBedBatches` to the effect dependency list to ensure batch data is refreshed after notes persist.
- Added a short explanatory paragraph in the header when `frontendMode` is displayed and corresponding styles in `index.css` for the `.app-mode-authority-note` class.

### Testing
- Ran the frontend build with `yarn build` and the command completed successfully.
- Executed the test suite with `yarn test` and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e940219bac8326860edc2a24c62ac3)