### PR TITLE
#62: Add backend-projected query DTO endpoints for seed inventory and taxonomy picker

### DIFF
--- a/backend/SurvivalGarden.Api/Endpoints/CoreEndpoints.cs
+++ b/backend/SurvivalGarden.Api/Endpoints/CoreEndpoints.cs
@@ -56,6 +56,92 @@ internal static class CoreEndpoints
             return Results.Ok(payload);
         });
 
+
+        app.MapGet("/api/query/taxonomy-picker", async (IGardenApplicationService service, CancellationToken ct) =>
+        {
+            var state = await service.LoadAppStateAsync(ct);
+            if (state is null)
+            {
+                return Results.NotFound();
+            }
+
+            var speciesById = (state["species"] as JsonArray ?? []).OfType<JsonObject>()
+                .Where(species => !string.IsNullOrWhiteSpace(species["id"]?.GetValue<string>()))
+                .ToDictionary(species => species["id"]!.GetValue<string>(), species => species);
+
+            var crops = (state["crops"] as JsonArray ?? []).OfType<JsonObject>().ToArray();
+            var cultivars = (state["cultivars"] as JsonArray ?? []).OfType<JsonObject>().ToArray();
+
+            var cropRows = crops.Select(crop =>
+            {
+                var cropId = crop["cropId"]?.GetValue<string>() ?? string.Empty;
+                var speciesId = crop["speciesId"]?.GetValue<string>() ?? string.Empty;
+                speciesById.TryGetValue(speciesId, out var species);
+                return new
+                {
+                    cropId,
+                    cropName = crop["name"]?.GetValue<string>() ?? cropId,
+                    speciesId,
+                    speciesDisplay = species?["commonName"]?.GetValue<string>() ?? species?["scientificName"]?.GetValue<string>() ?? string.Empty
+                };
+            });
+
+            var cultivarRows = cultivars.Select(cultivar =>
+            {
+                var cropTypeId = cultivar["cropTypeId"]?.GetValue<string>() ?? string.Empty;
+                var crop = crops.FirstOrDefault(candidate => string.Equals(candidate["cropId"]?.GetValue<string>(), cropTypeId, StringComparison.Ordinal));
+                var speciesId = crop?["speciesId"]?.GetValue<string>() ?? string.Empty;
+                speciesById.TryGetValue(speciesId, out var species);
+                return new
+                {
+                    cultivarId = cultivar["cultivarId"]?.GetValue<string>() ?? string.Empty,
+                    cultivarName = cultivar["name"]?.GetValue<string>() ?? string.Empty,
+                    cropTypeId,
+                    cropTypeName = crop?["name"]?.GetValue<string>() ?? cropTypeId,
+                    speciesDisplay = species?["commonName"]?.GetValue<string>() ?? species?["scientificName"]?.GetValue<string>() ?? string.Empty,
+                    archived = cultivar["isArchived"]?.GetValue<bool>() ?? false
+                };
+            });
+
+            return Results.Ok(new { crops = cropRows, cultivars = cultivarRows });
+        });
+
+        app.MapGet("/api/query/seed-inventory", async (IGardenApplicationService service, CancellationToken ct) =>
+        {
+            var state = await service.LoadAppStateAsync(ct);
+            if (state is null)
+            {
+                return Results.NotFound();
+            }
+
+            var items = (state["seedInventoryItems"] as JsonArray ?? []).OfType<JsonObject>().ToArray();
+            var crops = (state["crops"] as JsonArray ?? []).OfType<JsonObject>().ToArray();
+            var cultivars = (state["cultivars"] as JsonArray ?? []).OfType<JsonObject>().ToArray();
+            var speciesById = (state["species"] as JsonArray ?? []).OfType<JsonObject>()
+                .Where(species => !string.IsNullOrWhiteSpace(species["id"]?.GetValue<string>()))
+                .ToDictionary(species => species["id"]!.GetValue<string>(), species => species);
+
+            var rows = items.Select(item =>
+            {
+                var cultivarId = item["cultivarId"]?.GetValue<string>() ?? string.Empty;
+                var cultivar = cultivars.FirstOrDefault(candidate => string.Equals(candidate["cultivarId"]?.GetValue<string>(), cultivarId, StringComparison.Ordinal));
+                var cropTypeId = cultivar?["cropTypeId"]?.GetValue<string>() ?? item["cropId"]?.GetValue<string>() ?? string.Empty;
+                var crop = crops.FirstOrDefault(candidate => string.Equals(candidate["cropId"]?.GetValue<string>(), cropTypeId, StringComparison.Ordinal));
+                var speciesId = crop?["speciesId"]?.GetValue<string>() ?? string.Empty;
+                speciesById.TryGetValue(speciesId, out var species);
+                return new
+                {
+                    seedInventoryItemId = item["seedInventoryItemId"]?.GetValue<string>() ?? string.Empty,
+                    cultivarId,
+                    displayName = cultivar?["name"]?.GetValue<string>() ?? item["variety"]?.GetValue<string>() ?? cultivarId,
+                    cropTypeName = crop?["name"]?.GetValue<string>() ?? cropTypeId,
+                    speciesDisplay = species?["commonName"]?.GetValue<string>() ?? species?["scientificName"]?.GetValue<string>() ?? string.Empty
+                };
+            });
+
+            return Results.Ok(rows);
+        });
+
         MapEntityCrud(app, "species", "id");
         MapTypedEntityCrud<CropUpsertRequest>(app, "crops", "cropId", (payload, id) =>
         {

--- a/backend/SurvivalGarden.Api/Endpoints/CoreEndpoints.cs
+++ b/backend/SurvivalGarden.Api/Endpoints/CoreEndpoints.cs
@@ -74,12 +74,12 @@ internal static class CoreEndpoints
             {
                 var cropId = crop["cropId"]?.GetValue<string>() ?? string.Empty;
                 var speciesId = crop["speciesId"]?.GetValue<string>() ?? string.Empty;
-                return new
+                return new TaxonomyPickerCropDto
                 {
-                    cropId,
-                    cropName = crop["name"]?.GetValue<string>() ?? cropId,
-                    speciesId,
-                    speciesDisplay = ResolveSpeciesDisplay(speciesById, speciesId)
+                    CropId = cropId,
+                    CropName = crop["name"]?.GetValue<string>() ?? cropId,
+                    SpeciesId = speciesId,
+                    SpeciesDisplay = ResolveSpeciesDisplay(speciesById, speciesId)
                 };
             });
 
@@ -88,18 +88,22 @@ internal static class CoreEndpoints
                 var cropTypeId = cultivar["cropTypeId"]?.GetValue<string>() ?? string.Empty;
                 var crop = crops.FirstOrDefault(candidate => string.Equals(candidate["cropId"]?.GetValue<string>(), cropTypeId, StringComparison.Ordinal));
                 var speciesId = crop?["speciesId"]?.GetValue<string>() ?? string.Empty;
-                return new
+                return new TaxonomyPickerCultivarDto
                 {
-                    cultivarId = cultivar["cultivarId"]?.GetValue<string>() ?? string.Empty,
-                    cultivarName = cultivar["name"]?.GetValue<string>() ?? string.Empty,
-                    cropTypeId,
-                    cropTypeName = crop?["name"]?.GetValue<string>() ?? cropTypeId,
-                    speciesDisplay = ResolveSpeciesDisplay(speciesById, speciesId),
-                    archived = cultivar["isArchived"]?.GetValue<bool>() ?? false
+                    CultivarId = cultivar["cultivarId"]?.GetValue<string>() ?? string.Empty,
+                    CultivarName = cultivar["name"]?.GetValue<string>() ?? string.Empty,
+                    CropTypeId = cropTypeId,
+                    CropTypeName = crop?["name"]?.GetValue<string>() ?? cropTypeId,
+                    SpeciesDisplay = ResolveSpeciesDisplay(speciesById, speciesId),
+                    Archived = cultivar["isArchived"]?.GetValue<bool>() ?? false
                 };
             });
 
