### PR TITLE
Add /api/query/batch-list and consume projected batch display data in frontend

### DIFF
--- a/backend/SurvivalGarden.Api/Endpoints/CoreEndpoints.cs
+++ b/backend/SurvivalGarden.Api/Endpoints/CoreEndpoints.cs
@@ -135,6 +135,43 @@ internal static class CoreEndpoints
             return Results.Ok(rows);
         });
 
+        app.MapGet("/api/query/batch-list", async (IGardenApplicationService service, CancellationToken ct) =>
+        {
+            var state = await service.LoadAppStateAsync(ct);
+            if (state is null)
+            {
+                return Results.NotFound();
+            }
+
+            var batches = (state["batches"] as JsonArray ?? []).OfType<JsonObject>().ToArray();
+            var crops = (state["crops"] as JsonArray ?? []).OfType<JsonObject>().ToArray();
+            var cultivars = (state["cultivars"] as JsonArray ?? []).OfType<JsonObject>().ToArray();
+            var speciesById = BuildSpeciesLookup(state);
+
+            var rows = batches.Select(batch =>
+            {
+                var batchId = batch["batchId"]?.GetValue<string>() ?? string.Empty;
+                var lookupId = batch["cultivarId"]?.GetValue<string>() ?? batch["cropId"]?.GetValue<string>() ?? batchId;
+                var cultivar = cultivars.FirstOrDefault(candidate => string.Equals(candidate["cultivarId"]?.GetValue<string>(), lookupId, StringComparison.Ordinal));
+                var cropTypeId = batch["cropTypeId"]?.GetValue<string>() ?? cultivar?["cropTypeId"]?.GetValue<string>() ?? string.Empty;
+                var crop = crops.FirstOrDefault(candidate => string.Equals(candidate["cropId"]?.GetValue<string>(), cropTypeId, StringComparison.Ordinal));
+                var speciesId = crop?["speciesId"]?.GetValue<string>() ?? string.Empty;
+
+                return new
+                {
+                    batchId,
+                    identityId = cultivar?["cultivarId"]?.GetValue<string>() ?? lookupId,
+                    capabilityCropId = string.IsNullOrEmpty(cropTypeId) ? lookupId : cropTypeId,
+                    displayName = cultivar?["name"]?.GetValue<string>() ?? crop?["name"]?.GetValue<string>() ?? lookupId,
+                    cropTypeId,
+                    cropTypeName = crop?["name"]?.GetValue<string>() ?? cropTypeId,
+                    speciesDisplay = ResolveSpeciesDisplay(speciesById, speciesId)
+                };
+            });
+
+            return Results.Ok(rows);
+        });
+
         MapEntityCrud(app, "species", "id");
         MapTypedEntityCrud<CropUpsertRequest>(app, "crops", "cropId", (payload, id) =>
         {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2147,6 +2147,17 @@ type SeedInventoryQueryRow = {
   speciesDisplay: string;
 };
 
+type BatchListQueryRow = {
+  batchId: string;
+  identityId: string;
+  capabilityCropId: string;
+  displayName: string;
+  cropTypeId: string;
+  cropTypeName: string;
+  speciesDisplay: string;
+};
+
+
 function SeedInventoryPage() {
   const [items, setItems] = useState<SeedInventoryItem[]>([]);
   const [cultivarsById, setCultivarsById] = useState<Record<string, CultivarRecord>>({});
@@ -2738,11 +2749,13 @@ const getBatchCultivarDisplay = ({
   cultivarsById,
   cropNames,
   cropScientificNames,
+  projectedRowsByBatchId,
 }: {
   batch: Batch;
   cultivarsById: Record<string, CultivarRecord>;
   cropNames: Record<string, string>;
   cropScientificNames: Record<string, string>;
+  projectedRowsByBatchId?: Record<string, BatchListQueryRow>;
 }): {
   identityId: string;
   capabilityCropId: string;
@@ -2752,17 +2765,18 @@ const getBatchCultivarDisplay = ({
   cropTypeName?: string | undefined;
 } => {
   const lookupId = getBatchCultivarLookupId(batch) ?? batch.batchId;
+  const projected = projectedRowsByBatchId?.[batch.batchId];
   const cultivar = cultivarsById[lookupId];
-  const cropTypeId = batch.cropTypeId ?? cultivar?.cropTypeId;
-  const capabilityCropId = cropTypeId ?? lookupId;
+  const cropTypeId = projected?.cropTypeId ?? batch.cropTypeId ?? cultivar?.cropTypeId;
+  const capabilityCropId = projected?.capabilityCropId ?? cropTypeId ?? lookupId;
 
   return {
-    identityId: cultivar?.cultivarId ?? lookupId,
+    identityId: projected?.identityId ?? cultivar?.cultivarId ?? lookupId,
     capabilityCropId,
-    name: cultivar?.name ?? cropNames[lookupId] ?? cropNames[cropTypeId ?? ''],
-    scientificName: cropScientificNames[cropTypeId ?? ''] ?? cropScientificNames[lookupId],
+    name: projected?.displayName ?? cultivar?.name ?? cropNames[lookupId] ?? cropNames[cropTypeId ?? ''],
+    scientificName: projected?.speciesDisplay ?? cropScientificNames[cropTypeId ?? ''] ?? cropScientificNames[lookupId],
     cropTypeId,
-    cropTypeName: cropNames[cropTypeId ?? ''],
+    cropTypeName: projected?.cropTypeName ?? cropNames[cropTypeId ?? ''],
   };
 };
 
@@ -2786,6 +2800,7 @@ function BatchesPage({
   const [userDefinedCropIds, setUserDefinedCropIds] = useState<Record<string, boolean>>({});
   const [cultivars, setCultivars] = useState<CultivarRecord[]>([]);
   const [speciesById, setSpeciesById] = useState<Record<string, Species>>({});
+  const [projectedBatchRowsById, setProjectedBatchRowsById] = useState<Record<string, BatchListQueryRow>>({});
   const [editingSpeciesId, setEditingSpeciesId] = useState<string>('');
   const [isLoading, setIsLoading] = useState(true);
   const [isDeletingBatchId, setIsDeletingBatchId] = useState<string | null>(null);
@@ -2872,6 +2887,7 @@ function BatchesPage({
         setUserDefinedCropIds({});
         setCultivars([]);
         setSpeciesById({});
+        setProjectedBatchRowsById({});
         setIsLoading(false);
         return;
       }
@@ -2914,6 +2930,18 @@ function BatchesPage({
         ),
       );
       setCultivars(getCultivarsFromAppState(appState));
+
+      try {
+        const batchQueryResponse = await fetch('/api/query/batch-list');
+        if (batchQueryResponse.ok) {
+          const projected = await batchQueryResponse.json() as BatchListQueryRow[];
+          setProjectedBatchRowsById(Object.fromEntries(projected.map((row) => [row.batchId, row])));
+        } else {
+          setProjectedBatchRowsById({});
+        }
+      } catch {
+        setProjectedBatchRowsById({});
+      }
 
       if (taxonomyOnly) {
         try {
@@ -3058,6 +3086,7 @@ function BatchesPage({
           cultivarsById,
           cropNames,
           cropScientificNames,
+          projectedRowsByBatchId: projectedBatchRowsById,
         });
 
         const batchCropTypeId = batch.cropTypeId ?? cultivarsById[getBatchCultivarLookupId(batch) ?? '']?.cropTypeId;
@@ -4933,6 +4962,7 @@ function BatchesPage({
               cultivarsById,
               cropNames,
               cropScientificNames,
+              projectedRowsByBatchId: projectedBatchRowsById,
             });
 
             return (

--- a/frontend/src/generated/api-client.ts
+++ b/frontend/src/generated/api-client.ts
@@ -13,6 +13,7 @@ export type BackendApiPath =
   | '/api/settings'
   | '/api/query/taxonomy-picker'
   | '/api/query/seed-inventory'
+  | '/api/query/batch-list'
   | '/api/species'
   | '/api/species/{id}'
   | '/api/crops'

--- a/frontend/src/generated/openapi-paths.ts
+++ b/frontend/src/generated/openapi-paths.ts
@@ -20,15 +20,7 @@ export interface paths {
                     headers: {
                         [name: string]: unknown;
                     };
-                    content: {
-                        "application/json": Array<{
-                            seedInventoryItemId: string;
-                            cultivarId: string;
-                            displayName: string;
-                            cropTypeName: string;
-                            speciesDisplay: string;
-                        }>;
-                    };
+                    content?: never;
                 };
             };
         };
@@ -1037,17 +1029,7 @@ export interface paths {
                     headers: {
                         [name: string]: unknown;
                     };
-                    content: {
-                        "application/json": Array<{
-                            batchId: string;
-                            identityId: string;
-                            capabilityCropId: string;
-                            displayName: string;
-                            cropTypeId: string;
-                            cropTypeName: string;
-                            speciesDisplay: string;
-                        }>;
-                    };
+                    content?: never;
                 };
             };
         };
@@ -1113,24 +1095,7 @@ export interface paths {
                     headers: {
                         [name: string]: unknown;
                     };
-                    content: {
-                        "application/json": {
-                            crops: Array<{
-                                cropId: string;
-                                cropName: string;
-                                speciesId: string;
-                                speciesDisplay: string;
-                            }>;
-                            cultivars: Array<{
-                                cultivarId: string;
-                                cultivarName: string;
-                                cropTypeId: string;
-                                cropTypeName: string;
-                                speciesDisplay: string;
-                                archived: boolean;
-                            }>;
-                        };
-                    };
+                    content?: never;
                 };
             };
         };

--- a/frontend/src/generated/openapi-paths.ts
+++ b/frontend/src/generated/openapi-paths.ts
@@ -20,7 +20,15 @@ export interface paths {
                     headers: {
                         [name: string]: unknown;
                     };
-                    content?: never;
+                    content: {
+                        "application/json": Array<{
+                            seedInventoryItemId: string;
+                            cultivarId: string;
+                            displayName: string;
+                            cropTypeName: string;
+                            speciesDisplay: string;
+                        }>;
+                    };
                 };
             };
         };
@@ -1008,6 +1016,49 @@ export interface paths {
         };
         trace?: never;
     };
+    "/api/query/batch-list": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": Array<{
+                            batchId: string;
+                            identityId: string;
+                            capabilityCropId: string;
+                            displayName: string;
+                            cropTypeId: string;
+                            cropTypeName: string;
+                            speciesDisplay: string;
+                        }>;
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/query/seed-inventory": {
         parameters: {
             query?: never;
@@ -1062,7 +1113,24 @@ export interface paths {
                     headers: {
                         [name: string]: unknown;
                     };
-                    content?: never;
+                    content: {
+                        "application/json": {
+                            crops: Array<{
+                                cropId: string;
+                                cropName: string;
+                                speciesId: string;
+                                speciesDisplay: string;
+                            }>;
+                            cultivars: Array<{
+                                cultivarId: string;
+                                cultivarName: string;
+                                cropTypeId: string;
+                                cropTypeName: string;
+                                speciesDisplay: string;
+                                archived: boolean;
+                            }>;
+                        };
+                    };
                 };
             };
         };


### PR DESCRIPTION
### Motivation
- Provide a server-side projection of batch display metadata so the UI can show consistent cultivar/crop/species names and capability IDs without recomputing on the client. 
- Surface a compact, typed batch list via a new query endpoint to decouple display logic from stored batch payload structure. 
- Update generated API and OpenAPI types so the frontend can call the new endpoint with proper typings.

### Description
- Add a new endpoint `GET /api/query/batch-list` in `CoreEndpoints` that builds a projection of batches including `batchId`, `identityId`, `capabilityCropId`, `displayName`, `cropTypeId`, `cropTypeName`, and `speciesDisplay` by resolving cultivars, crops, and species. 
- Update the frontend `App.tsx` to introduce `BatchListQueryRow` type, a `projectedBatchRowsById` state, and a fetch to `/api/query/batch-list` during app-state load to populate that map. 
- Modify `getBatchCultivarDisplay` and batch list rendering to accept and prefer the projected server values where available so display names, species, and capability IDs come from the server projection. 
- Regenerate API/OpenAPI types in `frontend/src/generated/api-client.ts` and `frontend/src/generated/openapi-paths.ts` to include the new path and response schemas and to more explicitly type some existing query responses.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f864b098e08326ba4c3bbf08f2bd39)