### PR TITLE
Add intent-based batch workflow endpoints and migrate frontend batch mutations

### DIFF
--- a/backend/SurvivalGarden.Api/Endpoints/BatchEndpoints.cs
+++ b/backend/SurvivalGarden.Api/Endpoints/BatchEndpoints.cs
@@ -40,6 +40,18 @@ internal static class BatchEndpoints
                 });
             }
 
+            var batchId = payload["batchId"]?.GetValue<string>() ?? payload["id"]?.GetValue<string>() ?? string.Empty;
+            var existing = await service.GetByIdAsync("batches", "batchId", batchId, ct);
+            if (existing is not null)
+            {
+                return Results.Conflict(new
+                {
+                    error = "validation_failed",
+                    workflow = "create_batch",
+                    errors = new[] { new { path = "/batchId", message = "batch_already_exists" } }
+                });
+            }
+
             var saved = await service.UpsertAsync("batches", "batchId", payload, ct);
             return Results.Ok(saved);
         });
@@ -94,9 +106,9 @@ internal static class BatchEndpoints
             {
                 return Results.BadRequest(new
                 {
-                    error = transition.Error,
+                    error = "validation_failed",
                     workflow = "stage_event",
-                    batchId = id
+                    errors = new[] { new { path = "/stage", message = transition.Error ?? "invalid_stage_transition" } }
                 });
             }
 
@@ -165,7 +177,12 @@ internal static class BatchEndpoints
             var transition = ApplyStageEvent(batch, "ended", occurredAt);
             if (!transition.Ok)
             {
-                return Results.BadRequest(new { error = transition.Error, workflow = "complete_batch", batchId = id });
+                return Results.BadRequest(new
+                {
+                    error = "validation_failed",
+                    workflow = "complete_batch",
+                    errors = new[] { new { path = "/occurredAt", message = transition.Error ?? "invalid_stage_transition" } }
+                });
             }
 
             await service.SaveAppStateAsync(state, ct);
@@ -402,14 +419,14 @@ internal static class BatchEndpoints
         {
             return Results.BadRequest(new
             {
-                error = mutation.Error,
+                error = "validation_failed",
                 workflow = operation switch
                 {
                     "assign" => "assign_bed",
                     "move" => "move_bed",
                     _ => "unassign_bed"
                 },
-                batchId = id
+                errors = new[] { new { path = "/bedId|/at", message = mutation.Error ?? "invalid_assignment_operation" } }
             });
         }
 

--- a/backend/SurvivalGarden.Api/Endpoints/BatchEndpoints.cs
+++ b/backend/SurvivalGarden.Api/Endpoints/BatchEndpoints.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Nodes;
+using SurvivalGarden.Api.Contracts;
 using SurvivalGarden.Application;
 
 namespace SurvivalGarden.Api.Endpoints;
@@ -26,6 +27,23 @@ internal static class BatchEndpoints
             return batch is null ? Results.NotFound() : Results.Ok(batch);
         });
 
+        app.MapPost("/api/batches", async (IGardenApplicationService service, JsonObject payload, CancellationToken ct) =>
+        {
+            var validation = service.Validate("batches", payload);
+            if (!validation.Ok)
+            {
+                return Results.BadRequest(new
+                {
+                    error = "validation_failed",
+                    workflow = "create_batch",
+                    errors = validation.Issues
+                });
+            }
+
+            var saved = await service.UpsertAsync("batches", "batchId", payload, ct);
+            return Results.Ok(saved);
+        });
+
         app.MapPut("/api/batches/{id}", async (IGardenApplicationService service, string id, JsonObject payload, CancellationToken ct) =>
         {
             payload["batchId"] = id;
@@ -39,10 +57,375 @@ internal static class BatchEndpoints
             return Results.Ok(saved);
         });
 