-            return Results.Ok(new { crops = cropRows, cultivars = cultivarRows });
+            return Results.Ok(new TaxonomyPickerQueryResponseDto
+            {
+                Crops = cropRows.ToArray(),
+                Cultivars = cultivarRows.ToArray()
+            });
         });
 
         app.MapGet("/api/query/seed-inventory", async (IGardenApplicationService service, CancellationToken ct) =>
@@ -122,17 +126,17 @@ internal static class CoreEndpoints
                 var cropTypeId = cultivar?["cropTypeId"]?.GetValue<string>() ?? item["cropId"]?.GetValue<string>() ?? string.Empty;
                 var crop = crops.FirstOrDefault(candidate => string.Equals(candidate["cropId"]?.GetValue<string>(), cropTypeId, StringComparison.Ordinal));
                 var speciesId = crop?["speciesId"]?.GetValue<string>() ?? string.Empty;
-                return new
+                return new SeedInventoryQueryRowDto
                 {
-                    seedInventoryItemId = item["seedInventoryItemId"]?.GetValue<string>() ?? string.Empty,
-                    cultivarId,
-                    displayName = cultivar?["name"]?.GetValue<string>() ?? item["variety"]?.GetValue<string>() ?? cultivarId,
-                    cropTypeName = crop?["name"]?.GetValue<string>() ?? cropTypeId,
-                    speciesDisplay = ResolveSpeciesDisplay(speciesById, speciesId)
+                    SeedInventoryItemId = item["seedInventoryItemId"]?.GetValue<string>() ?? string.Empty,
+                    CultivarId = cultivarId,
+                    DisplayName = cultivar?["name"]?.GetValue<string>() ?? item["variety"]?.GetValue<string>() ?? cultivarId,
+                    CropTypeName = crop?["name"]?.GetValue<string>() ?? cropTypeId,
+                    SpeciesDisplay = ResolveSpeciesDisplay(speciesById, speciesId)
                 };
             });
 
-            return Results.Ok(rows);
+            return Results.Ok(rows.ToArray());
         });
 
         app.MapGet("/api/query/batch-list", async (IGardenApplicationService service, CancellationToken ct) =>
@@ -157,19 +161,19 @@ internal static class CoreEndpoints
                 var crop = crops.FirstOrDefault(candidate => string.Equals(candidate["cropId"]?.GetValue<string>(), cropTypeId, StringComparison.Ordinal));
                 var speciesId = crop?["speciesId"]?.GetValue<string>() ?? string.Empty;
 
-                return new
+                return new BatchListQueryRowDto
                 {
-                    batchId,
-                    identityId = cultivar?["cultivarId"]?.GetValue<string>() ?? lookupId,
-                    capabilityCropId = string.IsNullOrEmpty(cropTypeId) ? lookupId : cropTypeId,
-                    displayName = cultivar?["name"]?.GetValue<string>() ?? crop?["name"]?.GetValue<string>() ?? lookupId,
-                    cropTypeId,
-                    cropTypeName = crop?["name"]?.GetValue<string>() ?? cropTypeId,
-                    speciesDisplay = ResolveSpeciesDisplay(speciesById, speciesId)
+                    BatchId = batchId,
+                    IdentityId = cultivar?["cultivarId"]?.GetValue<string>() ?? lookupId,
+                    CapabilityCropId = string.IsNullOrEmpty(cropTypeId) ? lookupId : cropTypeId,
+                    DisplayName = cultivar?["name"]?.GetValue<string>() ?? crop?["name"]?.GetValue<string>() ?? lookupId,
+                    CropTypeId = cropTypeId,
+                    CropTypeName = crop?["name"]?.GetValue<string>() ?? cropTypeId,
+                    SpeciesDisplay = ResolveSpeciesDisplay(speciesById, speciesId)
                 };
             });
 
