### PR TITLE
Refactor taxonomy and import handlers to use data-layer commands

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -30,14 +30,75 @@ import {
   upsertBatch,
 } from './data';
 
-vi.mock('./data', () => ({
-  initializeAppStateStorage: vi.fn().mockResolvedValue(undefined),
-  resetToGoldenDataset: vi.fn().mockResolvedValue(undefined),
-  loadAppStateFromIndexedDb: vi.fn().mockResolvedValue(null),
-  parseImportedAppState: vi.fn(),
-  saveAppStateToIndexedDb: vi.fn().mockResolvedValue(undefined),
-  serializeAppStateForExport: vi.fn().mockReturnValue('{"schemaVersion":1}'),
-  assertValid: vi.fn((schemaName: string, value: unknown) => value),
+vi.mock('./data', () => {
+  const saveAppStateToIndexedDb = vi.fn().mockResolvedValue(undefined);
+  const loadAppStateFromIndexedDb = vi.fn().mockResolvedValue(null);
+
+  return {
+    initializeAppStateStorage: vi.fn().mockResolvedValue(undefined),
+    resetToGoldenDataset: vi.fn().mockResolvedValue(undefined),
+    loadAppStateFromIndexedDb,
+    parseImportedAppState: vi.fn(),
+    saveAppStateToIndexedDb,
+    serializeAppStateForExport: vi.fn().mockReturnValue('{"schemaVersion":1}'),
+    assertValid: vi.fn((schemaName: string, value: unknown) => value),
+    listCrops: vi.fn(async () => (await loadAppStateFromIndexedDb())?.crops ?? []),
+    listSpecies: vi.fn(async () => (await loadAppStateFromIndexedDb())?.species ?? []),
+    listCropPlans: vi.fn(async () => (await loadAppStateFromIndexedDb())?.cropPlans ?? []),
+    listSegments: vi.fn(async () => (await loadAppStateFromIndexedDb())?.segments ?? []),
+    upsertSpecies: vi.fn(async (species: { id: string }) => {
+      const state = await loadAppStateFromIndexedDb();
+      if (!state) {
+        return species;
+      }
+
+      const nextSpecies = (state.species ?? []).some((entry: { id: string }) => entry.id === species.id)
+        ? (state.species ?? []).map((entry: { id: string }) => (entry.id === species.id ? species : entry))
+        : [...(state.species ?? []), species];
+      await saveAppStateToIndexedDb({ ...state, species: nextSpecies });
+      return species;
+    }),
+    importCrops: vi.fn(async () => ({ summary: { imported: 0, merged: 0, skipped: 0, rejected: 0 }, errors: [] })),
+    importSpecies: vi.fn(async () => ({ summary: { imported: 0, merged: 0, skipped: 0, rejected: 0 }, errors: [] })),
+    importCropPlans: vi.fn(async () => ({ summary: { imported: 0, merged: 0, skipped: 0, rejected: 0 }, errors: [] })),
+    importSegments: vi.fn(async (segments: Array<{ segmentId: string; name: string; originReference?: string }>) => {
+      const state = await loadAppStateFromIndexedDb();
+      const summary = { imported: 0, merged: 0, skipped: 0, rejected: 0 };
+      const errors: Array<{ path: string; message: string }> = [];
+
+      if (state) {
+        const segmentsById = new Map((state.segments ?? []).map((segment: { segmentId: string }) => [segment.segmentId, segment]));
+        segments.forEach((incomingSegment, index) => {
+          const currentSegment = segmentsById.get(incomingSegment.segmentId) as { name?: string; originReference?: string } | undefined;
+
+          if (!currentSegment) {
+            segmentsById.set(incomingSegment.segmentId, incomingSegment);
+            summary.imported += 1;
+            return;
+          }
+
+          if (JSON.stringify(currentSegment) === JSON.stringify(incomingSegment)) {
+            summary.skipped += 1;
+            return;
+          }
+
+          if (currentSegment.name !== incomingSegment.name || currentSegment.originReference !== incomingSegment.originReference) {
+            summary.rejected += 1;
+            errors.push({
+              path: `/segments/${index}`,
+              message: `rejected (segment_identity_conflict): identity mismatch for segmentId ${incomingSegment.segmentId}`,
+            });
+            return;
+          }
+
+          segmentsById.set(incomingSegment.segmentId, incomingSegment);
+          summary.merged += 1;
+        });
+
+        await saveAppStateToIndexedDb({ ...state, segments: [...segmentsById.values()] }, { mode: 'replace' });
+      }
+      return { summary, errors };
+    }),
   upsertCropInAppState: vi.fn((appState: { crops?: Array<{ cropId: string }> }, crop: { cropId: string }) => ({
     ...appState,
     crops: [...(appState.crops ?? []).filter((entry: { cropId: string }) => entry.cropId !== crop.cropId), crop],
@@ -61,7 +122,8 @@ vi.mock('./data', () => ({
       this.issues = issues;
     }
   },
-}));
+  };
+});
 
 const buildBatchCreationState = () => ({
   schemaVersion: 1,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,6 +27,15 @@ import {
   mutateBatchAssignment,
   regenerateCalendarTasks,
   transitionBatchStage,
+  listCrops,
+  listSpecies,
+  listCropPlans,
+  listSegments,
+  upsertSpecies,
+  importCrops,
+  importSpecies,
+  importCropPlans,
+  importSegments,
   upsertBed,
   upsertCrop,
   upsertSeedInventoryItem,
@@ -3729,18 +3738,13 @@ function BatchesPage({
       if (!notes) {
         delete (nextSpecies as { notes?: string }).notes;
       }
-      const nextSpeciesCollection = (appState.species ?? []).map((entry) => (entry.id === existingSpecies.id ? nextSpecies : entry));
-      const nextState = assertValid('appState', {
-        ...appState,
-        species: nextSpeciesCollection,
-      });
-      const nextSpeciesById = buildSpeciesLookup(nextState.species);
-
-      await saveAppStateToIndexedDb(nextState);
+      await upsertSpecies(nextSpecies);
+      const [refreshedCrops, refreshedSpecies] = await Promise.all([listCrops(), listSpecies()]);
+      const nextSpeciesById = buildSpeciesLookup(refreshedSpecies);
       setSpeciesById(nextSpeciesById);
       setCropScientificNames(
         Object.fromEntries(
-          nextState.crops.map((crop) => [crop.cropId, getCropSpeciesScientificName(crop, nextSpeciesById)]),
+          refreshedCrops.map((crop) => [crop.cropId, getCropSpeciesScientificName(crop, nextSpeciesById)]),
         ),
       );
       setSpeciesEditErrors({});
@@ -3756,7 +3760,7 @@ function BatchesPage({
       );
       setFormValues((current) =>
         selectedCultivar &&
-        nextState.crops.some((crop) => crop.cropId === selectedCultivar.cropTypeId && (crop as Crop & { speciesId?: string }).speciesId === existingSpecies.id)
+        refreshedCrops.some((crop) => crop.cropId === selectedCultivar.cropTypeId && (crop as Crop & { speciesId?: string }).speciesId === existingSpecies.id)
           ? {
               ...current,
               cropInput:
@@ -3829,18 +3833,14 @@ function BatchesPage({
         ...(aliases.length > 0 ? { aliases } : {}),
         ...(notes ? { notes } : {}),
       };
-      const nextState = assertValid('appState', {
-        ...appState,
-        species: [...(appState.species ?? []), nextSpecies],
-      });
-      const nextSpeciesById = buildSpeciesLookup(nextState.species);
-
-      await saveAppStateToIndexedDb(nextState);
+      await upsertSpecies(nextSpecies);
+      const [refreshedCrops, refreshedSpecies] = await Promise.all([listCrops(), listSpecies()]);
+      const nextSpeciesById = buildSpeciesLookup(refreshedSpecies);
       setSpeciesById(nextSpeciesById);
       setEditingSpeciesId(speciesId);
       setCropScientificNames(
         Object.fromEntries(
-          nextState.crops.map((crop) => [crop.cropId, getCropSpeciesScientificName(crop, nextSpeciesById)]),
+          refreshedCrops.map((crop) => [crop.cropId, getCropSpeciesScientificName(crop, nextSpeciesById)]),
         ),
       );
       setSpeciesCreateValues({
@@ -7085,109 +7085,11 @@ function DataPage({ showDevResetButton, onResetToGoldenDataset }: DataPageProps)
     setImportErrors([]);
 
     try {
-      const existingAppState = await loadAppStateFromIndexedDb();
-      if (!existingAppState) {
-        setImportMessage('Crop import failed: local app state is unavailable.');
-        return;
-      }
-
-      const cropsById = new Map(existingAppState.crops.map((crop) => [crop.cropId, crop]));
-      const summary = { imported: 0, merged: 0, skipped: 0, rejected: 0 };
-      const results: Array<{ path: string; message: string }> = [];
-
-      pendingCropImportCrops.forEach((incomingCrop, index) => {
-        const currentCrop = cropsById.get(incomingCrop.cropId);
-
-        if (!currentCrop) {
-          cropsById.set(incomingCrop.cropId, incomingCrop);
-          summary.imported += 1;
-          return;
-        }
-
-        if (incomingCrop.createdAt !== currentCrop.createdAt) {
-          summary.rejected += 1;
-          results.push({
-            path: `/crops/${index}`,
-            message: `rejected (crop_identity_conflict): createdAt mismatch for cropId ${incomingCrop.cropId}`,
-          });
-          return;
-        }
-
-        const mergedCrop: Crop = {
-          ...currentCrop,
-          name: incomingCrop.name,
-          rules: incomingCrop.rules,
-          nutritionProfile: incomingCrop.nutritionProfile,
-          updatedAt: incomingCrop.updatedAt,
-        };
-
-        if (incomingCrop.aliases !== undefined) {
-          mergedCrop.aliases = incomingCrop.aliases;
-        }
-        if (incomingCrop.category !== undefined) {
-          mergedCrop.category = incomingCrop.category;
-        }
-        if (incomingCrop.cultivarGroup !== undefined) {
-          mergedCrop.cultivarGroup = incomingCrop.cultivarGroup;
-        }
-        if (incomingCrop.taskRules !== undefined) {
-          mergedCrop.taskRules = incomingCrop.taskRules;
-        }
-        const incomingCultivar = (incomingCrop as Crop & { cultivar?: string }).cultivar;
-        if (incomingCultivar !== undefined) {
-          (mergedCrop as Crop & { cultivar?: string }).cultivar = incomingCultivar;
-        }
-        const incomingSpeciesId = (incomingCrop as Crop & { speciesId?: string }).speciesId;
-        if (incomingSpeciesId !== undefined) {
-          (mergedCrop as Crop & { speciesId?: string }).speciesId = incomingSpeciesId;
-        }
-
-        const incomingSpecies = (incomingCrop as Crop & {
-          species?: { id?: string; commonName: string; scientificName: string; taxonomy?: { family?: string; genus?: string; species?: string } };
-        }).species;
-        const incomingTaxonomy = incomingCrop.taxonomy;
-
-        if (incomingSpecies !== undefined || incomingTaxonomy !== undefined) {
-          const currentSpecies = (currentCrop as Crop & {
-            species?: { id?: string; commonName: string; scientificName: string; taxonomy?: { family?: string; genus?: string; species?: string } };
-          }).species;
-          const commonName = incomingSpecies?.commonName ?? currentSpecies?.commonName;
-          const scientificName = incomingSpecies?.scientificName ?? currentSpecies?.scientificName;
-
-          if (commonName !== undefined && scientificName !== undefined) {
-            (mergedCrop as Crop & {
-              species?: { id?: string; commonName: string; scientificName: string; taxonomy?: { family?: string; genus?: string; species?: string } };
-            }).species = {
-              ...(currentSpecies?.id !== undefined ? { id: currentSpecies.id } : {}),
-              ...(incomingSpecies?.id !== undefined ? { id: incomingSpecies.id } : {}),
-              commonName,
-              scientificName,
-              ...((incomingTaxonomy !== undefined || incomingSpecies?.taxonomy !== undefined || currentSpecies?.taxonomy !== undefined)
-                ? {
-                    taxonomy: {
-                      ...(currentSpecies?.taxonomy ?? {}),
-                      ...(incomingTaxonomy ?? {}),
-                      ...(incomingSpecies?.taxonomy ?? {}),
-                    },
-                  }
-                : {}),
-            };
-          }
-        }
-
-        const unchanged = JSON.stringify(currentCrop) === JSON.stringify(mergedCrop);
-        cropsById.set(incomingCrop.cropId, mergedCrop);
-        if (unchanged) {
-          summary.skipped += 1;
-        } else {
-          summary.merged += 1;
-        }
-      });
-
-      await saveAppStateToIndexedDb({ ...existingAppState, crops: [...cropsById.values()] }, { mode: 'replace' });
-      setCropImportStatusSummary(summary);
-      setImportErrors(results);
-      setImportMessage(`Crop import complete. imported: ${summary.imported}, merged: ${summary.merged}, skipped: ${summary.skipped}, rejected: ${summary.rejected}.`);
+      const commandResult = await importCrops(pendingCropImportCrops);
+      await Promise.all([listCrops(), listSpecies()]);
+      setCropImportStatusSummary(commandResult.summary);
+      setImportErrors(commandResult.errors);
+      setImportMessage(`Crop import complete. imported: ${commandResult.summary.imported}, merged: ${commandResult.summary.merged}, skipped: ${commandResult.summary.skipped}, rejected: ${commandResult.summary.rejected}.`);
       setPendingCropImportCrops([]);
     } catch (error) {
       setImportMessage('Import failed while saving.');
@@ -7207,61 +7109,11 @@ function DataPage({ showDevResetButton, onResetToGoldenDataset }: DataPageProps)
     setImportErrors([]);
 
     try {
-      const existingAppState = await loadAppStateFromIndexedDb();
-      if (!existingAppState) {
-        setImportMessage('Species import failed: local app state is unavailable.');
-        return;
-      }
-
-      const speciesById = new Map((existingAppState.species ?? []).map((entry) => [entry.id, entry]));
-      const summary = { imported: 0, merged: 0, skipped: 0, rejected: 0 };
-      const results: Array<{ path: string; message: string }> = [];
-
-      pendingSpeciesImportSpecies.forEach((incomingSpecies, index) => {
-        const currentSpecies = speciesById.get(incomingSpecies.id);
-
-        if (!currentSpecies) {
-          speciesById.set(incomingSpecies.id, incomingSpecies);
-          summary.imported += 1;
-          return;
-        }
-
-        const mergedSpecies: Species = {
-          ...currentSpecies,
-          ...((incomingSpecies.commonName ?? currentSpecies.commonName) !== undefined
-            ? { commonName: incomingSpecies.commonName ?? currentSpecies.commonName }
-            : {}),
-          ...((incomingSpecies.scientificName ?? currentSpecies.scientificName) !== undefined
-            ? { scientificName: incomingSpecies.scientificName ?? currentSpecies.scientificName }
-            : {}),
-          ...((incomingSpecies.aliases ?? currentSpecies.aliases) !== undefined
-            ? { aliases: incomingSpecies.aliases ?? currentSpecies.aliases }
-            : {}),
-          ...((incomingSpecies.notes ?? currentSpecies.notes) !== undefined
-            ? { notes: incomingSpecies.notes ?? currentSpecies.notes }
-            : {}),
-        };
-
-        const unchanged = JSON.stringify(currentSpecies) === JSON.stringify(mergedSpecies);
-        speciesById.set(incomingSpecies.id, mergedSpecies);
-        if (unchanged) {
-          summary.skipped += 1;
-        } else {
-          summary.merged += 1;
-          if (currentSpecies.commonName !== incomingSpecies.commonName || currentSpecies.scientificName !== incomingSpecies.scientificName) {
-            results.push({
-              path: `/species/${index}`,
-              message: `merged (shared_reference_update): crop species references remain linked to ${incomingSpecies.id}`,
-            });
-          }
-        }
-      });
-
-      const nextState = { ...existingAppState, species: [...speciesById.values()] };
-      await saveAppStateToIndexedDb(nextState, { mode: 'replace' });
-      setSpeciesImportStatusSummary(summary);
-      setImportErrors(results);
-      setImportMessage(`Species import complete. imported: ${summary.imported}, merged: ${summary.merged}, skipped: ${summary.skipped}, rejected: ${summary.rejected}.`);
+      const commandResult = await importSpecies(pendingSpeciesImportSpecies);
+      await Promise.all([listSpecies(), listCrops()]);
+      setSpeciesImportStatusSummary(commandResult.summary);
+      setImportErrors(commandResult.errors);
+      setImportMessage(`Species import complete. imported: ${commandResult.summary.imported}, merged: ${commandResult.summary.merged}, skipped: ${commandResult.summary.skipped}, rejected: ${commandResult.summary.rejected}.`);
       setPendingSpeciesImportSpecies([]);
     } catch (error) {
       setImportMessage('Import failed while saving.');
@@ -7280,35 +7132,10 @@ function DataPage({ showDevResetButton, onResetToGoldenDataset }: DataPageProps)
     setImportMessage(null);
 
     try {
-      const existingAppState = await loadAppStateFromIndexedDb();
-      if (!existingAppState) {
-        setImportMessage('Crop plan import failed: local app state is unavailable.');
-        return;
-      }
-
-      const plansById = new Map(existingAppState.cropPlans.map((plan) => [plan.planId, plan]));
-      const summary = { imported: 0, merged: 0, skipped: 0, rejected: 0 };
-
-      pendingCropPlanImportPlans.forEach((incomingPlan) => {
-        const currentPlan = plansById.get(incomingPlan.planId);
-        if (!currentPlan) {
-          plansById.set(incomingPlan.planId, incomingPlan);
-          summary.imported += 1;
-          return;
-        }
-
-        const unchanged = JSON.stringify(currentPlan) === JSON.stringify(incomingPlan);
-        plansById.set(incomingPlan.planId, incomingPlan);
-        if (unchanged) {
-          summary.skipped += 1;
-        } else {
-          summary.merged += 1;
-        }
-      });
-
-      await saveAppStateToIndexedDb({ ...existingAppState, cropPlans: [...plansById.values()] }, { mode: 'replace' });
-      setCropPlanImportStatusSummary(summary);
-      setImportMessage(`Crop plan import complete. imported: ${summary.imported}, merged: ${summary.merged}, skipped: ${summary.skipped}, rejected: ${summary.rejected}.`);
+      const commandResult = await importCropPlans(pendingCropPlanImportPlans);
+      await listCropPlans();
+      setCropPlanImportStatusSummary(commandResult.summary);
+      setImportMessage(`Crop plan import complete. imported: ${commandResult.summary.imported}, merged: ${commandResult.summary.merged}, skipped: ${commandResult.summary.skipped}, rejected: ${commandResult.summary.rejected}.`);
       setPendingCropPlanImportPlans([]);
     } catch (error) {
       setImportMessage('Import failed while saving.');
@@ -7329,47 +7156,11 @@ function DataPage({ showDevResetButton, onResetToGoldenDataset }: DataPageProps)
     setImportErrors([]);
 
     try {
-      const existingAppState = await loadAppStateFromIndexedDb();
-      if (!existingAppState) {
-        setImportMessage('Segment import failed: local app state is unavailable.');
-        return;
-      }
-
-      const segmentsById = new Map((existingAppState.segments ?? []).map((segment) => [segment.segmentId, segment]));
-      const summary = { imported: 0, merged: 0, skipped: 0, rejected: 0 };
-      const results: Array<{ path: string; message: string }> = [];
-
-      pendingSegmentImportSegments.forEach((incomingSegment, index) => {
-        const currentSegment = segmentsById.get(incomingSegment.segmentId);
-
-        if (!currentSegment) {
-          segmentsById.set(incomingSegment.segmentId, incomingSegment);
-          summary.imported += 1;
-          return;
-        }
-
-        if (JSON.stringify(currentSegment) === JSON.stringify(incomingSegment)) {
-          summary.skipped += 1;
-          return;
-        }
-
-        if (currentSegment.name !== incomingSegment.name || currentSegment.originReference !== incomingSegment.originReference) {
-          summary.rejected += 1;
-          results.push({
-            path: `/segments/${index}`,
-            message: `rejected (segment_identity_conflict): identity mismatch for segmentId ${incomingSegment.segmentId}`,
-          });
-          return;
-        }
-
-        segmentsById.set(incomingSegment.segmentId, incomingSegment);
-        summary.merged += 1;
-      });
-
-      await saveAppStateToIndexedDb({ ...existingAppState, segments: [...segmentsById.values()] }, { mode: 'replace' });
-      setSegmentImportStatusSummary(summary);
-      setImportErrors(results);
-      setImportMessage(`Segment import complete. imported: ${summary.imported}, merged: ${summary.merged}, skipped: ${summary.skipped}, rejected: ${summary.rejected}.`);
+      const commandResult = await importSegments(pendingSegmentImportSegments);
+      await listSegments();
+      setSegmentImportStatusSummary(commandResult.summary);
+      setImportErrors(commandResult.errors);
+      setImportMessage(`Segment import complete. imported: ${commandResult.summary.imported}, merged: ${commandResult.summary.merged}, skipped: ${commandResult.summary.skipped}, rejected: ${commandResult.summary.rejected}.`);
       setPendingSegmentImportSegments([]);
       setPendingSegmentImportPreview([]);
     } catch (error) {

--- a/frontend/src/data/index.ts
+++ b/frontend/src/data/index.ts
@@ -1,4 +1,4 @@
-import type { AppState, Batch, Bed, Crop, CropPlan, SeedInventoryItem, Task } from '../contracts';
+import type { AppState, Batch, Bed, Crop, CropPlan, SeedInventoryItem, Segment, Species, Task } from '../contracts';
 import { SchemaValidationError, assertValid } from './validation';
 import { getSettingsOrDefault } from './repos/settingsRepository';
 import { mergeTaskForImport } from './repos/taskRepository';
@@ -1800,6 +1800,57 @@ export const getCrop = async (cropId: Crop['cropId']): Promise<Crop | null> => {
   return appState ? getCropFromAppStateLocal(appState, cropId) : null;
 };
 
+export const listSpecies = async (): Promise<Species[]> => {
+  if (shouldUseCanonicalWorkflowWithoutRollback('taxonomy')) {
+    return workflowAdapter.taxonomy.listSpecies();
+  }
+
+  const appState = await loadAppStateFromIndexedDb();
+  return appState?.species ?? [];
+};
+
+export const getSpecies = async (speciesId: Species['id']): Promise<Species | null> => {
+  if (shouldUseCanonicalWorkflowWithoutRollback('taxonomy')) {
+    return workflowAdapter.taxonomy.getSpecies(speciesId);
+  }
+
+  const appState = await loadAppStateFromIndexedDb();
+  return (appState?.species ?? []).find((species) => species.id === speciesId) ?? null;
+};
+
+export const upsertSpecies = async (species: unknown): Promise<Species> => {
+  const validatedSpecies = assertValid('species', species);
+
+  if (shouldUseCanonicalWorkflowWithoutRollback('taxonomy')) {
+    return assertValid('species', await workflowAdapter.taxonomy.upsertSpecies(validatedSpecies));
+  }
+
+  const appState = await loadAppStateFromIndexedDb();
+  const nextSpecies = (appState?.species ?? []).some((entry) => entry.id === validatedSpecies.id)
+    ? (appState?.species ?? []).map((entry) => (entry.id === validatedSpecies.id ? validatedSpecies : entry))
+    : [...(appState?.species ?? []), validatedSpecies];
+  const nextState = assertValid('appState', { ...(appState ?? createEmptyAppState(appState)), species: nextSpecies });
+  await saveAppStateToIndexedDb(nextState);
+  return validatedSpecies;
+};
+
+export const removeSpecies = async (speciesId: Species['id']): Promise<void> => {
+  if (shouldUseCanonicalWorkflowWithoutRollback('taxonomy')) {
+    await workflowAdapter.taxonomy.removeSpecies(speciesId);
+    return;
+  }
+
+  const appState = await loadAppStateFromIndexedDb();
+  if (!appState) {
+    return;
+  }
+
+  await saveAppStateToIndexedDb(assertValid('appState', {
+    ...appState,
+    species: (appState.species ?? []).filter((species) => species.id !== speciesId),
+  }));
+};
+
 export const listCrops = async (): Promise<Crop[]> => {
   if (shouldUseCanonicalWorkflowWithoutRollback('taxonomy')) {
     return workflowAdapter.taxonomy.listCrops();
@@ -1873,6 +1924,276 @@ export const removeCropPlan = async (planId: CropPlan['planId']): Promise<void> 
     return;
   }
   await saveAppStateToIndexedDb(removeCropPlanFromAppStateLocal(appState, planId));
+};
+
+type ImportStatusSummary = {
+  imported: number;
+  merged: number;
+  skipped: number;
+  rejected: number;
+};
+
+type ImportStatusIssue = {
+  path: string;
+  message: string;
+};
+
+type ImportCommandResult = {
+  summary: ImportStatusSummary;
+  errors: ImportStatusIssue[];
+};
+
+export const importCrops = async (crops: Crop[]): Promise<ImportCommandResult> => {
+  if (shouldUseCanonicalWorkflowWithoutRollback('taxonomy')) {
+    return workflowAdapter.taxonomy.importCrops(crops);
+  }
+
+  const existingAppState = await loadAppStateFromIndexedDb();
+  if (!existingAppState) {
+    throw new Error('Crop import failed: local app state is unavailable.');
+  }
+
+  const cropsById = new Map(existingAppState.crops.map((crop) => [crop.cropId, crop]));
+  const summary: ImportStatusSummary = { imported: 0, merged: 0, skipped: 0, rejected: 0 };
+  const errors: ImportStatusIssue[] = [];
+
+  crops.forEach((incomingCrop, index) => {
+    const currentCrop = cropsById.get(incomingCrop.cropId);
+
+    if (!currentCrop) {
+      cropsById.set(incomingCrop.cropId, incomingCrop);
+      summary.imported += 1;
+      return;
+    }
+
+    if (incomingCrop.createdAt !== currentCrop.createdAt) {
+      summary.rejected += 1;
+      errors.push({
+        path: `/crops/${index}`,
+        message: `rejected (crop_identity_conflict): createdAt mismatch for cropId ${incomingCrop.cropId}`,
+      });
+      return;
+    }
+
+    const mergedCrop: Crop = {
+      ...currentCrop,
+      name: incomingCrop.name,
+      rules: incomingCrop.rules,
+      nutritionProfile: incomingCrop.nutritionProfile,
+      updatedAt: incomingCrop.updatedAt,
+    };
+
+    if (incomingCrop.aliases !== undefined) {
+      mergedCrop.aliases = incomingCrop.aliases;
+    }
+    if (incomingCrop.category !== undefined) {
+      mergedCrop.category = incomingCrop.category;
+    }
+    if (incomingCrop.cultivarGroup !== undefined) {
+      mergedCrop.cultivarGroup = incomingCrop.cultivarGroup;
+    }
+    if (incomingCrop.taskRules !== undefined) {
+      mergedCrop.taskRules = incomingCrop.taskRules;
+    }
+    const incomingCultivar = (incomingCrop as Crop & { cultivar?: string }).cultivar;
+    if (incomingCultivar !== undefined) {
+      (mergedCrop as Crop & { cultivar?: string }).cultivar = incomingCultivar;
+    }
+    const incomingSpeciesId = (incomingCrop as Crop & { speciesId?: string }).speciesId;
+    if (incomingSpeciesId !== undefined) {
+      (mergedCrop as Crop & { speciesId?: string }).speciesId = incomingSpeciesId;
+    }
+
+    const incomingSpecies = (incomingCrop as Crop & {
+      species?: { id?: string; commonName: string; scientificName: string; taxonomy?: { family?: string; genus?: string; species?: string } };
+    }).species;
+    const incomingTaxonomy = incomingCrop.taxonomy;
+
+    if (incomingSpecies !== undefined || incomingTaxonomy !== undefined) {
+      const currentSpecies = (currentCrop as Crop & {
+        species?: { id?: string; commonName: string; scientificName: string; taxonomy?: { family?: string; genus?: string; species?: string } };
+      }).species;
+      const commonName = incomingSpecies?.commonName ?? currentSpecies?.commonName;
+      const scientificName = incomingSpecies?.scientificName ?? currentSpecies?.scientificName;
+
+      if (commonName !== undefined && scientificName !== undefined) {
+        (mergedCrop as Crop & {
+          species?: { id?: string; commonName: string; scientificName: string; taxonomy?: { family?: string; genus?: string; species?: string } };
+        }).species = {
+          ...(currentSpecies?.id !== undefined ? { id: currentSpecies.id } : {}),
+          ...(incomingSpecies?.id !== undefined ? { id: incomingSpecies.id } : {}),
+          commonName,
+          scientificName,
+          ...((incomingTaxonomy !== undefined || incomingSpecies?.taxonomy !== undefined || currentSpecies?.taxonomy !== undefined)
+            ? {
+                taxonomy: {
+                  ...(currentSpecies?.taxonomy ?? {}),
+                  ...(incomingTaxonomy ?? {}),
+                  ...(incomingSpecies?.taxonomy ?? {}),
+                },
+              }
+            : {}),
+        };
+      }
+    }
+
+    const unchanged = JSON.stringify(currentCrop) === JSON.stringify(mergedCrop);
+    cropsById.set(incomingCrop.cropId, mergedCrop);
+    if (unchanged) {
+      summary.skipped += 1;
+    } else {
+      summary.merged += 1;
+    }
+  });
+
+  await saveAppStateToIndexedDb({ ...existingAppState, crops: [...cropsById.values()] }, { mode: 'replace' });
+  return { summary, errors };
+};
+
+export const importSpecies = async (species: Species[]): Promise<ImportCommandResult> => {
+  if (shouldUseCanonicalWorkflowWithoutRollback('taxonomy')) {
+    return workflowAdapter.taxonomy.importSpecies(species);
+  }
+
+  const existingAppState = await loadAppStateFromIndexedDb();
+  if (!existingAppState) {
+    throw new Error('Species import failed: local app state is unavailable.');
+  }
+
+  const speciesById = new Map((existingAppState.species ?? []).map((entry) => [entry.id, entry]));
+  const summary: ImportStatusSummary = { imported: 0, merged: 0, skipped: 0, rejected: 0 };
+  const errors: ImportStatusIssue[] = [];
+
+  species.forEach((incomingSpecies, index) => {
+    const currentSpecies = speciesById.get(incomingSpecies.id);
+
+    if (!currentSpecies) {
+      speciesById.set(incomingSpecies.id, incomingSpecies);
+      summary.imported += 1;
+      return;
+    }
+
+    const mergedSpecies: Species = {
+      ...currentSpecies,
+      ...((incomingSpecies.commonName ?? currentSpecies.commonName) !== undefined
+        ? { commonName: incomingSpecies.commonName ?? currentSpecies.commonName }
+        : {}),
+      ...((incomingSpecies.scientificName ?? currentSpecies.scientificName) !== undefined
+        ? { scientificName: incomingSpecies.scientificName ?? currentSpecies.scientificName }
+        : {}),
+      ...((incomingSpecies.aliases ?? currentSpecies.aliases) !== undefined
+        ? { aliases: incomingSpecies.aliases ?? currentSpecies.aliases }
+        : {}),
+      ...((incomingSpecies.notes ?? currentSpecies.notes) !== undefined
+        ? { notes: incomingSpecies.notes ?? currentSpecies.notes }
+        : {}),
+    };
+
+    const unchanged = JSON.stringify(currentSpecies) === JSON.stringify(mergedSpecies);
+    speciesById.set(incomingSpecies.id, mergedSpecies);
+    if (unchanged) {
+      summary.skipped += 1;
+    } else {
+      summary.merged += 1;
+      if (currentSpecies.commonName !== incomingSpecies.commonName || currentSpecies.scientificName !== incomingSpecies.scientificName) {
+        errors.push({
+          path: `/species/${index}`,
+          message: `merged (shared_reference_update): crop species references remain linked to ${incomingSpecies.id}`,
+        });
+      }
+    }
+  });
+
+  await saveAppStateToIndexedDb({ ...existingAppState, species: [...speciesById.values()] }, { mode: 'replace' });
+  return { summary, errors };
+};
+
+export const importCropPlans = async (cropPlans: CropPlan[]): Promise<ImportCommandResult> => {
+  if (shouldUseCanonicalWorkflowWithoutRollback('taxonomy')) {
+    return workflowAdapter.taxonomy.importCropPlans(cropPlans);
+  }
+
+  const existingAppState = await loadAppStateFromIndexedDb();
+  if (!existingAppState) {
+    throw new Error('Crop plan import failed: local app state is unavailable.');
+  }
+
+  const plansById = new Map(existingAppState.cropPlans.map((plan) => [plan.planId, plan]));
+  const summary: ImportStatusSummary = { imported: 0, merged: 0, skipped: 0, rejected: 0 };
+
+  cropPlans.forEach((incomingPlan) => {
+    const currentPlan = plansById.get(incomingPlan.planId);
+    if (!currentPlan) {
+      plansById.set(incomingPlan.planId, incomingPlan);
+      summary.imported += 1;
+      return;
+    }
+
+    const unchanged = JSON.stringify(currentPlan) === JSON.stringify(incomingPlan);
+    plansById.set(incomingPlan.planId, incomingPlan);
+    if (unchanged) {
+      summary.skipped += 1;
+    } else {
+      summary.merged += 1;
+    }
+  });
+
+  await saveAppStateToIndexedDb({ ...existingAppState, cropPlans: [...plansById.values()] }, { mode: 'replace' });
+  return { summary, errors: [] };
+};
+
+export const listSegments = async (): Promise<Segment[]> => {
+  if (shouldUseCanonicalWorkflowWithoutRollback('bedsSegments')) {
+    return workflowAdapter.bedsSegments.listSegments();
+  }
+
+  const appState = await loadAppStateFromIndexedDb();
+  return appState?.segments ?? [];
+};
+
+export const importSegments = async (segments: Segment[]): Promise<ImportCommandResult> => {
+  if (shouldUseCanonicalWorkflowWithoutRollback('bedsSegments')) {
+    return workflowAdapter.bedsSegments.importSegments(segments);
+  }
+
+  const existingAppState = await loadAppStateFromIndexedDb();
+  if (!existingAppState) {
+    throw new Error('Segment import failed: local app state is unavailable.');
+  }
+
+  const segmentsById = new Map((existingAppState.segments ?? []).map((segment) => [segment.segmentId, segment]));
+  const summary: ImportStatusSummary = { imported: 0, merged: 0, skipped: 0, rejected: 0 };
+  const errors: ImportStatusIssue[] = [];
+
+  segments.forEach((incomingSegment, index) => {
+    const currentSegment = segmentsById.get(incomingSegment.segmentId);
+
+    if (!currentSegment) {
+      segmentsById.set(incomingSegment.segmentId, incomingSegment);
+      summary.imported += 1;
+      return;
+    }
+
+    if (JSON.stringify(currentSegment) === JSON.stringify(incomingSegment)) {
+      summary.skipped += 1;
+      return;
+    }
+
+    if (currentSegment.name !== incomingSegment.name || currentSegment.originReference !== incomingSegment.originReference) {
+      summary.rejected += 1;
+      errors.push({
+        path: `/segments/${index}`,
+        message: `rejected (segment_identity_conflict): identity mismatch for segmentId ${incomingSegment.segmentId}`,
+      });
+      return;
+    }
+
+    segmentsById.set(incomingSegment.segmentId, incomingSegment);
+    summary.merged += 1;
+  });
+
+  await saveAppStateToIndexedDb({ ...existingAppState, segments: [...segmentsById.values()] }, { mode: 'replace' });
+  return { summary, errors };
 };
 
 export const getSeedInventoryItem = async (

--- a/frontend/src/data/workflowAdapter.ts
+++ b/frontend/src/data/workflowAdapter.ts
@@ -1,4 +1,4 @@
-import type { AppState, Batch, Bed, Crop, CropPlan, SeedInventoryItem, Segment } from '../contracts';
+import type { AppState, Batch, Bed, Crop, CropPlan, SeedInventoryItem, Segment, Species } from '../contracts';
 import { assertValid } from './validation';
 import type { SchemaName, SchemaTypeMap } from './validation';
 import type { BackendApiPath } from '../generated/api-client';
@@ -202,6 +202,76 @@ const assertContractList = <T extends SchemaName>(
   return payload.map((item, index) => assertContract(`${contractName}[${index}]`, schemaName, item));
 };
 
+type ImportSummary = {
+  imported: number;
+  merged: number;
+  skipped: number;
+  rejected: number;
+};
+
+type ImportIssue = {
+  path: string;
+  message: string;
+};
+
+type ImportCommandResult = {
+  summary: ImportSummary;
+  errors: ImportIssue[];
+};
+
+const assertImportSummary = (contractName: string, payload: unknown): ImportSummary => {
+  if (!payload || typeof payload !== 'object') {
+    throw buildContractMismatchError(contractName, new Error('expected object payload'));
+  }
+
+  const summary = payload as Record<string, unknown>;
+  const getNumber = (key: keyof ImportSummary): number => {
+    const value = summary[key];
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+      throw buildContractMismatchError(contractName, new Error(`expected numeric ${key}`));
+    }
+    return value;
+  };
+
+  return {
+    imported: getNumber('imported'),
+    merged: getNumber('merged'),
+    skipped: getNumber('skipped'),
+    rejected: getNumber('rejected'),
+  };
+};
+
+const assertImportIssues = (contractName: string, payload: unknown): ImportIssue[] => {
+  if (!Array.isArray(payload)) {
+    return [];
+  }
+
+  return payload.map((entry, index) => {
+    if (!entry || typeof entry !== 'object') {
+      throw buildContractMismatchError(contractName, new Error(`errors[${index}] must be an object`));
+    }
+
+    const issue = entry as Record<string, unknown>;
+    if (typeof issue.path !== 'string' || typeof issue.message !== 'string') {
+      throw buildContractMismatchError(contractName, new Error(`errors[${index}] must include string path/message`));
+    }
+
+    return { path: issue.path, message: issue.message };
+  });
+};
+
+const assertImportCommandResult = (contractName: string, payload: unknown): ImportCommandResult => {
+  if (!payload || typeof payload !== 'object') {
+    throw buildContractMismatchError(contractName, new Error('expected object payload'));
+  }
+
+  const typedPayload = payload as Record<string, unknown>;
+  return {
+    summary: assertImportSummary(`${contractName}.summary`, typedPayload.summary),
+    errors: assertImportIssues(`${contractName}.errors`, typedPayload.errors),
+  };
+};
+
 export const workflowAdapter = {
   batches: {
     upsertBatch: async (batch: Batch): Promise<Batch> =>
@@ -319,8 +389,41 @@ export const workflowAdapter = {
         throw new Error(await parseBackendError(response));
       }
     },
+    importSegments: async (segments: Segment[]): Promise<ImportCommandResult> =>
+      assertImportCommandResult('bedsSegments.importSegments', await fetchJson<unknown>('/api/import/segments', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ segments }),
+      })),
   },
   taxonomy: {
+    listSpecies: async (): Promise<Species[]> =>
+      assertContractList('taxonomy.listSpecies', 'species', await fetchJson<unknown>(backendPath('/api/species'), { method: 'GET' })),
+    getSpecies: async (speciesId: string): Promise<Species | null> => {
+      const response = await fetch(toBackendApiUrl(`/api/species/${encodeURIComponent(speciesId)}`), { method: 'GET' });
+      if (response.status === 404) {
+        return null;
+      }
+      if (!response.ok) {
+        throw new Error(await parseBackendError(response));
+      }
+      return assertContract('taxonomy.getSpecies', 'species', await response.json());
+    },
+    upsertSpecies: async (species: Species): Promise<Species> =>
+      assertContract('taxonomy.upsertSpecies', 'species', await fetchJson<unknown>(`/api/species/${encodeURIComponent(species.id)}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(species),
+      })),
+    removeSpecies: async (speciesId: string): Promise<void> => {
+      const response = await fetch(toBackendApiUrl(`/api/species/${encodeURIComponent(speciesId)}`), { method: 'DELETE' });
+      if (response.status === 404 || response.status === 204) {
+        return;
+      }
+      if (!response.ok) {
+        throw new Error(await parseBackendError(response));
+      }
+    },
     listCrops: async (): Promise<Crop[]> =>
       assertContractList('taxonomy.listCrops', 'crop', await fetchJson<unknown>(backendPath('/api/crops'), { method: 'GET' })),
     getCrop: async (cropId: string): Promise<Crop | null> => {
@@ -375,6 +478,24 @@ export const workflowAdapter = {
         throw new Error(await parseBackendError(response));
       }
     },
+    importSpecies: async (species: Species[]): Promise<ImportCommandResult> =>
+      assertImportCommandResult('taxonomy.importSpecies', await fetchJson<unknown>('/api/import/species', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ species }),
+      })),
+    importCrops: async (crops: Crop[]): Promise<ImportCommandResult> =>
+      assertImportCommandResult('taxonomy.importCrops', await fetchJson<unknown>('/api/import/crops', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ crops }),
+      })),
+    importCropPlans: async (cropPlans: CropPlan[]): Promise<ImportCommandResult> =>
+      assertImportCommandResult('taxonomy.importCropPlans', await fetchJson<unknown>('/api/import/crop-plans', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ cropPlans }),
+      })),
   },
   inventory: {
     listSeedInventoryItems: async (): Promise<SeedInventoryItem[]> =>


### PR DESCRIPTION
### Motivation
- Move species/crop/crop-plan/segment write and import logic out of the UI layer so commands route through the centralized data layer. 
- Prefer backend-first routing and contract validation for imports and taxonomy writes to ensure server parity and stronger runtime validation. 
- Keep UI handlers simple and refresh state from canonical query results after a backend-backed command completes instead of composing and persisting canonical app-state objects locally.

### Description
- Replaced direct `saveAppStateToIndexedDb(...)` and in-UI canonical object assembly in species admin and the crop/crop-plan/species/segment import confirm handlers with data-layer command calls from `frontend/src/data/index.ts` (added `upsertSpecies`, `listSpecies`, `getSpecies`, `removeSpecies`, `importCrops`, `importSpecies`, `importCropPlans`, `importSegments`, `listSegments`).
- Added backend request implementations and import result contract validation in `frontend/src/data/workflowAdapter.ts` (species CRUD endpoints and `/api/import/*` endpoints) and introduced typed import result assertions to surface server-side validation results safely.
- Updated `frontend/src/App.tsx` handlers to call the new data-layer commands and then refresh UI state from query functions (`listCrops`, `listSpecies`, `listCropPlans`, `listSegments`) and to use the import command result summaries/errors for messages, instead of using locally-assembled post-mutation app state.
- Preserved existing TypeScript/local IndexedDB fallback behavior via `shouldUseCanonicalWorkflowWithoutRollback` and reused existing `saveAppStateToIndexedDb` logic when backend routing is not enabled.

### Testing
- Ran `npm --prefix frontend run typecheck` which completed successfully. 
- Ran `npm --prefix frontend run lint` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea356fb89c8326aec8224ed9495138)