+        app.MapPost("/api/batches/{id}/stage-events", async (
+            IGardenApplicationService service,
+            string id,
+            StageEventRequest request,
+            CancellationToken ct) =>
+        {
+            var state = await service.LoadAppStateAsync(ct);
+            if (state is null)
+            {
+                return Results.NotFound(new { error = "app_state_not_found", workflow = "stage_event" });
+            }
+
+            var batch = GetCollection(state, "batches")
+                .OfType<JsonObject>()
+                .FirstOrDefault(candidate => string.Equals(candidate["batchId"]?.GetValue<string>(), id, StringComparison.Ordinal));
+            if (batch is null)
+            {
+                return Results.NotFound(new { error = "batch_not_found", workflow = "stage_event", batchId = id });
+            }
+
+            var nextStage = request.Stage ?? string.Empty;
+            var occurredAt = request.OccurredAt ?? string.Empty;
+            if (string.IsNullOrWhiteSpace(nextStage) || string.IsNullOrWhiteSpace(occurredAt))
+            {
+                return Results.BadRequest(new
+                {
+                    error = "validation_failed",
+                    workflow = "stage_event",
+                    errors = new[] { new { path = "/stage|/occurredAt", message = "stage_and_occurredAt_required" } }
+                });
+            }
+
+            var transition = ApplyStageEvent(batch, nextStage, occurredAt);
+            if (!transition.Ok)
+            {
+                return Results.BadRequest(new
+                {
+                    error = transition.Error,
+                    workflow = "stage_event",
+                    batchId = id
+                });
+            }
+
+            await service.SaveAppStateAsync(state, ct);
+            return Results.Ok(transition.Batch);
+        });
+
+        app.MapPost("/api/batches/{id}/assign-bed", async (
+            IGardenApplicationService service,
+            string id,
+            BatchAssignmentRequest request,
+            CancellationToken ct) =>
+        {
+            return await MutateBatchAssignment(service, id, "assign", request.BedId, request.At, ct);
+        });
+
+        app.MapPost("/api/batches/{id}/unassign-bed", async (
+            IGardenApplicationService service,
+            string id,
+            BatchAssignmentRequest request,
+            CancellationToken ct) =>
+        {
+            return await MutateBatchAssignment(service, id, "remove", request.BedId, request.At, ct);
+        });
+
+        app.MapPost("/api/batches/{id}/move-bed", async (
+            IGardenApplicationService service,
+            string id,
+            BatchAssignmentRequest request,
+            CancellationToken ct) =>
+        {
+            return await MutateBatchAssignment(service, id, "move", request.BedId, request.At, ct);
+        });
+
+        app.MapPost("/api/batches/{id}/complete", async (
+            IGardenApplicationService service,
+            string id,
+            StageEventRequest request,
+            CancellationToken ct) =>
+        {
+            var occurredAt = request.OccurredAt ?? string.Empty;
+            if (string.IsNullOrWhiteSpace(occurredAt))
+            {
+                return Results.BadRequest(new
+                {
+                    error = "validation_failed",
+                    workflow = "complete_batch",
+                    errors = new[] { new { path = "/occurredAt", message = "occurredAt_required" } }
+                });
+            }
+
+            var state = await service.LoadAppStateAsync(ct);
+            if (state is null)
+            {
+                return Results.NotFound(new { error = "app_state_not_found", workflow = "complete_batch" });
+            }
+
+            var batch = GetCollection(state, "batches")
+                .OfType<JsonObject>()
+                .FirstOrDefault(candidate => string.Equals(candidate["batchId"]?.GetValue<string>(), id, StringComparison.Ordinal));
+            if (batch is null)
+            {
+                return Results.NotFound(new { error = "batch_not_found", workflow = "complete_batch", batchId = id });
+            }
+
+            var transition = ApplyStageEvent(batch, "ended", occurredAt);
+            if (!transition.Ok)
+            {
+                return Results.BadRequest(new { error = transition.Error, workflow = "complete_batch", batchId = id });
+            }
+
+            await service.SaveAppStateAsync(state, ct);
+            return Results.Ok(transition.Batch);
+        });
+
         app.MapDelete("/api/batches/{id}", async (IGardenApplicationService service, string id, CancellationToken ct) =>
         {
             var removed = await service.RemoveAsync("batches", "batchId", id, ct);
             return removed ? Results.NoContent() : Results.NotFound();
         });
