### PR TITLE
Switch batch imports to backend command response flow

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -31,6 +31,7 @@ import {
   SchemaValidationError,
   serializeAppStateForExport,
   importSegments,
+  importBatches,
   upsertBatch,
   upsertSpecies,
   upsertSegment,
@@ -74,6 +75,7 @@ vi.mock('./data', () => {
     importCrops: vi.fn(async () => ({ summary: { imported: 0, merged: 0, skipped: 0, rejected: 0 }, errors: [] })),
     importSpecies: vi.fn(async () => ({ summary: { imported: 0, merged: 0, skipped: 0, rejected: 0 }, errors: [] })),
     importCropPlans: vi.fn(async () => ({ summary: { imported: 0, merged: 0, skipped: 0, rejected: 0 }, errors: [] })),
+    importBatches: vi.fn(async () => ({ summary: { imported: 0, merged: 0, skipped: 0, rejected: 0 }, errors: [] })),
     importSegments: vi.fn(async (segments: Array<{ segmentId: string; name: string; originReference?: string }>) => {
       const state = await loadAppStateFromIndexedDb();
       const summary = { imported: 0, merged: 0, skipped: 0, rejected: 0 };
@@ -653,7 +655,7 @@ describe('App', () => {
       expect(screen.getByText(/local_precheck_warning \(batchId: batch-invalid, field: startedAt\)/)).toBeInTheDocument();
     });
 
-    expect(upsertBatch).not.toHaveBeenCalled();
+    expect(importBatches).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
     expect(screen.queryByText('Import Preview')).not.toBeInTheDocument();
@@ -662,16 +664,23 @@ describe('App', () => {
     await waitFor(() => {
       expect(screen.getByText('Import Preview')).toBeInTheDocument();
     });
+    vi.mocked(importBatches).mockResolvedValueOnce({
+      summary: { imported: 2, merged: 3, skipped: 1, rejected: 4 },
+      errors: [{ path: '/batches/0', message: 'rejected (batch_identity_conflict): duplicate batch id batch-1' }],
+    });
 
     fireEvent.click(screen.getByRole('button', { name: 'Import' }));
 
     await waitFor(() => {
-      expect(upsertBatch).toHaveBeenCalledTimes(1);
+      expect(importBatches).toHaveBeenCalledTimes(1);
       expect(screen.getByText('Collision Status Summary')).toBeInTheDocument();
-      expect(screen.getByText('skipped (identical_batch): 0')).toBeInTheDocument();
-      expect(screen.getByText('merged (eventsAdded): 0')).toBeInTheDocument();
-      expect(screen.getByText('rejected (batch_identity_conflict): 0')).toBeInTheDocument();
+      expect(screen.getByText('created (imported): 2')).toBeInTheDocument();
+      expect(screen.getByText('skipped (identical_batch): 1')).toBeInTheDocument();
+      expect(screen.getByText('merged (eventsAdded): 3')).toBeInTheDocument();
+      expect(screen.getByText('rejected (batch_identity_conflict): 4')).toBeInTheDocument();
       expect(screen.getByText('renamed (newId): 0')).toBeInTheDocument();
+      expect(screen.getByText(/Batch import complete\. Created: 2\./)).toBeInTheDocument();
+      expect(screen.getByText(/Conflict reasons: rejected \(batch_identity_conflict\): duplicate batch id batch-1/)).toBeInTheDocument();
     });
   });
 
@@ -862,7 +871,7 @@ describe('App', () => {
       expect(screen.getByText('Import failed. Fix the errors below and try again.')).toBeInTheDocument();
     });
 
-    expect(upsertBatch).not.toHaveBeenCalled();
+    expect(importBatches).not.toHaveBeenCalled();
   });
 
 
@@ -921,12 +930,12 @@ describe('App', () => {
     });
 
     expect(screen.getByText('Import Preview')).toBeInTheDocument();
-    expect(upsertBatch).not.toHaveBeenCalled();
+    expect(importBatches).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByRole('button', { name: 'Import' }));
 
     await waitFor(() => {
-      expect(upsertBatch).toHaveBeenCalledWith(expect.objectContaining({ batchId: 'batch-1' }));
+      expect(importBatches).toHaveBeenCalledWith([expect.objectContaining({ batchId: 'batch-1' })]);
     });
   });
 
@@ -941,7 +950,7 @@ describe('App', () => {
       expect(screen.getByText('Deep-link import failed. Payload was invalid or too large.')).toBeInTheDocument();
     });
 
