### PR TITLE
test: assert command/query flows for species and segment imports

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1224,17 +1224,16 @@ describe('App', () => {
 
 
   it('keeps a created species after command save and query refresh on the taxonomy page', async () => {
-    const createdSpecies = {
-      id: 'species_pea',
-      commonName: 'Pea',
-      scientificName: 'Pisum sativum',
-      createdAt: '2026-01-01T00:00:00Z',
-      updatedAt: '2026-01-01T00:00:00Z',
-    };
     let persistedAppState = {
       schemaVersion: 1,
       beds: [],
-      species: [] as Array<typeof createdSpecies>,
+      species: [] as Array<{
+        id: string;
+        commonName: string;
+        scientificName: string;
+        createdAt: string;
+        updatedAt: string;
+      }>,
       crops: [],
       cropPlans: [],
       batches: [],
@@ -1256,7 +1255,13 @@ describe('App', () => {
     vi.mocked(upsertSpecies).mockImplementation(async (species) => {
       persistedAppState = {
         ...persistedAppState,
-        species: [...persistedAppState.species, species as typeof createdSpecies],
+        species: [...persistedAppState.species, species as {
+          id: string;
+          commonName: string;
+          scientificName: string;
+          createdAt: string;
+          updatedAt: string;
+        }],
       };
       return species as never;
     });

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -22,12 +22,17 @@ import {
   assertValid,
   initializeAppStateStorage,
   loadAppStateFromIndexedDb,
+  listCrops,
+  listSegments,
+  listSpecies,
   parseImportedAppState,
   resetToGoldenDataset,
   saveAppStateToIndexedDb,
   SchemaValidationError,
   serializeAppStateForExport,
+  importSegments,
   upsertBatch,
+  upsertSpecies,
   upsertSegment,
 } from './data';
 
@@ -738,6 +743,20 @@ describe('App', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Import segments' }));
 
     await waitFor(() => {
+      expect(importSegments).toHaveBeenCalledTimes(1);
+      expect(importSegments).toHaveBeenCalledWith(expect.arrayContaining([
+        expect.objectContaining({
+          segmentId: 'segment_new',
+          name: 'North Segment',
+          beds: expect.arrayContaining([expect.objectContaining({ bedId: 'bed_n1' })]),
+          paths: expect.arrayContaining([expect.objectContaining({ pathId: 'path_north_1' })]),
+        }),
+        expect.objectContaining({
+          segmentId: 'segment_existing',
+          name: 'Existing Segment',
+        }),
+      ]));
+      expect(listSegments).toHaveBeenCalledTimes(1);
       expect(screen.getByText('Segment Import Summary')).toBeInTheDocument();
       expect(screen.getByText('imported: 1')).toBeInTheDocument();
       expect(screen.getByText('merged: 0')).toBeInTheDocument();
@@ -807,6 +826,15 @@ describe('App', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Import segments' }));
 
     await waitFor(() => {
+      expect(importSegments).toHaveBeenCalledTimes(1);
+      expect(importSegments).toHaveBeenCalledWith(expect.arrayContaining([
+        expect.objectContaining({
+          segmentId: 'segment_north',
+          name: 'Conflicting Name',
+          originReference: 'se_corner',
+        }),
+      ]));
+      expect(listSegments).toHaveBeenCalledTimes(1);
       expect(screen.getByText('rejected (segment_identity_conflict): 1')).toBeInTheDocument();
       expect(screen.getByText(/rejected \(segment_identity_conflict\): identity mismatch for segmentId segment_north/)).toBeInTheDocument();
     });
@@ -991,12 +1019,14 @@ describe('App', () => {
 
     expect(screen.getByText('Size: 5.8 m × 4.5 m')).toBeInTheDocument();
     expect(screen.getByText('Types: vegetable_bed')).toBeInTheDocument();
-    expect(saveAppStateToIndexedDb).not.toHaveBeenCalledWith(expect.objectContaining({ segments: expect.anything() }), { mode: 'replace' });
+    expect(importSegments).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByRole('button', { name: 'Import segments' }));
 
     await waitFor(() => {
-      expect(saveAppStateToIndexedDb).toHaveBeenCalledWith(expect.objectContaining({ segments: validSegmentState.segments }), { mode: 'replace' });
+      expect(importSegments).toHaveBeenCalledTimes(1);
+      expect(importSegments).toHaveBeenCalledWith(validSegmentState.segments);
+      expect(listSegments).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -1193,11 +1223,18 @@ describe('App', () => {
   });
 
 
-  it('keeps a created species after save and reload on the batches page', async () => {
+  it('keeps a created species after command save and query refresh on the taxonomy page', async () => {
+    const createdSpecies = {
+      id: 'species_pea',
+      commonName: 'Pea',
+      scientificName: 'Pisum sativum',
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+    };
     let persistedAppState = {
       schemaVersion: 1,
       beds: [],
-      species: [],
+      species: [] as Array<typeof createdSpecies>,
       crops: [],
       cropPlans: [],
       batches: [],
@@ -1214,9 +1251,14 @@ describe('App', () => {
     };
 
     vi.mocked(loadAppStateFromIndexedDb).mockImplementation(async () => persistedAppState as never);
-    vi.mocked(saveAppStateToIndexedDb).mockImplementation(async (nextState) => {
-      persistedAppState = nextState as typeof persistedAppState;
-      return undefined as never;
+    vi.mocked(listCrops).mockImplementation(async () => persistedAppState.crops as never);
+    vi.mocked(listSpecies).mockImplementation(async () => persistedAppState.species as never);
+    vi.mocked(upsertSpecies).mockImplementation(async (species) => {
+      persistedAppState = {
+        ...persistedAppState,
+        species: [...persistedAppState.species, species as typeof createdSpecies],
+      };
+      return species as never;
     });
 
     const { unmount } = render(
@@ -1239,16 +1281,16 @@ describe('App', () => {
     fireEvent.click(within(form).getByRole('button', { name: 'Create species' }));
 
     await waitFor(() => {
-      expect(saveAppStateToIndexedDb).toHaveBeenCalledWith(expect.objectContaining({
-        species: [
-          expect.objectContaining({
-            id: 'species_pea',
-            commonName: 'Pea',
-            scientificName: 'Pisum sativum',
-          }),
-        ],
+      expect(upsertSpecies).toHaveBeenCalledTimes(1);
+      expect(upsertSpecies).toHaveBeenCalledWith(expect.objectContaining({
+        id: 'species_pea',
+        commonName: 'Pea',
+        scientificName: 'Pisum sativum',
       }));
+      expect(listCrops).toHaveBeenCalledTimes(1);
+      expect(listSpecies).toHaveBeenCalledTimes(1);
       expect(screen.getByText('Species created.')).toBeInTheDocument();
+      expect(screen.getAllByRole('option', { name: 'Pea (Pisum sativum)' })).toHaveLength(2);
     });
 
     unmount();


### PR DESCRIPTION
### Motivation
- Tests previously asserted direct persistence via `saveAppStateToIndexedDb` which couples tests to legacy storage paths instead of the current command/query API surface.
- Update flow-specific tests to validate that the intended command functions are invoked with correct payloads and that UI refreshes use query-derived state.

### Description
- Added command/query imports to `frontend/src/App.test.tsx` (`listCrops`, `listSpecies`, `listSegments`, `importSegments`, `upsertSpecies`) and updated the test mocks accordingly.
- Refactored the species-creation test to mock `upsertSpecies` and `list*` queries, assert `upsertSpecies` invocation count and payload shape, and assert UI refresh from `listSpecies`/`listCrops`-derived state.
- Updated segment import tests (preview, conflict, deep-link) to assert `importSegments` invocation count and per-entity payload shape and to assert post-command refresh via `listSegments`.
- Removed assertions that relied on `saveAppStateToIndexedDb(..., { mode: 'replace' })` for segment import flows and replaced them with command-path authoritative assertions.

### Testing
- Ran the frontend test file with `cd frontend && npm test -- src/App.test.tsx`, and all tests in that file passed (`32 tests passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb6a6c414c8326a9a8b5964c3fba49)