+    }
+
+    private static string NormalizeStage(string stage) => stage switch
+    {
+        "pre_sown" => "sowing",
+        _ => stage
+    };
+
+    private static bool CanTransition(string currentStage, string nextStage)
+    {
+        var current = NormalizeStage(currentStage);
+        var next = NormalizeStage(nextStage);
+        if (next == "failed")
+        {
+            return true;
+        }
+
+        if (next == "ended")
+        {
+            return current is "harvest" or "failed";
+        }
+
+        return current switch
+        {
+            "sowing" => next is "transplant" or "harvest" or "failed",
+            "started" => next is "transplant" or "harvest" or "failed",
+            "transplant" => next is "harvest" or "failed",
+            "harvest" => next is "ended" or "failed",
+            "failed" => next is "ended",
+            "ended" => next is "failed",
+            _ => false
+        };
+    }
+
+    private static (bool Ok, string? Error, JsonObject Batch) ApplyStageEvent(JsonObject batch, string nextStage, string occurredAt)
+    {
+        var currentStage = NormalizeStage(batch["currentStage"]?.GetValue<string>() ?? batch["stage"]?.GetValue<string>() ?? "unknown");
+        var normalizedNextStage = NormalizeStage(nextStage);
+        if (normalizedNextStage != currentStage && !CanTransition(currentStage, normalizedNextStage))
+        {
+            return (false, "invalid_stage_transition", batch);
+        }
+
+        batch["currentStage"] = normalizedNextStage;
+        var stageEvents = batch["stageEvents"] as JsonArray ?? new JsonArray();
+        stageEvents.Add(new JsonObject
+        {
+            ["stage"] = normalizedNextStage,
+            ["occurredAt"] = occurredAt
+        });
+        batch["stageEvents"] = stageEvents;
+        return (true, null, batch);
+    }
+
+    private static bool IsWithinWindow(JsonObject assignment, string at)
+    {
+        var fromDate = assignment["fromDate"]?.GetValue<string>() ?? assignment["assignedAt"]?.GetValue<string>() ?? "";
+        var toDate = assignment["toDate"]?.GetValue<string>();
+        if (string.CompareOrdinal(fromDate, at) > 0)
+        {
+            return false;
+        }
+
+        if (toDate is not null && string.CompareOrdinal(toDate, at) < 0)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static JsonObject? GetActiveAssignment(JsonObject batch, string at)
+    {
+        var assignments = batch["bedAssignments"] as JsonArray ?? batch["assignments"] as JsonArray;
+        if (assignments is null)
+        {
+            return null;
+        }
+
+        JsonObject? active = null;
+        foreach (var assignment in assignments.OfType<JsonObject>())
+        {
+            if (!IsWithinWindow(assignment, at))
+            {
+                continue;
+            }
+
+            var activeFrom = active?["fromDate"]?.GetValue<string>() ?? active?["assignedAt"]?.GetValue<string>() ?? "";
+            var candidateFrom = assignment["fromDate"]?.GetValue<string>() ?? assignment["assignedAt"]?.GetValue<string>() ?? "";
+            if (active is null || string.CompareOrdinal(candidateFrom, activeFrom) >= 0)
+            {
+                active = assignment;
+            }
+        }
+
+        return active;
+    }
+
+    private static (bool Ok, string? Error, JsonObject Batch) MutateAssignment(JsonObject batch, string operation, string? bedId, string at)
+    {
+        var assignments = batch["bedAssignments"] as JsonArray ?? batch["assignments"] as JsonArray ?? new JsonArray();
+        batch["bedAssignments"] = assignments;
+
+        if (operation == "assign")
+        {
+            if (string.IsNullOrWhiteSpace(bedId))
+            {
+                return (false, "bedId_required", batch);
+            }
+
+            var sameBedActive = assignments.OfType<JsonObject>()
+                .Any(assignment => string.Equals(assignment["bedId"]?.GetValue<string>(), bedId, StringComparison.Ordinal) && IsWithinWindow(assignment, at));
+            if (sameBedActive)
+            {
+                return (true, null, batch);
+            }
+
+            var overlap = assignments.OfType<JsonObject>()
+                .Any(assignment => IsWithinWindow(assignment, at));
+            if (overlap)
+            {
+                return (false, "batch_assignment_overlap", batch);
+            }
+
+            assignments.Add(new JsonObject
+            {
+                ["bedId"] = bedId,
+                ["assignedAt"] = at,
+                ["fromDate"] = at
+            });
+
+            return (true, null, batch);
+        }
+
+        if (operation == "remove")
+        {
+            var active = GetActiveAssignment(batch, at);
+            if (active is null)
+            {
+                return (true, null, batch);
+            }
+
+            active["toDate"] = at;
+            return (true, null, batch);
+        }
+
+        if (operation == "move")
+        {
+            if (string.IsNullOrWhiteSpace(bedId))
+            {
+                return (false, "bedId_required", batch);
+            }
+
+            var active = GetActiveAssignment(batch, at);
+            if (active is null)
+            {
+                return (false, "batch_assignment_no_active", batch);
+            }
+
+            var activeFrom = active["fromDate"]?.GetValue<string>() ?? active["assignedAt"]?.GetValue<string>() ?? "";
+            if (string.CompareOrdinal(at, activeFrom) < 0)
+            {
+                return (false, "batch_assignment_move_before_start", batch);
+            }
+
+            if (string.Equals(active["bedId"]?.GetValue<string>(), bedId, StringComparison.Ordinal))
+            {
+                return (true, null, batch);
+            }
+
+            active["toDate"] = at;
+            assignments.Add(new JsonObject
+            {
+                ["bedId"] = bedId,
+                ["assignedAt"] = at,
+                ["fromDate"] = at
+            });
+            return (true, null, batch);
+        }
+
+        return (false, "invalid_assignment_operation", batch);
+    }
+
+    private static async Task<IResult> MutateBatchAssignment(
+        IGardenApplicationService service,
+        string id,
+        string operation,
+        string? bedId,
+        string? at,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(at))
+        {
+            return Results.BadRequest(new
+            {
+                error = "validation_failed",
+                workflow = operation switch
+                {
+                    "assign" => "assign_bed",
+                    "move" => "move_bed",
+                    _ => "unassign_bed"
+                },
+                errors = new[] { new { path = "/at", message = "at_required" } }
+            });
+        }
+
+        var state = await service.LoadAppStateAsync(ct);
+        if (state is null)
+        {
+            return Results.NotFound(new { error = "app_state_not_found" });
+        }
+
+        var batch = GetCollection(state, "batches")
+            .OfType<JsonObject>()
+            .FirstOrDefault(candidate => string.Equals(candidate["batchId"]?.GetValue<string>(), id, StringComparison.Ordinal));
+        if (batch is null)
+        {
+            return Results.NotFound(new { error = "batch_not_found", batchId = id });
+        }
+
+        var mutation = MutateAssignment(batch, operation, bedId, at);
+        if (!mutation.Ok)
+        {
+            return Results.BadRequest(new
+            {
+                error = mutation.Error,
+                workflow = operation switch
+                {
+                    "assign" => "assign_bed",
+                    "move" => "move_bed",
+                    _ => "unassign_bed"
+                },
+                batchId = id
+            });
+        }
+
+        await service.SaveAppStateAsync(state, ct);
+        return Results.Ok(mutation.Batch);
+    }
+
+    private static JsonArray GetCollection(JsonObject state, string name)
+    {
+        if (state[name] is JsonArray collection)
+        {
+            return collection;
+        }
+
+        var created = new JsonArray();
+        state[name] = created;
+        return created;
     }
 }

