### PR TITLE
Route segment writes through workflow intent endpoints

### DIFF
--- a/backend/SurvivalGarden.Api/Endpoints/CoreEndpoints.cs
+++ b/backend/SurvivalGarden.Api/Endpoints/CoreEndpoints.cs
@@ -63,7 +63,6 @@ internal static class CoreEndpoints
             return DtoJsonMapper.ToJsonObject(payload);
         });
         MapEntityCrud(app, "cultivars", "id");
-        MapEntityCrud(app, "segments", "segmentId");
         MapTypedEntityCrud<SeedInventoryItemUpsertRequest>(app, "seedInventoryItems", "seedInventoryItemId", (payload, id) =>
         {
             payload.SeedInventoryItemId = id;
@@ -141,6 +140,18 @@ internal static class CoreEndpoints
 
             var saved = await service.UpsertAsync("segments", "segmentId", updated, ct);
             return Results.Ok(saved);
+        });
+
+        app.MapDelete("/api/segments/{id}", async (IGardenApplicationService service, string id, CancellationToken ct) =>
+        {
+            var current = await service.GetByIdAsync("segments", "segmentId", id, ct);
+            if (current is null)
+            {
+                return Results.NotFound();
+            }
+
+            await service.RemoveAsync("segments", "segmentId", id, ct);
+            return Results.NoContent();
         });
 
         app.MapPost("/api/segments/{id}/beds", async (IGardenApplicationService service, string id, JsonObject payload, CancellationToken ct) =>

--- a/frontend/src/data/workflowAdapter.ts
+++ b/frontend/src/data/workflowAdapter.ts
@@ -430,12 +430,22 @@ export const workflowAdapter = {
       }
       return assertContract('bedsSegments.getSegment', 'segment', await response.json());
     },
-    upsertSegment: async (segment: Segment): Promise<Segment> =>
-      fetchJson<Segment>(`/api/segments/${encodeURIComponent(segment.segmentId)}`, {
-        method: 'PUT',
+    upsertSegment: async (segment: Segment): Promise<Segment> => {
+      const existingSegment = await workflowAdapter.bedsSegments.getSegment(segment.segmentId);
+      if (!existingSegment) {
+        return fetchJson<Segment>('/api/segments', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(segment),
+        });
+      }
+
+      return fetchJson<Segment>(`/api/segments/${encodeURIComponent(segment.segmentId)}`, {
+        method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(segment),
-      }),
+      });
+    },
     removeSegment: async (segmentId: string): Promise<void> => {
       const response = await fetch(toBackendApiUrl(`/api/segments/${encodeURIComponent(segmentId)}`), { method: 'DELETE' });
       if (response.status === 404 || response.status === 204) {


### PR DESCRIPTION
### Motivation
- Segment mutation was still exposed via generic CRUD endpoints and the frontend used `PUT /api/segments/{id}` and `DELETE /api/segments/{id}`, which bypassed the new intent-oriented layout workflow endpoints.
- The goal is to complete the migration to the layout workflow model so layout writes (segments/beds/paths) are expressed through workflow endpoints and intent semantics.

### Description
- Removed the generic `segments` CRUD mapping (`MapEntityCrud(app, "segments", "segmentId")`) so raw entity CRUD no longer exposes segment writes.
- Added an explicit workflow-owned `DELETE /api/segments/{id}` endpoint inside `MapLayoutWorkflowEndpoints` that validates existence and calls `RemoveAsync("segments","segmentId",id,ct)` before returning `204`.
- Updated the frontend `workflowAdapter.bedsSegments.upsertSegment` to use workflow intent semantics by checking existence with `getSegment` and then creating with `POST /api/segments` or updating with `PATCH /api/segments/{id}` instead of `PUT`.
- Left other layout workflow endpoints (beds/paths create & patch) intact and left read paths (`GET /api/segments`) unchanged.

### Testing
- Ran frontend type checking using `npm --prefix frontend run -s typecheck`, which completed successfully.
- Attempted to build the backend with `dotnet build backend/SurvivalGarden.Api/SurvivalGarden.Api.csproj`, but the command could not be executed in this environment due to `dotnet` not being available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f37d0112d483269c0901454d7e4cde)