### PR TITLE
Expose full segments CRUD and switch frontend upsert to POST/PATCH

### DIFF
--- a/backend/SurvivalGarden.Api/Endpoints/CoreEndpoints.cs
+++ b/backend/SurvivalGarden.Api/Endpoints/CoreEndpoints.cs
@@ -63,7 +63,6 @@ internal static class CoreEndpoints
             return DtoJsonMapper.ToJsonObject(payload);
         });
         MapEntityCrud(app, "cultivars", "id");
-        MapEntityCrud(app, "segments", "segmentId");
         MapTypedEntityCrud<SeedInventoryItemUpsertRequest>(app, "seedInventoryItems", "seedInventoryItemId", (payload, id) =>
         {
             payload.SeedInventoryItemId = id;
@@ -85,6 +84,18 @@ internal static class CoreEndpoints
 
     private static void MapLayoutWorkflowEndpoints(WebApplication app)
     {
+        app.MapGet("/api/segments", async (IGardenApplicationService service, CancellationToken ct) =>
+        {
+            var items = await service.ListAsync("segments", ct);
+            return Results.Ok(items);
+        });
+
+        app.MapGet("/api/segments/{id}", async (IGardenApplicationService service, string id, CancellationToken ct) =>
+        {
+            var item = await service.GetByIdAsync("segments", "segmentId", id, ct);
+            return item is null ? Results.NotFound() : Results.Ok(item);
+        });
+
         app.MapGet("/api/beds", async (IGardenApplicationService service, CancellationToken ct) =>
         {
             var segments = (await service.ListAsync("segments", ct)).OfType<JsonObject>();
@@ -141,6 +152,12 @@ internal static class CoreEndpoints
 
             var saved = await service.UpsertAsync("segments", "segmentId", updated, ct);
             return Results.Ok(saved);
+        });
+
+        app.MapDelete("/api/segments/{id}", async (IGardenApplicationService service, string id, CancellationToken ct) =>
+        {
+            var removed = await service.RemoveAsync("segments", "segmentId", id, ct);
+            return removed ? Results.NoContent() : Results.NotFound();
         });
 
         app.MapPost("/api/segments/{id}/beds", async (IGardenApplicationService service, string id, JsonObject payload, CancellationToken ct) =>

--- a/frontend/src/data/workflowAdapter.ts
+++ b/frontend/src/data/workflowAdapter.ts
@@ -430,12 +430,21 @@ export const workflowAdapter = {
       }
       return assertContract('bedsSegments.getSegment', 'segment', await response.json());
     },
-    upsertSegment: async (segment: Segment): Promise<Segment> =>
-      fetchJson<Segment>(`/api/segments/${encodeURIComponent(segment.segmentId)}`, {
-        method: 'PUT',
+    upsertSegment: async (segment: Segment): Promise<Segment> => {
+      const existing = await workflowAdapter.bedsSegments.getSegment(segment.segmentId);
+      if (!existing) {
+        return fetchJson<Segment>('/api/segments', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(segment),
+        });
+      }
+      return fetchJson<Segment>(`/api/segments/${encodeURIComponent(segment.segmentId)}`, {
+        method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(segment),
-      }),
+      });
+    },
     removeSegment: async (segmentId: string): Promise<void> => {
       const response = await fetch(toBackendApiUrl(`/api/segments/${encodeURIComponent(segmentId)}`), { method: 'DELETE' });
       if (response.status === 404 || response.status === 204) {


### PR DESCRIPTION
### Motivation
- Reintroduce and complete explicit CRUD surface for `segments` so layout workflow can list, fetch, create, update and delete segments with proper REST semantics.
- Align frontend `upsertSegment` behavior with the server's create/update endpoints to avoid incorrect `PUT` usage and to handle creates vs updates correctly.

### Description
- Removed the generic `MapEntityCrud` usage for `segments` and added explicit endpoints in `MapLayoutWorkflowEndpoints` for `GET /api/segments`, `GET /api/segments/{id}`, and `DELETE /api/segments/{id}` while keeping the existing `POST /api/segments` and `PATCH /api/segments/{id}` behavior and validation.
- Ensured segment-related list and single-item retrieval use `service.ListAsync` and `service.GetByIdAsync` and that `DELETE` returns `204` on success or `404` when not found.
- Updated the frontend `workflowAdapter.upsertSegment` to check for existence via `getSegment` and then call `POST /api/segments` to create or `PATCH /api/segments/{id}` to update instead of always issuing a `PUT`.

### Testing
- No automated tests were executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3695e8c508326b21c3dcb480e0993)