-            return Results.Ok(rows);
+            return Results.Ok(rows.ToArray());
         });
 
         MapEntityCrud(app, "species", "id");
@@ -211,6 +215,50 @@ internal static class CoreEndpoints
         }
 
         return species["commonName"]?.GetValue<string>() ?? species["scientificName"]?.GetValue<string>() ?? string.Empty;
+    }
+
+    private sealed class TaxonomyPickerQueryResponseDto
+    {
+        public required TaxonomyPickerCropDto[] Crops { get; init; }
+        public required TaxonomyPickerCultivarDto[] Cultivars { get; init; }
+    }
+
+    private sealed class TaxonomyPickerCropDto
+    {
+        public required string CropId { get; init; }
+        public required string CropName { get; init; }
+        public required string SpeciesId { get; init; }
+        public required string SpeciesDisplay { get; init; }
+    }
+
+    private sealed class TaxonomyPickerCultivarDto
+    {
+        public required string CultivarId { get; init; }
+        public required string CultivarName { get; init; }
+        public required string CropTypeId { get; init; }
+        public required string CropTypeName { get; init; }
+        public required string SpeciesDisplay { get; init; }
+        public required bool Archived { get; init; }
+    }
+
+    private sealed class SeedInventoryQueryRowDto
+    {
+        public required string SeedInventoryItemId { get; init; }
+        public required string CultivarId { get; init; }
+        public required string DisplayName { get; init; }
+        public required string CropTypeName { get; init; }
+        public required string SpeciesDisplay { get; init; }
+    }
+
+    private sealed class BatchListQueryRowDto
+    {
+        public required string BatchId { get; init; }
+        public required string IdentityId { get; init; }
+        public required string CapabilityCropId { get; init; }
+        public required string DisplayName { get; init; }
+        public required string CropTypeId { get; init; }
+        public required string CropTypeName { get; init; }
+        public required string SpeciesDisplay { get; init; }
     }
 
     private static void MapEntityCrud(WebApplication app, string collectionName, string idProperty)

--- a/backend/SurvivalGarden.Api/Endpoints/CoreEndpoints.cs
+++ b/backend/SurvivalGarden.Api/Endpoints/CoreEndpoints.cs
@@ -135,6 +135,43 @@ internal static class CoreEndpoints
             return Results.Ok(rows);
         });
 
+        app.MapGet("/api/query/batch-list", async (IGardenApplicationService service, CancellationToken ct) =>
+        {
+            var state = await service.LoadAppStateAsync(ct);
+            if (state is null)
+            {
+                return Results.NotFound();
+            }
+
+            var batches = (state["batches"] as JsonArray ?? []).OfType<JsonObject>().ToArray();
+            var crops = (state["crops"] as JsonArray ?? []).OfType<JsonObject>().ToArray();
+            var cultivars = (state["cultivars"] as JsonArray ?? []).OfType<JsonObject>().ToArray();
+            var speciesById = BuildSpeciesLookup(state);
+
+            var rows = batches.Select(batch =>
+            {
+                var batchId = batch["batchId"]?.GetValue<string>() ?? string.Empty;
+                var lookupId = batch["cultivarId"]?.GetValue<string>() ?? batch["cropId"]?.GetValue<string>() ?? batchId;
+                var cultivar = cultivars.FirstOrDefault(candidate => string.Equals(candidate["cultivarId"]?.GetValue<string>(), lookupId, StringComparison.Ordinal));
+                var cropTypeId = batch["cropTypeId"]?.GetValue<string>() ?? cultivar?["cropTypeId"]?.GetValue<string>() ?? string.Empty;
+                var crop = crops.FirstOrDefault(candidate => string.Equals(candidate["cropId"]?.GetValue<string>(), cropTypeId, StringComparison.Ordinal));
+                var speciesId = crop?["speciesId"]?.GetValue<string>() ?? string.Empty;
+
+                return new
+                {
+                    batchId,
+                    identityId = cultivar?["cultivarId"]?.GetValue<string>() ?? lookupId,
+                    capabilityCropId = string.IsNullOrEmpty(cropTypeId) ? lookupId : cropTypeId,
+                    displayName = cultivar?["name"]?.GetValue<string>() ?? crop?["name"]?.GetValue<string>() ?? lookupId,
+                    cropTypeId,
+                    cropTypeName = crop?["name"]?.GetValue<string>() ?? cropTypeId,
+                    speciesDisplay = ResolveSpeciesDisplay(speciesById, speciesId)
+                };
+            });
+
+            return Results.Ok(rows);
+        });
+
         MapEntityCrud(app, "species", "id");
         MapTypedEntityCrud<CropUpsertRequest>(app, "crops", "cropId", (payload, id) =>
         {

--- a/backend/SurvivalGarden.Api/Endpoints/CoreEndpoints.cs
+++ b/backend/SurvivalGarden.Api/Endpoints/CoreEndpoints.cs
@@ -65,9 +65,7 @@ internal static class CoreEndpoints
                 return Results.NotFound();
             }
 
-            var speciesById = (state["species"] as JsonArray ?? []).OfType<JsonObject>()
-                .Where(species => !string.IsNullOrWhiteSpace(species["id"]?.GetValue<string>()))
-                .ToDictionary(species => species["id"]!.GetValue<string>(), species => species);
+            var speciesById = BuildSpeciesLookup(state);
 
             var crops = (state["crops"] as JsonArray ?? []).OfType<JsonObject>().ToArray();
             var cultivars = (state["cultivars"] as JsonArray ?? []).OfType<JsonObject>().ToArray();
@@ -76,13 +74,12 @@ internal static class CoreEndpoints
             {
                 var cropId = crop["cropId"]?.GetValue<string>() ?? string.Empty;
                 var speciesId = crop["speciesId"]?.GetValue<string>() ?? string.Empty;
-                speciesById.TryGetValue(speciesId, out var species);
                 return new
                 {
                     cropId,
                     cropName = crop["name"]?.GetValue<string>() ?? cropId,
                     speciesId,
-                    speciesDisplay = species?["commonName"]?.GetValue<string>() ?? species?["scientificName"]?.GetValue<string>() ?? string.Empty
+                    speciesDisplay = ResolveSpeciesDisplay(speciesById, speciesId)
                 };
             });
 