-    expect(upsertBatch).not.toHaveBeenCalled();
+    expect(importBatches).not.toHaveBeenCalled();
   });
 
   it('accepts deep-link segment import payload and requires confirmation before import', async () => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -37,6 +37,7 @@ import {
   importCrops,
   importSpecies,
   importCropPlans,
+  importBatches,
   importSegments,
   upsertSegment,
   removeSegment,
@@ -6406,6 +6407,7 @@ function DataPage({ showDevResetButton, onResetToGoldenDataset }: DataPageProps)
   }>>([]);
   const [autoRenameOnConflict, setAutoRenameOnConflict] = useState(false);
   const [batchImportStatusSummary, setBatchImportStatusSummary] = useState<{
+    created: number;
     skipped: number;
     merged: number;
     rejected: number;
@@ -7048,41 +7050,29 @@ function DataPage({ showDevResetButton, onResetToGoldenDataset }: DataPageProps)
 
     try {
       const appStateWithBatches = pendingBatchImportState as { batches?: unknown[] };
-      const candidateBatches = Array.isArray(appStateWithBatches.batches) ? appStateWithBatches.batches : [];
-      const importErrors: Array<{ path: string; message: string }> = [];
-      let created = 0;
-
-      await Promise.all(candidateBatches.map(async (batchCandidate, index) => {
-        try {
-          await upsertBatch(batchCandidate);
-          created += 1;
-        } catch (error) {
-          importErrors.push({
-            path: `/batches/${index}`,
-            message: error instanceof Error ? error.message : 'Batch upsert failed.',
-          });
-        }
-      }));
-
-      const merged = 0;
-      const skipped = 0;
-      const rejectedConflict = importErrors.length;
-      const renamed = 0;
-      const conflictDetail = rejectedConflict > 0 && importErrors.length > 0
-        ? ` Conflict reasons: ${importErrors.map((entry) => entry.message).join('; ')}`
+      const candidateBatches = (Array.isArray(appStateWithBatches.batches) ? appStateWithBatches.batches : []) as Batch[];
+      const commandResult = await importBatches(candidateBatches);
+      const created = commandResult.summary.imported;
+      const merged = commandResult.summary.merged;
+      const skipped = commandResult.summary.skipped;
+      const rejected = commandResult.summary.rejected;
+      const renamed = commandResult.errors.filter((entry) => entry.message.toLowerCase().includes('renamed')).length;
+      const conflictDetail = commandResult.errors.length > 0
+        ? ` Conflict reasons: ${commandResult.errors.map((entry) => entry.message).join('; ')}`
         : '';
       const renameCapabilityNote = autoRenameOnConflict
         ? ' Auto-rename requested, but this importer currently reports collisions as deterministic rejects.'
         : '';
       setBatchImportStatusSummary({
+        created,
         skipped,
         merged,
-        rejected: rejectedConflict,
+        rejected,
         renamed,
       });
-      setImportErrors(importErrors);
+      setImportErrors(commandResult.errors);
       setImportMessage(
-        `Batch import complete. Created: ${created}. Statuses: merged ${merged}, skipped ${skipped}, rejected ${rejectedConflict}, renamed ${renamed}.`
+        `Batch import complete. Created: ${created}. Statuses: merged ${merged}, skipped ${skipped}, rejected ${rejected}, renamed ${renamed}.`
         + conflictDetail
         + renameCapabilityNote,
       );
@@ -7786,6 +7776,7 @@ function DataPage({ showDevResetButton, onResetToGoldenDataset }: DataPageProps)
         <section>
           <h3>Collision Status Summary</h3>
           <ul>
+            <li>created (imported): {batchImportStatusSummary.created}</li>
             <li>skipped (identical_batch): {batchImportStatusSummary.skipped}</li>
             <li>merged (eventsAdded): {batchImportStatusSummary.merged}</li>
             <li>rejected (batch_identity_conflict): {batchImportStatusSummary.rejected}</li>

--- a/frontend/src/data/index.ts
+++ b/frontend/src/data/index.ts
@@ -2020,6 +2020,12 @@ export const upsertBatch = async (batch: unknown): Promise<Batch> => {
   return savedBatch;
 };
 
+export const importBatches = async (batches: Batch[]): Promise<ImportCommandResult> => {
+  const result = await workflowAdapter.batches.importBatches(batches);
+  await syncLocalMirrorFromBackend();
+  return result;
+};
+
 export const transitionBatchStage = async (
   batchId: string,
   nextStage: string,

--- a/frontend/src/data/workflowAdapter.ts
+++ b/frontend/src/data/workflowAdapter.ts
@@ -305,6 +305,12 @@ export const workflowAdapter = {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(batch),
       })),
+    importBatches: async (batches: Batch[]): Promise<ImportCommandResult> =>
+      assertImportCommandResult('batches.importBatches', await fetchJson<unknown>('/api/import/batches', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ batches }),
+      })),
     transitionStage: async (batchId: string, nextStage: string, occurredAt: string): Promise<Batch> =>
       fetchJson<Batch>(`/api/domain/batches/${encodeURIComponent(batchId)}/stage-events`, {
         method: 'POST',


### PR DESCRIPTION
### Motivation
- Move batch import consolidation and collision resolution to the backend so the UI consumes a single, validated command response instead of performing per-batch upserts and computing counts locally.
- Ensure import result shape matches other import flows (`taxonomy`/`segments`) by reusing the existing `assertImportCommandResult` contract validation.

### Description
- Added a backend adapter call `workflowAdapter.batches.importBatches` that posts `{ batches }` to `/api/import/batches` and validates the response with `assertImportCommandResult` (file: `frontend/src/data/workflowAdapter.ts`).
- Added a top-level command `importBatches` in `frontend/src/data/index.ts` that delegates to the adapter and runs `syncLocalMirrorFromBackend` after completion.
- Replaced the per-batch `upsertBatch` loop in the UI `handleConfirmBatchImport` with a single `importBatches(...)` call and derived `created/merged/skipped/rejected` counts and conflict details exclusively from the backend `summary` and `errors` fields (file: `frontend/src/App.tsx`).
- Updated UI wiring to surface the backend-provided `created (imported)` count and to populate import errors strictly from the backend response, while preserving existing user-facing messages.
- Updated tests and mocks in `frontend/src/App.test.tsx` to mock and assert `importBatches` usage and to verify rendering driven by backend result data instead of local loop behavior.

### Testing
- Ran the batch-focused test suite with `npm test -- App.test.tsx`, and all tests passed.
- Ran full TypeScript checks with `npm run typecheck`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef78906e508326b4810282dad78aa9)