--- a/frontend/src/data/workflowAdapter.test.ts
+++ b/frontend/src/data/workflowAdapter.test.ts
@@ -203,7 +203,7 @@ describe('workflow adapter transport', () => {
     expect(toBackendApiUrl('/api/beds')).toBe('/api/beds');
   });
 
-  it('posts stage transitions to the backend domain endpoint', async () => {
+  it('posts stage transitions to the backend batch endpoint', async () => {
     vi.stubEnv('VITE_BACKEND_API_BASE_URL', 'http://localhost:5142');
 
     const fetchMock = vi.fn().mockResolvedValue({
@@ -216,7 +216,7 @@ describe('workflow adapter transport', () => {
 
     expect(batch.batchId).toBe('batch-1');
     expect(fetchMock).toHaveBeenCalledWith(
-      'http://localhost:5142/api/domain/batches/batch-1/stage-events',
+      'http://localhost:5142/api/batches/batch-1/stage-events',
       expect.objectContaining({ method: 'POST' }),
     );
   });

--- a/frontend/src/data/workflowAdapter.ts
+++ b/frontend/src/data/workflowAdapter.ts
@@ -300,8 +300,8 @@ export const workflowAdapter = {
   },
   batches: {
     upsertBatch: async (batch: Batch): Promise<Batch> =>
-      assertContract('batches.upsertBatch', 'batch', await fetchJson<unknown>(`/api/batches/${encodeURIComponent(batch.batchId)}`, {
-        method: 'PUT',
+      assertContract('batches.upsertBatch', 'batch', await fetchJson<unknown>('/api/batches', {
+        method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(batch),
       })),
@@ -312,7 +312,7 @@ export const workflowAdapter = {
         body: JSON.stringify({ batches }),
       })),
     transitionStage: async (batchId: string, nextStage: string, occurredAt: string): Promise<Batch> =>
-      fetchJson<Batch>(`/api/domain/batches/${encodeURIComponent(batchId)}/stage-events`, {
+      fetchJson<Batch>(`/api/batches/${encodeURIComponent(batchId)}/stage-events`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ stage: nextStage, occurredAt }),
@@ -321,11 +321,18 @@ export const workflowAdapter = {
       operation: 'assign' | 'move' | 'remove',
       payload: { batchId: string; bedId?: string; at: string },
     ): Promise<Batch> =>
-      fetchJson<Batch>(`/api/domain/batches/${encodeURIComponent(payload.batchId)}/assignment`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ operation, bedId: payload.bedId, at: payload.at }),
-      }),
+      fetchJson<Batch>(
+        operation === 'assign'
+          ? `/api/batches/${encodeURIComponent(payload.batchId)}/assign-bed`
+          : operation === 'move'
+            ? `/api/batches/${encodeURIComponent(payload.batchId)}/move-bed`
+            : `/api/batches/${encodeURIComponent(payload.batchId)}/unassign-bed`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ bedId: payload.bedId, at: payload.at }),
+        },
+      ),
     removeBatch: async (batchId: string): Promise<void> => {
       const response = await fetch(toBackendApiUrl(`/api/batches/${encodeURIComponent(batchId)}`), { method: 'DELETE' });
       if (response.status === 404 || response.status === 204) {

--- a/frontend/src/data/workflowAdapter.ts
+++ b/frontend/src/data/workflowAdapter.ts
@@ -312,7 +312,9 @@ export const workflowAdapter = {
         body: JSON.stringify({ batches }),
       })),
     transitionStage: async (batchId: string, nextStage: string, occurredAt: string): Promise<Batch> =>
-      fetchJson<Batch>(`/api/batches/${encodeURIComponent(batchId)}/stage-events`, {
+      fetchJson<Batch>(nextStage === 'ended'
+        ? `/api/batches/${encodeURIComponent(batchId)}/complete`
+        : `/api/batches/${encodeURIComponent(batchId)}/stage-events`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ stage: nextStage, occurredAt }),

--- a/frontend/src/generated/api-client.ts
+++ b/frontend/src/generated/api-client.ts
@@ -30,6 +30,11 @@ export type BackendApiPath =
   | '/api/validate/{collection}'
   | '/api/batches'
   | '/api/batches/{id}'
+  | '/api/batches/{id}/stage-events'
+  | '/api/batches/{id}/assign-bed'
+  | '/api/batches/{id}/unassign-bed'
+  | '/api/batches/{id}/move-bed'
+  | '/api/batches/{id}/complete'
   | '/api/domain/batches/{id}/stage-events'
   | '/api/domain/batches/{id}/assignment'
   | '/api/domain/tasks/regenerate-calendar';

--- a/frontend/src/generated/openapi-paths.ts
+++ b/frontend/src/generated/openapi-paths.ts
@@ -25,28 +25,7 @@ export interface paths {
             };
         };
         put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": components["schemas"]["JsonObject"];
-                };
-            };
-            responses: {
-                /** @description OK */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-            };
-        };
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -100,7 +79,28 @@ export interface paths {
                 };
             };
         };
