### PR TITLE
#62: Add taxonomy-picker and seed-inventory query endpoints and surface enriched data in UI

### DIFF
--- a/backend/SurvivalGarden.Api/Endpoints/CoreEndpoints.cs
+++ b/backend/SurvivalGarden.Api/Endpoints/CoreEndpoints.cs
@@ -56,6 +56,85 @@ internal static class CoreEndpoints
             return Results.Ok(payload);
         });
 
+
+        app.MapGet("/api/query/taxonomy-picker", async (IGardenApplicationService service, CancellationToken ct) =>
+        {
+            var state = await service.LoadAppStateAsync(ct);
+            if (state is null)
+            {
+                return Results.NotFound();
+            }
+
+            var speciesById = BuildSpeciesLookup(state);
+
+            var crops = (state["crops"] as JsonArray ?? []).OfType<JsonObject>().ToArray();
+            var cultivars = (state["cultivars"] as JsonArray ?? []).OfType<JsonObject>().ToArray();
+
+            var cropRows = crops.Select(crop =>
+            {
+                var cropId = crop["cropId"]?.GetValue<string>() ?? string.Empty;
+                var speciesId = crop["speciesId"]?.GetValue<string>() ?? string.Empty;
+                return new
+                {
+                    cropId,
+                    cropName = crop["name"]?.GetValue<string>() ?? cropId,
+                    speciesId,
+                    speciesDisplay = ResolveSpeciesDisplay(speciesById, speciesId)
+                };
+            });
+
+            var cultivarRows = cultivars.Select(cultivar =>
+            {
+                var cropTypeId = cultivar["cropTypeId"]?.GetValue<string>() ?? string.Empty;
+                var crop = crops.FirstOrDefault(candidate => string.Equals(candidate["cropId"]?.GetValue<string>(), cropTypeId, StringComparison.Ordinal));
+                var speciesId = crop?["speciesId"]?.GetValue<string>() ?? string.Empty;
+                return new
+                {
+                    cultivarId = cultivar["cultivarId"]?.GetValue<string>() ?? string.Empty,
+                    cultivarName = cultivar["name"]?.GetValue<string>() ?? string.Empty,
+                    cropTypeId,
+                    cropTypeName = crop?["name"]?.GetValue<string>() ?? cropTypeId,
+                    speciesDisplay = ResolveSpeciesDisplay(speciesById, speciesId),
+                    archived = cultivar["isArchived"]?.GetValue<bool>() ?? false
+                };
+            });
+
+            return Results.Ok(new { crops = cropRows, cultivars = cultivarRows });
+        });
+
+        app.MapGet("/api/query/seed-inventory", async (IGardenApplicationService service, CancellationToken ct) =>
+        {
+            var state = await service.LoadAppStateAsync(ct);
+            if (state is null)
+            {
+                return Results.NotFound();
+            }
+
+            var items = (state["seedInventoryItems"] as JsonArray ?? []).OfType<JsonObject>().ToArray();
+            var crops = (state["crops"] as JsonArray ?? []).OfType<JsonObject>().ToArray();
+            var cultivars = (state["cultivars"] as JsonArray ?? []).OfType<JsonObject>().ToArray();
+            var speciesById = BuildSpeciesLookup(state);
+
+            var rows = items.Select(item =>
+            {
+                var cultivarId = item["cultivarId"]?.GetValue<string>() ?? string.Empty;
+                var cultivar = cultivars.FirstOrDefault(candidate => string.Equals(candidate["cultivarId"]?.GetValue<string>(), cultivarId, StringComparison.Ordinal));
+                var cropTypeId = cultivar?["cropTypeId"]?.GetValue<string>() ?? item["cropId"]?.GetValue<string>() ?? string.Empty;
+                var crop = crops.FirstOrDefault(candidate => string.Equals(candidate["cropId"]?.GetValue<string>(), cropTypeId, StringComparison.Ordinal));
+                var speciesId = crop?["speciesId"]?.GetValue<string>() ?? string.Empty;
+                return new
+                {
+                    seedInventoryItemId = item["seedInventoryItemId"]?.GetValue<string>() ?? string.Empty,
+                    cultivarId,
+                    displayName = cultivar?["name"]?.GetValue<string>() ?? item["variety"]?.GetValue<string>() ?? cultivarId,
+                    cropTypeName = crop?["name"]?.GetValue<string>() ?? cropTypeId,
+                    speciesDisplay = ResolveSpeciesDisplay(speciesById, speciesId)
+                };
+            });
+
+            return Results.Ok(rows);
+        });
+
         MapEntityCrud(app, "species", "id");
         MapTypedEntityCrud<CropUpsertRequest>(app, "crops", "cropId", (payload, id) =>
         {
@@ -79,6 +158,22 @@ internal static class CoreEndpoints
                 issues = validation.Issues
             });
         });