@@ -91,14 +88,13 @@ internal static class CoreEndpoints
                 var cropTypeId = cultivar["cropTypeId"]?.GetValue<string>() ?? string.Empty;
                 var crop = crops.FirstOrDefault(candidate => string.Equals(candidate["cropId"]?.GetValue<string>(), cropTypeId, StringComparison.Ordinal));
                 var speciesId = crop?["speciesId"]?.GetValue<string>() ?? string.Empty;
-                speciesById.TryGetValue(speciesId, out var species);
                 return new
                 {
                     cultivarId = cultivar["cultivarId"]?.GetValue<string>() ?? string.Empty,
                     cultivarName = cultivar["name"]?.GetValue<string>() ?? string.Empty,
                     cropTypeId,
                     cropTypeName = crop?["name"]?.GetValue<string>() ?? cropTypeId,
-                    speciesDisplay = species?["commonName"]?.GetValue<string>() ?? species?["scientificName"]?.GetValue<string>() ?? string.Empty,
+                    speciesDisplay = ResolveSpeciesDisplay(speciesById, speciesId),
                     archived = cultivar["isArchived"]?.GetValue<bool>() ?? false
                 };
             });
@@ -117,9 +113,7 @@ internal static class CoreEndpoints
             var items = (state["seedInventoryItems"] as JsonArray ?? []).OfType<JsonObject>().ToArray();
             var crops = (state["crops"] as JsonArray ?? []).OfType<JsonObject>().ToArray();
             var cultivars = (state["cultivars"] as JsonArray ?? []).OfType<JsonObject>().ToArray();
-            var speciesById = (state["species"] as JsonArray ?? []).OfType<JsonObject>()
-                .Where(species => !string.IsNullOrWhiteSpace(species["id"]?.GetValue<string>()))
-                .ToDictionary(species => species["id"]!.GetValue<string>(), species => species);
+            var speciesById = BuildSpeciesLookup(state);
 
             var rows = items.Select(item =>
             {
@@ -128,14 +122,13 @@ internal static class CoreEndpoints
                 var cropTypeId = cultivar?["cropTypeId"]?.GetValue<string>() ?? item["cropId"]?.GetValue<string>() ?? string.Empty;
                 var crop = crops.FirstOrDefault(candidate => string.Equals(candidate["cropId"]?.GetValue<string>(), cropTypeId, StringComparison.Ordinal));
                 var speciesId = crop?["speciesId"]?.GetValue<string>() ?? string.Empty;
-                speciesById.TryGetValue(speciesId, out var species);
                 return new
                 {
                     seedInventoryItemId = item["seedInventoryItemId"]?.GetValue<string>() ?? string.Empty,
                     cultivarId,
                     displayName = cultivar?["name"]?.GetValue<string>() ?? item["variety"]?.GetValue<string>() ?? cultivarId,
                     cropTypeName = crop?["name"]?.GetValue<string>() ?? cropTypeId,
-                    speciesDisplay = species?["commonName"]?.GetValue<string>() ?? species?["scientificName"]?.GetValue<string>() ?? string.Empty
+                    speciesDisplay = ResolveSpeciesDisplay(speciesById, speciesId)
                 };
             });
 
@@ -165,6 +158,22 @@ internal static class CoreEndpoints
                 issues = validation.Issues
             });
         });
+    }
+
+
+    private static Dictionary<string, JsonObject> BuildSpeciesLookup(JsonObject state) =>
+        (state["species"] as JsonArray ?? []).OfType<JsonObject>()
+            .Where(species => !string.IsNullOrWhiteSpace(species["id"]?.GetValue<string>()))
+            .ToDictionary(species => species["id"]!.GetValue<string>(), species => species);
+
+    private static string ResolveSpeciesDisplay(IReadOnlyDictionary<string, JsonObject> speciesById, string speciesId)
+    {
+        if (!speciesById.TryGetValue(speciesId, out var species))
+        {
+            return string.Empty;
+        }
+
+        return species["commonName"]?.GetValue<string>() ?? species["scientificName"]?.GetValue<string>() ?? string.Empty;
     }
 
     private static void MapEntityCrud(WebApplication app, string collectionName, string idProperty)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2988,7 +2988,13 @@ function BatchesPage({
       Array.from(
         new Set(
           batches
-            .map((batch) => batch.cropTypeId ?? cultivarsById[getBatchCultivarLookupId(batch) ?? '']?.cropTypeId)
+            .map((batch) => getBatchCultivarDisplay({
+              batch,
+              cultivarsById,
+              cropNames,
+              cropScientificNames,
+              projectedRowsByBatchId: projectedBatchRowsById,
+            }).cropTypeId)
             .filter((cropTypeId): cropTypeId is string => Boolean(cropTypeId)),
         ),
       )
@@ -3001,7 +3007,7 @@ function BatchesPage({
             scientificName: cropScientificNames[cropId],
           }),
         })),
