### PR TITLE
Fix SegmentBed typing in workflow adapter test fixture

### DIFF
--- a/frontend/src/data/workflowAdapter.test.ts
+++ b/frontend/src/data/workflowAdapter.test.ts
@@ -15,7 +15,7 @@ const validBed = {
   bedId: 'bed-1',
   gardenId: 'garden-1',
   name: 'Bed 1',
-  type: 'vegetable_bed',
+  type: 'vegetable_bed' as const,
   createdAt: '2024-01-01T00:00:00Z',
   updatedAt: '2024-01-02T00:00:00Z',
 };
@@ -28,7 +28,7 @@ const validSegment = {
   widthM: 10,
   lengthM: 5,
   originReference: 'nw_corner',
-  beds: [{ ...validBed, x: 0, y: 0, width: 2, height: 1 }],
+  beds: [{ ...validBed, segmentId: 'segment-1', x: 0, y: 0, width: 2, height: 1, widthM: 2, lengthM: 1 }],
   paths: [],
 };
 


### PR DESCRIPTION
### Motivation
- A TypeScript error (`TS2345`) occurred in tests because the `validSegment.beds` fixture did not include required `SegmentBed` properties and `validBed.type` widened to `string`, making the fixture incompatible with the `Segment` shape expected by the code under test.

### Description
- Add the missing `SegmentBed` fields to the fixture by including `segmentId`, `widthM`, and `lengthM` on the `validSegment.beds` entry.
- Narrow `validBed.type` to a literal (`as const`) so it is assignable to the `BedType` union instead of widening to `string`.

### Testing
- Ran TypeScript check with `cd frontend && pnpm -s tsc --noEmit --pretty false`, which succeeds and resolves the reported `TS2345` mismatch in `workflowAdapter.test.ts`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8503d41148326aa177431639d1fbd)