+    }
+
+
+    private static Dictionary<string, JsonObject> BuildSpeciesLookup(JsonObject state) =>
+        (state["species"] as JsonArray ?? []).OfType<JsonObject>()
+            .Where(species => !string.IsNullOrWhiteSpace(species["id"]?.GetValue<string>()))
+            .ToDictionary(species => species["id"]!.GetValue<string>(), species => species);
+
+    private static string ResolveSpeciesDisplay(IReadOnlyDictionary<string, JsonObject> speciesById, string speciesId)
+    {
+        if (!speciesById.TryGetValue(speciesId, out var species))
+        {
+            return string.Empty;
+        }
+
+        return species["commonName"]?.GetValue<string>() ?? species["scientificName"]?.GetValue<string>() ?? string.Empty;
     }
 
     private static void MapEntityCrud(WebApplication app, string collectionName, string idProperty)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2133,11 +2133,26 @@ function CultivarAdminPage() {
   );
 }
 
+
+type TaxonomyPickerQueryResponse = {
+  crops: Array<{ cropId: string; cropName: string; speciesId: string; speciesDisplay: string }>;
+  cultivars: Array<{ cultivarId: string; cultivarName: string; cropTypeId: string; cropTypeName: string; speciesDisplay: string; archived: boolean }>;
+};
+
+type SeedInventoryQueryRow = {
+  seedInventoryItemId: string;
+  cultivarId: string;
+  displayName: string;
+  cropTypeName: string;
+  speciesDisplay: string;
+};
+
 function SeedInventoryPage() {
   const [items, setItems] = useState<SeedInventoryItem[]>([]);
   const [cultivarsById, setCultivarsById] = useState<Record<string, CultivarRecord>>({});
   const [cropNames, setCropNames] = useState<Record<string, string>>({});
   const [speciesNames, setSpeciesNames] = useState<Record<string, string>>({});
+  const [projectedRowsById, setProjectedRowsById] = useState<Record<string, SeedInventoryQueryRow>>({});
   const [cultivarIds, setCultivarIds] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [savingId, setSavingId] = useState<string | null>(null);
@@ -2158,6 +2173,7 @@ function SeedInventoryPage() {
       setCropNames({});
       setSpeciesNames({});
       setCultivarIds([]);
+      setProjectedRowsById({});
       setIsLoading(false);
       return;
     }
@@ -2177,6 +2193,19 @@ function SeedInventoryPage() {
       ),
     );
     setCultivarIds(cultivars.map((cultivar) => cultivar.cultivarId).sort((left, right) => left.localeCompare(right)));
+
+    try {
+      const response = await fetch('/api/query/seed-inventory');
+      if (response.ok) {
+        const projectedRows = await response.json() as SeedInventoryQueryRow[];
+        setProjectedRowsById(Object.fromEntries(projectedRows.map((row) => [row.seedInventoryItemId, row])));
+      } else {
+        setProjectedRowsById({});
+      }
+    } catch {
+      setProjectedRowsById({});
+    }
+
     setIsLoading(false);
   }, []);
 