-    [batches, cultivarsById, cropNames, cropScientificNames],
+    [batches, cultivarsById, cropNames, cropScientificNames, projectedBatchRowsById],
   );
 
   const stageOptions = useMemo(
@@ -3022,20 +3028,30 @@ function BatchesPage({
   );
 
   const cultivarOptions = useMemo(
-    () =>
-      Array.from(
-        new Set(
-          batches
-            .map((batch) => getBatchCultivarLookupId(batch))
-            .filter((cultivarId): cultivarId is string => Boolean(cultivarId && cultivarsById[cultivarId])),
-        ),
-      )
-        .map((cultivarId) => ({
-          value: cultivarId,
-          label: cultivarsById[cultivarId]?.name ?? cultivarId,
-        }))
-        .sort((left, right) => left.label.localeCompare(right.label)),
-    [batches, cultivarsById],
+    () => {
+      const optionsById = new Map<string, string>();
+
+      for (const batch of batches) {
+        const display = getBatchCultivarDisplay({
+          batch,
+          cultivarsById,
+          cropNames,
+          cropScientificNames,
+          projectedRowsByBatchId: projectedBatchRowsById,
+        });
+
+        if (!display.identityId) {
+          continue;
+        }
+
+        optionsById.set(display.identityId, display.name ?? cultivarsById[display.identityId]?.name ?? display.identityId);
+      }
+
+      return Array.from(optionsById.entries())
+        .map(([value, label]) => ({ value, label }))
+        .sort((left, right) => left.label.localeCompare(right.label));
+    },
+    [batches, cultivarsById, cropNames, cropScientificNames, projectedBatchRowsById],
   );
 
   const cultivarInputOptions = useMemo(
@@ -3079,8 +3095,6 @@ function BatchesPage({
         .filter((batch) => {
         const derivedBedId = getDerivedBedId(batch);
         const batchDate = batch.startedAt.slice(0, 10);
-        const cultivarId = getBatchCultivarLookupId(batch);
-        const cultivarName = cultivarId ? (cultivarsById[cultivarId]?.name ?? '') : '';
         const batchDisplay = getBatchCultivarDisplay({
           batch,
           cultivarsById,
@@ -3088,8 +3102,10 @@ function BatchesPage({
           cropScientificNames,
           projectedRowsByBatchId: projectedBatchRowsById,
         });
+        const cultivarId = batchDisplay.identityId;
+        const cultivarName = cultivarsById[cultivarId]?.name ?? batchDisplay.name ?? '';
 
-        const batchCropTypeId = batch.cropTypeId ?? cultivarsById[getBatchCultivarLookupId(batch) ?? '']?.cropTypeId;
+        const batchCropTypeId = batchDisplay.cropTypeId;
         if (filters.crop && batchCropTypeId !== filters.crop) {
           return false;
         }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2164,6 +2164,7 @@ function SeedInventoryPage() {
   const [cropNames, setCropNames] = useState<Record<string, string>>({});
   const [speciesNames, setSpeciesNames] = useState<Record<string, string>>({});
   const [projectedRowsById, setProjectedRowsById] = useState<Record<string, SeedInventoryQueryRow>>({});
+  const [isProjectedInventoryAuthoritative, setIsProjectedInventoryAuthoritative] = useState(false);
   const [cultivarIds, setCultivarIds] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [savingId, setSavingId] = useState<string | null>(null);
@@ -2185,6 +2186,7 @@ function SeedInventoryPage() {
       setSpeciesNames({});
       setCultivarIds([]);
       setProjectedRowsById({});
+      setIsProjectedInventoryAuthoritative(false);
       setIsLoading(false);
       return;
     }
@@ -2210,11 +2212,14 @@ function SeedInventoryPage() {
       if (response.ok) {
         const projectedRows = await response.json() as SeedInventoryQueryRow[];
         setProjectedRowsById(Object.fromEntries(projectedRows.map((row) => [row.seedInventoryItemId, row])));
+        setIsProjectedInventoryAuthoritative(true);
       } else {
         setProjectedRowsById({});
+        setIsProjectedInventoryAuthoritative(false);
       }
     } catch {
       setProjectedRowsById({});
+      setIsProjectedInventoryAuthoritative(false);
     }
 
     setIsLoading(false);
@@ -2362,9 +2367,15 @@ function SeedInventoryPage() {
             const cultivar = cultivarsById[item.cultivarId];
             const projected = projectedRowsById[item.seedInventoryItemId];
             const cropTypeId = cultivar?.cropTypeId ?? item.cropId ?? '';
-            const cropTypeName = projected?.cropTypeName ?? (cropTypeId ? (cropNames[cropTypeId] ?? cropTypeId) : 'Unknown crop type');
-            const speciesName = projected?.speciesDisplay ?? (cropTypeId ? speciesNames[cropTypeId] : '');
-            const displayName = projected?.displayName ?? cultivar?.name ?? item.variety ?? item.cultivarId;
+            const cropTypeName = isProjectedInventoryAuthoritative
+              ? (projected?.cropTypeName ?? 'Unknown crop type')
+              : (cropTypeId ? (cropNames[cropTypeId] ?? cropTypeId) : 'Unknown crop type');
+            const speciesName = isProjectedInventoryAuthoritative
+              ? (projected?.speciesDisplay ?? '')
+              : (cropTypeId ? speciesNames[cropTypeId] : '');
+            const displayName = isProjectedInventoryAuthoritative
+              ? (projected?.displayName ?? item.cultivarId)
+              : (cultivar?.name ?? item.variety ?? item.cultivarId);
 
             return (
               <li key={item.seedInventoryItemId} className="seed-inventory-row">

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2133,11 +2133,21 @@ function CultivarAdminPage() {
   );
 }
 
+
+type SeedInventoryQueryRow = {
+  seedInventoryItemId: string;
+  cultivarId: string;
+  displayName: string;
+  cropTypeName: string;
+  speciesDisplay: string;
+};
+
 function SeedInventoryPage() {
   const [items, setItems] = useState<SeedInventoryItem[]>([]);
   const [cultivarsById, setCultivarsById] = useState<Record<string, CultivarRecord>>({});
   const [cropNames, setCropNames] = useState<Record<string, string>>({});
   const [speciesNames, setSpeciesNames] = useState<Record<string, string>>({});
+  const [projectedRowsById, setProjectedRowsById] = useState<Record<string, SeedInventoryQueryRow>>({});
   const [cultivarIds, setCultivarIds] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [savingId, setSavingId] = useState<string | null>(null);
@@ -2158,6 +2168,7 @@ function SeedInventoryPage() {
       setCropNames({});
       setSpeciesNames({});
       setCultivarIds([]);
+      setProjectedRowsById({});
       setIsLoading(false);
       return;
     }
@@ -2177,6 +2188,19 @@ function SeedInventoryPage() {
       ),
     );
     setCultivarIds(cultivars.map((cultivar) => cultivar.cultivarId).sort((left, right) => left.localeCompare(right)));
+
+    try {
+      const response = await fetch('/api/query/seed-inventory');
+      if (response.ok) {
+        const projectedRows = await response.json() as SeedInventoryQueryRow[];
+        setProjectedRowsById(Object.fromEntries(projectedRows.map((row) => [row.seedInventoryItemId, row])));
+      } else {
+        setProjectedRowsById({});
+      }
+    } catch {
+      setProjectedRowsById({});
+    }
+
     setIsLoading(false);
   }, []);
 
@@ -2320,10 +2344,11 @@ function SeedInventoryPage() {
         <ul className="seed-inventory-list">
           {items.map((item) => {
             const cultivar = cultivarsById[item.cultivarId];
+            const projected = projectedRowsById[item.seedInventoryItemId];
             const cropTypeId = cultivar?.cropTypeId ?? item.cropId ?? '';
-            const cropTypeName = cropTypeId ? (cropNames[cropTypeId] ?? cropTypeId) : 'Unknown crop type';
-            const speciesName = cropTypeId ? speciesNames[cropTypeId] : '';
-            const displayName = cultivar?.name ?? item.variety ?? item.cultivarId;
+            const cropTypeName = projected?.cropTypeName ?? (cropTypeId ? (cropNames[cropTypeId] ?? cropTypeId) : 'Unknown crop type');
+            const speciesName = projected?.speciesDisplay ?? (cropTypeId ? speciesNames[cropTypeId] : '');
+            const displayName = projected?.displayName ?? cultivar?.name ?? item.variety ?? item.cultivarId;
 
             return (
               <li key={item.seedInventoryItemId} className="seed-inventory-row">

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2134,6 +2134,11 @@ function CultivarAdminPage() {
 }
 
 
+type TaxonomyPickerQueryResponse = {
+  crops: Array<{ cropId: string; cropName: string; speciesId: string; speciesDisplay: string }>;
+  cultivars: Array<{ cultivarId: string; cultivarName: string; cropTypeId: string; cropTypeName: string; speciesDisplay: string; archived: boolean }>;
+};
+
 type SeedInventoryQueryRow = {
   seedInventoryItemId: string;
   cultivarId: string;
@@ -2188,6 +2193,18 @@ function SeedInventoryPage() {
       ),
     );
     setCultivarIds(cultivars.map((cultivar) => cultivar.cultivarId).sort((left, right) => left.localeCompare(right)));
+
+    try {
+      const taxonomyResponse = await fetch('/api/query/taxonomy-picker');
+      if (taxonomyResponse.ok) {
+        const taxonomy = await taxonomyResponse.json() as TaxonomyPickerQueryResponse;
+        setCropNames(Object.fromEntries(taxonomy.crops.map((crop) => [crop.cropId, crop.cropName])));
+        setSpeciesNames(Object.fromEntries(taxonomy.crops.map((crop) => [crop.cropId, crop.speciesDisplay])));
+        setCultivarIds(taxonomy.cultivars.map((cultivar) => cultivar.cultivarId).sort((left, right) => left.localeCompare(right)));
+      }
+    } catch {
+      // keep local fallback state from app state
+    }
 
     try {
       const response = await fetch('/api/query/seed-inventory');

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2147,6 +2147,17 @@ type SeedInventoryQueryRow = {
   speciesDisplay: string;
 };
 
+type BatchListQueryRow = {
+  batchId: string;
+  identityId: string;
+  capabilityCropId: string;
+  displayName: string;
+  cropTypeId: string;
+  cropTypeName: string;
+  speciesDisplay: string;
+};
+
+
 function SeedInventoryPage() {
   const [items, setItems] = useState<SeedInventoryItem[]>([]);
   const [cultivarsById, setCultivarsById] = useState<Record<string, CultivarRecord>>({});
@@ -2738,11 +2749,13 @@ const getBatchCultivarDisplay = ({
   cultivarsById,
   cropNames,
   cropScientificNames,
+  projectedRowsByBatchId,
 }: {
   batch: Batch;
   cultivarsById: Record<string, CultivarRecord>;
   cropNames: Record<string, string>;
   cropScientificNames: Record<string, string>;
+  projectedRowsByBatchId?: Record<string, BatchListQueryRow>;
 }): {
   identityId: string;
   capabilityCropId: string;
@@ -2752,17 +2765,18 @@ const getBatchCultivarDisplay = ({
   cropTypeName?: string | undefined;
 } => {
   const lookupId = getBatchCultivarLookupId(batch) ?? batch.batchId;
+  const projected = projectedRowsByBatchId?.[batch.batchId];
   const cultivar = cultivarsById[lookupId];
-  const cropTypeId = batch.cropTypeId ?? cultivar?.cropTypeId;
-  const capabilityCropId = cropTypeId ?? lookupId;
+  const cropTypeId = projected?.cropTypeId ?? batch.cropTypeId ?? cultivar?.cropTypeId;
+  const capabilityCropId = projected?.capabilityCropId ?? cropTypeId ?? lookupId;
 
   return {
-    identityId: cultivar?.cultivarId ?? lookupId,
+    identityId: projected?.identityId ?? cultivar?.cultivarId ?? lookupId,
     capabilityCropId,
-    name: cultivar?.name ?? cropNames[lookupId] ?? cropNames[cropTypeId ?? ''],
-    scientificName: cropScientificNames[cropTypeId ?? ''] ?? cropScientificNames[lookupId],
+    name: projected?.displayName ?? cultivar?.name ?? cropNames[lookupId] ?? cropNames[cropTypeId ?? ''],
+    scientificName: projected?.speciesDisplay ?? cropScientificNames[cropTypeId ?? ''] ?? cropScientificNames[lookupId],
     cropTypeId,
-    cropTypeName: cropNames[cropTypeId ?? ''],
+    cropTypeName: projected?.cropTypeName ?? cropNames[cropTypeId ?? ''],
   };
 };
 
@@ -2786,6 +2800,7 @@ function BatchesPage({
   const [userDefinedCropIds, setUserDefinedCropIds] = useState<Record<string, boolean>>({});
   const [cultivars, setCultivars] = useState<CultivarRecord[]>([]);
   const [speciesById, setSpeciesById] = useState<Record<string, Species>>({});
+  const [projectedBatchRowsById, setProjectedBatchRowsById] = useState<Record<string, BatchListQueryRow>>({});
   const [editingSpeciesId, setEditingSpeciesId] = useState<string>('');
   const [isLoading, setIsLoading] = useState(true);
   const [isDeletingBatchId, setIsDeletingBatchId] = useState<string | null>(null);
@@ -2872,6 +2887,7 @@ function BatchesPage({
         setUserDefinedCropIds({});
         setCultivars([]);
         setSpeciesById({});
+        setProjectedBatchRowsById({});
         setIsLoading(false);
         return;
       }
@@ -2914,6 +2930,18 @@ function BatchesPage({
         ),
       );
       setCultivars(getCultivarsFromAppState(appState));
+
+      try {
+        const batchQueryResponse = await fetch('/api/query/batch-list');
+        if (batchQueryResponse.ok) {
+          const projected = await batchQueryResponse.json() as BatchListQueryRow[];
+          setProjectedBatchRowsById(Object.fromEntries(projected.map((row) => [row.batchId, row])));
+        } else {
+          setProjectedBatchRowsById({});
+        }
+      } catch {
+        setProjectedBatchRowsById({});
+      }
 
       if (taxonomyOnly) {
         try {
@@ -3058,6 +3086,7 @@ function BatchesPage({
           cultivarsById,
           cropNames,
           cropScientificNames,
+          projectedRowsByBatchId: projectedBatchRowsById,
         });
 
         const batchCropTypeId = batch.cropTypeId ?? cultivarsById[getBatchCultivarLookupId(batch) ?? '']?.cropTypeId;
@@ -4933,6 +4962,7 @@ function BatchesPage({
               cultivarsById,
               cropNames,
               cropScientificNames,
+              projectedRowsByBatchId: projectedBatchRowsById,
             });
 
             return (

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2195,18 +2195,6 @@ function SeedInventoryPage() {
     setCultivarIds(cultivars.map((cultivar) => cultivar.cultivarId).sort((left, right) => left.localeCompare(right)));
 
     try {
-      const taxonomyResponse = await fetch('/api/query/taxonomy-picker');
-      if (taxonomyResponse.ok) {
-        const taxonomy = await taxonomyResponse.json() as TaxonomyPickerQueryResponse;
-        setCropNames(Object.fromEntries(taxonomy.crops.map((crop) => [crop.cropId, crop.cropName])));
-        setSpeciesNames(Object.fromEntries(taxonomy.crops.map((crop) => [crop.cropId, crop.speciesDisplay])));
-        setCultivarIds(taxonomy.cultivars.map((cultivar) => cultivar.cultivarId).sort((left, right) => left.localeCompare(right)));
-      }
-    } catch {
-      // keep local fallback state from app state
-    }
-
-    try {
       const response = await fetch('/api/query/seed-inventory');
       if (response.ok) {
         const projectedRows = await response.json() as SeedInventoryQueryRow[];
@@ -2926,11 +2914,25 @@ function BatchesPage({
         ),
       );
       setCultivars(getCultivarsFromAppState(appState));
+
+      if (taxonomyOnly) {
+        try {
+          const taxonomyResponse = await fetch('/api/query/taxonomy-picker');
+          if (taxonomyResponse.ok) {
+            const taxonomy = await taxonomyResponse.json() as TaxonomyPickerQueryResponse;
+            setCropNames(Object.fromEntries(taxonomy.crops.map((crop) => [crop.cropId, crop.cropName])));
+            setCropScientificNames(Object.fromEntries(taxonomy.crops.map((crop) => [crop.cropId, crop.speciesDisplay])));
+          }
+        } catch {
+          // keep app-state fallback values
+        }
+      }
+
       setIsLoading(false);
     };
 
     void load();
-  }, []);
+  }, [taxonomyOnly]);
 
   const filters = useMemo(
     () => ({

--- a/frontend/src/generated/api-client.ts
+++ b/frontend/src/generated/api-client.ts
@@ -13,6 +13,7 @@ export type BackendApiPath =
   | '/api/settings'
   | '/api/query/taxonomy-picker'
   | '/api/query/seed-inventory'
+  | '/api/query/batch-list'
   | '/api/species'
   | '/api/species/{id}'
   | '/api/crops'

--- a/frontend/src/generated/api-client.ts
+++ b/frontend/src/generated/api-client.ts
@@ -11,6 +11,8 @@ export type BackendApiPath =
   | '/'
   | '/api/app-state'
   | '/api/settings'
+  | '/api/query/taxonomy-picker'
+  | '/api/query/seed-inventory'
   | '/api/species'
   | '/api/species/{id}'
   | '/api/crops'

--- a/frontend/src/generated/openapi-paths.ts
+++ b/frontend/src/generated/openapi-paths.ts
@@ -20,15 +20,7 @@ export interface paths {
                     headers: {
                         [name: string]: unknown;
                     };
-                    content: {
-                        "application/json": Array<{
-                            seedInventoryItemId: string;
-                            cultivarId: string;
-                            displayName: string;
-                            cropTypeName: string;
-                            speciesDisplay: string;
-                        }>;
-                    };
+                    content?: never;
                 };
             };
         };
@@ -1037,17 +1029,7 @@ export interface paths {
                     headers: {
                         [name: string]: unknown;
                     };
-                    content: {
-                        "application/json": Array<{
-                            batchId: string;
-                            identityId: string;
-                            capabilityCropId: string;
-                            displayName: string;
-                            cropTypeId: string;
-                            cropTypeName: string;
-                            speciesDisplay: string;
-                        }>;
-                    };
+                    content?: never;
                 };
             };
         };
@@ -1113,24 +1095,7 @@ export interface paths {
                     headers: {
                         [name: string]: unknown;
                     };
-                    content: {
-                        "application/json": {
-                            crops: Array<{
-                                cropId: string;
-                                cropName: string;
-                                speciesId: string;
-                                speciesDisplay: string;
-                            }>;
-                            cultivars: Array<{
-                                cultivarId: string;
-                                cultivarName: string;
-                                cropTypeId: string;
-                                cropTypeName: string;
-                                speciesDisplay: string;
-                                archived: boolean;
-                            }>;
-                        };
-                    };
+                    content?: never;
                 };
             };
         };

--- a/frontend/src/generated/openapi-paths.ts
+++ b/frontend/src/generated/openapi-paths.ts
@@ -20,7 +20,15 @@ export interface paths {
                     headers: {
                         [name: string]: unknown;
                     };
-                    content?: never;
+                    content: {
+                        "application/json": Array<{
+                            seedInventoryItemId: string;
+                            cultivarId: string;
+                            displayName: string;
+                            cropTypeName: string;
+                            speciesDisplay: string;
+                        }>;
+                    };
                 };
             };
         };
@@ -1008,6 +1016,49 @@ export interface paths {
         };
         trace?: never;
     };
+    "/api/query/batch-list": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": Array<{
+                            batchId: string;
+                            identityId: string;
+                            capabilityCropId: string;
+                            displayName: string;
+                            cropTypeId: string;
+                            cropTypeName: string;
+                            speciesDisplay: string;
+                        }>;
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/query/seed-inventory": {
         parameters: {
             query?: never;
@@ -1062,7 +1113,24 @@ export interface paths {
                     headers: {
                         [name: string]: unknown;
                     };
-                    content?: never;
+                    content: {
+                        "application/json": {
+                            crops: Array<{
+                                cropId: string;
+                                cropName: string;
+                                speciesId: string;
+                                speciesDisplay: string;
+                            }>;
+                            cultivars: Array<{
+                                cultivarId: string;
+                                cultivarName: string;
+                                cropTypeId: string;
+                                cropTypeName: string;
+                                speciesDisplay: string;
+                                archived: boolean;
+                            }>;
+                        };
+                    };
                 };
             };
         };

--- a/frontend/src/generated/openapi-paths.ts
+++ b/frontend/src/generated/openapi-paths.ts
@@ -1008,6 +1008,72 @@ export interface paths {
         };
         trace?: never;
     };
+    "/api/query/seed-inventory": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/query/taxonomy-picker": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/seedInventoryItems": {
         parameters: {
             query?: never;


### PR DESCRIPTION
### Motivation
- Reduce frontend responsibility for stitching taxonomy, cultivars, and inventory into display models by providing backend read-only projections.
- Move simple join/projection logic server-side for key UI workflows (seed inventory list and taxonomy pickers) to make the client thinner and more robust.
- Apply the change only to display plumbing, preserving existing normalized CRUD endpoints and write semantics.

### Description
- Added two read-only query endpoints in `CoreEndpoints.cs`: `GET /api/query/taxonomy-picker` and `GET /api/query/seed-inventory`, which load app-state and project display-oriented DTOs by joining species/crops/cultivars/seedInventoryItems server-side.
- Updated `SeedInventoryPage` in `frontend/src/App.tsx` to introduce `SeedInventoryQueryRow`, fetch `/api/query/seed-inventory` during `loadInventory`, store projected rows in `projectedRowsById`, and prefer projected display fields with graceful fallback to existing local joins.
- Kept all existing entity CRUD and write paths untouched and ensured the new endpoints are read-only projections only.

### Testing
- No automated tests were executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f85859bc1c8326841fec30160e7136)