-        post?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["JsonObject"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
         delete?: never;
         options?: never;
         head?: never;

--- a/frontend/src/generated/openapi-paths.ts
+++ b/frontend/src/generated/openapi-paths.ts
@@ -79,28 +79,7 @@ export interface paths {
                 };
             };
         };
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": components["schemas"]["JsonObject"];
-                };
-            };
-            responses: {
-                /** @description OK */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-            };
-        };
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -139,7 +118,28 @@ export interface paths {
             };
         };
         put?: never;
-        post?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["JsonObject"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
         delete?: never;
         options?: never;
         head?: never;

--- a/frontend/src/generated/openapi-paths.ts
+++ b/frontend/src/generated/openapi-paths.ts
@@ -25,7 +25,28 @@ export interface paths {
             };
         };
         put?: never;
-        post?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["JsonObject"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
         delete?: never;
         options?: never;
         head?: never;
@@ -197,6 +218,201 @@ export interface paths {
                 };
             };
         };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/batches/{id}/assign-bed": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["BatchAssignmentRequest"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/batches/{id}/complete": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["StageEventRequest"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/batches/{id}/move-bed": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["BatchAssignmentRequest"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/batches/{id}/stage-events": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["StageEventRequest"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/batches/{id}/unassign-bed": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["BatchAssignmentRequest"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
         options?: never;
         head?: never;
         patch?: never;


### PR DESCRIPTION
### Motivation
- Batch transitions and bed assignments are business workflows and must be owned by the backend rather than via generic document PUTs. 
- Introduce explicit intent endpoints so transition rules, validation, and side effects are centralized server-side. 
- Move frontend callers off legacy generic mutation paths onto workflow-specific endpoints to enforce backend-authoritative semantics.

### Description
- Added intent-based batch endpoints in `backend/SurvivalGarden.Api/Endpoints/BatchEndpoints.cs`: `POST /api/batches` (create), `POST /api/batches/{id}/stage-events`, `POST /api/batches/{id}/assign-bed`, `POST /api/batches/{id}/move-bed`, `POST /api/batches/{id}/unassign-bed`, and `POST /api/batches/{id}/complete`, while keeping `GET` and `DELETE` routes; included workflow-specific validation and structured error payloads.
- Implemented internal workflow handlers (stage transition, assignment/move/remove logic, normalization helpers, and a shared `MutateBatchAssignment` helper) to centralize transition validation and side effects in the backend.
- Updated frontend integration in `frontend/src/data/workflowAdapter.ts` to call the new intent endpoints: replaced `PUT /api/batches/{id}` usage for upsert with `POST /api/batches`, replaced `/api/domain/.../stage-events` with `/api/batches/{id}/stage-events`, and routed assignment calls to `/assign-bed`, `/move-bed`, or `/unassign-bed` accordingly.
- Kept legacy CRUD endpoints available for compatibility; new endpoints return structured workflow-aware errors (`error`, `workflow`, and structured `errors`) for client consumption.

### Testing
- No automated test suites were executed as part of this fast patch change.
- Repo-level sanity commands were used during the change (file inspections and local commits); no build or runtime validation was performed.
- Further CI/local test runs are recommended to validate integration and existing unit tests after this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f07101d2f88326bf6c4fca2e2f50cc)