### PR TITLE
Route full app-state import/reset writes through command APIs

### DIFF
--- a/frontend/docs/entity-migration-checklist.md
+++ b/frontend/docs/entity-migration-checklist.md
@@ -58,3 +58,8 @@ This checklist tracks command/query migration progress for write workflows acros
 - [x] Post-write layout refresh uses query/read path (`listSegments`, `listBeds`, plus mirrored state read for batches).
 - [x] Segment and batch import confirmation paths now route through command APIs instead of direct canonical merge persistence.
 
+## Full App-State Import / Reset
+- [x] Added `replaceCanonicalAppState` command in `frontend/src/data/index.ts` for full-state replace flows.
+- [x] `frontend/src/data/workflowAdapter.ts` now exposes `appState.replace` backend write command for canonical app-state replacement.
+- [x] `frontend/src/App.tsx` full import confirmations (Recovery + Data page) now use command path instead of direct `saveAppStateToIndexedDb(..., { mode: 'replace' })`.
+- [x] `frontend/src/App.tsx` "Empty all data" reset flow now writes via command path and re-reads state using query/read APIs for post-write validation and UI refresh.

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -39,6 +39,10 @@ import {
 vi.mock('./data', () => {
   const saveAppStateToIndexedDb = vi.fn().mockResolvedValue(undefined);
   const loadAppStateFromIndexedDb = vi.fn().mockResolvedValue(null);
+  const replaceCanonicalAppState = vi.fn(async (state: unknown) => {
+    await saveAppStateToIndexedDb(state, { mode: 'replace' });
+    return state;
+  });
 
   return {
     initializeAppStateStorage: vi.fn().mockResolvedValue(undefined),
@@ -46,6 +50,7 @@ vi.mock('./data', () => {
     loadAppStateFromIndexedDb,
     parseImportedAppState: vi.fn(),
     saveAppStateToIndexedDb,
+    replaceCanonicalAppState,
     serializeAppStateForExport: vi.fn().mockReturnValue('{"schemaVersion":1}'),
     assertValid: vi.fn((schemaName: string, value: unknown) => value),
     listCrops: vi.fn(async () => (await loadAppStateFromIndexedDb())?.crops ?? []),

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,10 +13,10 @@ import {
   loadPhotoBlobFromIndexedDb,
   resetToGoldenDataset,
   parseImportedAppState,
+  replaceCanonicalAppState,
   removeBed,
   removeBatch,
   removeSeedInventoryItem,
-  saveAppStateToIndexedDb,
   savePhotoBlobToIndexedDb,
   serializeAppStateForExport,
   listSeedInventoryItemsFromAppState,
@@ -6293,7 +6293,8 @@ export function RecoveryScreen({ error, onRetry, showDevResetButton = false }: R
     setImportMessage(null);
 
     try {
-      await saveAppStateToIndexedDb(pendingImportState, { mode: 'replace' });
+      await replaceCanonicalAppState(pendingImportState);
+      await loadAppStateFromIndexedDb();
       setPendingImportState(null);
       setImportMessage('Import complete. Existing data was replaced.');
     } catch (importError) {
@@ -7024,7 +7025,8 @@ function DataPage({ showDevResetButton, onResetToGoldenDataset }: DataPageProps)
     setImportErrors([]);
 
     try {
-      await saveAppStateToIndexedDb(pendingImportState, { mode: 'replace' });
+      await replaceCanonicalAppState(pendingImportState);
+      await loadAppStateFromIndexedDb();
       setPendingImportState(null);
       setImportMessage('Import complete. Existing data was replaced.');
     } catch (error) {
@@ -7206,9 +7208,7 @@ function DataPage({ showDevResetButton, onResetToGoldenDataset }: DataPageProps)
     try {
       const currentState = await loadAppStateFromIndexedDb();
       const emptyState = createEmptyAppState(currentState);
-
-      await saveAppStateToIndexedDb(emptyState, { mode: 'replace' });
-      const validatedEmptyState = await loadAppStateFromIndexedDb();
+      const validatedEmptyState = await replaceCanonicalAppState(emptyState);
 
       if (
         !validatedEmptyState
@@ -7239,15 +7239,15 @@ function DataPage({ showDevResetButton, onResetToGoldenDataset }: DataPageProps)
       setImportErrors([]);
       setImportMessage(null);
       setEmptyAllDataRecordCounts({
-        species: 0,
-        crops: 0,
-        segments: 0,
-        beds: 0,
-        paths: 0,
-        cropPlans: 0,
-        batches: 0,
-        tasks: 0,
-        seedInventoryItems: 0,
+        species: (validatedEmptyState.species ?? []).length,
+        crops: validatedEmptyState.crops.length,
+        segments: (validatedEmptyState.segments ?? []).length,
+        beds: listBedsFromAppState(validatedEmptyState).length,
+        paths: (validatedEmptyState.segments ?? []).reduce((total, segment) => total + segment.paths.length, 0),
+        cropPlans: validatedEmptyState.cropPlans.length,
+        batches: validatedEmptyState.batches.length,
+        tasks: validatedEmptyState.tasks.length,
+        seedInventoryItems: validatedEmptyState.seedInventoryItems.length,
       });
       setEmptyAllDataConfirmed(false);
       setEmptyAllDataConfirmationText('');

--- a/frontend/src/data/index.ts
+++ b/frontend/src/data/index.ts
@@ -1900,6 +1900,31 @@ type ImportCommandResult = {
   errors: ImportStatusIssue[];
 };
 
+export const replaceCanonicalAppState = async (appState: unknown): Promise<AppState> => {
+  const candidateState =
+    appState && typeof appState === 'object'
+      ? {
+          ...(appState as Record<string, unknown>),
+          settings: getSettingsOrDefault((appState as { settings?: unknown }).settings),
+        }
+      : appState;
+  const canonicalState = canonicalizeForExport(assertValid('appState', candidateState));
+
+  if (isBackendModeEnabled()) {
+    await workflowAdapter.appState.replace(canonicalState);
+    await syncLocalMirrorFromBackend();
+  } else {
+    await saveAppStateToLocalIndexedDb(canonicalState, { mode: 'replace' });
+  }
+
+  const refreshedState = await loadAppStateFromIndexedDb();
+  if (!refreshedState) {
+    throw new AppStateStorageError('Canonical app state replacement completed but no readable state was returned.');
+  }
+
+  return refreshedState;
+};
+
 export const importCrops = async (crops: Crop[]): Promise<ImportCommandResult> => {
   const result = await workflowAdapter.taxonomy.importCrops(crops);
   await syncLocalMirrorFromBackend();

--- a/frontend/src/data/workflowAdapter.ts
+++ b/frontend/src/data/workflowAdapter.ts
@@ -285,6 +285,19 @@ const assertImportCommandResult = (contractName: string, payload: unknown): Impo
 };
 
 export const workflowAdapter = {
+  appState: {
+    replace: async (appState: AppState): Promise<void> => {
+      const response = await fetch(toBackendApiUrl('/api/app-state'), {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(appState),
+      });
+
+      if (!response.ok) {
+        throw new Error(await parseBackendError(response));
+      }
+    },
+  },
   batches: {
     upsertBatch: async (batch: Batch): Promise<Batch> =>
       assertContract('batches.upsertBatch', 'batch', await fetchJson<unknown>(`/api/batches/${encodeURIComponent(batch.batchId)}`, {


### PR DESCRIPTION
### Motivation
- Replace direct UI writes that used `saveAppStateToIndexedDb(..., { mode: 'replace' })` with canonical backend command paths so the backend is authoritative for full-state replace and local mirror refreshes.
- Ensure full-import, recovery, and empty/reset flows follow the same workflow pattern used by other command APIs (validate/canonicalize -> backend write via `workflowAdapter` -> refresh local mirror -> re-read via query APIs).

### Description
- Added `workflowAdapter.appState.replace` to `frontend/src/data/workflowAdapter.ts` to POST canonical full-app-state replacements to `/api/app-state` with backend error parsing.
- Added `replaceCanonicalAppState` to `frontend/src/data/index.ts` to validate/canonicalize payloads, invoke the adapter command in backend mode (or fall back to local write), sync the local mirror, and return the refreshed `AppState` from `loadAppStateFromIndexedDb`.
- Replaced direct `saveAppStateToIndexedDb(..., { mode: 'replace' })` calls in `frontend/src/App.tsx` (Recovery import confirm, Data import confirm, and Empty-all-data reset) with `replaceCanonicalAppState` and ensured UI refreshes use `loadAppStateFromIndexedDb`/query helpers afterward; UI-only preview/draft state remains local.
- Updated `frontend/docs/entity-migration-checklist.md` marking full app-state import/reset write paths as migrated to command APIs.

### Testing
- Ran type checking with `npm --prefix frontend run typecheck` and it succeeded without errors.
- Executed the adapter unit tests with `npm --prefix frontend run test -- src/data/workflowAdapter.test.ts` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef66284a648326a9981257f2ea571a)