@@ -2320,10 +2349,11 @@ function SeedInventoryPage() {
         <ul className="seed-inventory-list">
           {items.map((item) => {
             const cultivar = cultivarsById[item.cultivarId];
+            const projected = projectedRowsById[item.seedInventoryItemId];
             const cropTypeId = cultivar?.cropTypeId ?? item.cropId ?? '';
-            const cropTypeName = cropTypeId ? (cropNames[cropTypeId] ?? cropTypeId) : 'Unknown crop type';
-            const speciesName = cropTypeId ? speciesNames[cropTypeId] : '';
-            const displayName = cultivar?.name ?? item.variety ?? item.cultivarId;
+            const cropTypeName = projected?.cropTypeName ?? (cropTypeId ? (cropNames[cropTypeId] ?? cropTypeId) : 'Unknown crop type');
+            const speciesName = projected?.speciesDisplay ?? (cropTypeId ? speciesNames[cropTypeId] : '');
+            const displayName = projected?.displayName ?? cultivar?.name ?? item.variety ?? item.cultivarId;
 
             return (
               <li key={item.seedInventoryItemId} className="seed-inventory-row">
@@ -2884,11 +2914,25 @@ function BatchesPage({
         ),
       );
       setCultivars(getCultivarsFromAppState(appState));
+
+      if (taxonomyOnly) {
+        try {
+          const taxonomyResponse = await fetch('/api/query/taxonomy-picker');
+          if (taxonomyResponse.ok) {
+            const taxonomy = await taxonomyResponse.json() as TaxonomyPickerQueryResponse;
+            setCropNames(Object.fromEntries(taxonomy.crops.map((crop) => [crop.cropId, crop.cropName])));
+            setCropScientificNames(Object.fromEntries(taxonomy.crops.map((crop) => [crop.cropId, crop.speciesDisplay])));
+          }
+        } catch {
+          // keep app-state fallback values
+        }
+      }
+
       setIsLoading(false);
     };
 
     void load();
-  }, []);
+  }, [taxonomyOnly]);
 
   const filters = useMemo(
     () => ({

--- a/frontend/src/generated/api-client.ts
+++ b/frontend/src/generated/api-client.ts
@@ -11,6 +11,8 @@ export type BackendApiPath =
   | '/'
   | '/api/app-state'
   | '/api/settings'
+  | '/api/query/taxonomy-picker'
+  | '/api/query/seed-inventory'
   | '/api/species'
   | '/api/species/{id}'
   | '/api/crops'

--- a/frontend/src/generated/openapi-paths.ts
+++ b/frontend/src/generated/openapi-paths.ts
@@ -1008,6 +1008,72 @@ export interface paths {
         };
         trace?: never;
     };
+    "/api/query/seed-inventory": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/query/taxonomy-picker": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/seedInventoryItems": {
         parameters: {
             query?: never;


### PR DESCRIPTION
### Motivation

- Provide lightweight query endpoints to drive UI pickers and enrich seed inventory display without reading full app state in the client.
- Improve seed inventory rows with resolved cultivar/crop/species labels and avoid reliance solely on local app-state joins.

### Description

- Adds two new backend endpoints: `GET /api/query/taxonomy-picker` to return flattened crop and cultivar rows and `GET /api/query/seed-inventory` to return projected seed inventory rows with resolved cultivar, crop type, and species display values.
- Implements helper methods `BuildSpeciesLookup` and `ResolveSpeciesDisplay` to centralize species lookup and display resolution in `CoreEndpoints.cs`.
- Updates frontend `App.tsx` to declare types for the new query payloads, fetch `/api/query/seed-inventory` to populate `projectedRowsById`, and prefer the projected `displayName`, `cropTypeName`, and `speciesDisplay` when rendering seed inventory rows.
- Adds optional fetch of `/api/query/taxonomy-picker` when `taxonomyOnly` is true to populate crop name and scientific name overrides and wires the data into existing `cropNames` and `cropScientificNames` state.

### Testing

- Ran a backend build with `dotnet build` which completed successfully.
- Ran a frontend build with `npm run build` which completed successfully.
- No new automated unit tests were added for these query endpoints in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f85859bc1c8326841fec30160e7136)