### PR TITLE
Introduce DTOs for taxonomy, seed-inventory, and batch query endpoints

### DIFF
--- a/backend/SurvivalGarden.Api/Endpoints/CoreEndpoints.cs
+++ b/backend/SurvivalGarden.Api/Endpoints/CoreEndpoints.cs
@@ -74,12 +74,12 @@ internal static class CoreEndpoints
             {
                 var cropId = crop["cropId"]?.GetValue<string>() ?? string.Empty;
                 var speciesId = crop["speciesId"]?.GetValue<string>() ?? string.Empty;
-                return new
+                return new TaxonomyPickerCropDto
                 {
-                    cropId,
-                    cropName = crop["name"]?.GetValue<string>() ?? cropId,
-                    speciesId,
-                    speciesDisplay = ResolveSpeciesDisplay(speciesById, speciesId)
+                    CropId = cropId,
+                    CropName = crop["name"]?.GetValue<string>() ?? cropId,
+                    SpeciesId = speciesId,
+                    SpeciesDisplay = ResolveSpeciesDisplay(speciesById, speciesId)
                 };
             });
 
@@ -88,18 +88,22 @@ internal static class CoreEndpoints
                 var cropTypeId = cultivar["cropTypeId"]?.GetValue<string>() ?? string.Empty;
                 var crop = crops.FirstOrDefault(candidate => string.Equals(candidate["cropId"]?.GetValue<string>(), cropTypeId, StringComparison.Ordinal));
                 var speciesId = crop?["speciesId"]?.GetValue<string>() ?? string.Empty;
-                return new
+                return new TaxonomyPickerCultivarDto
                 {
-                    cultivarId = cultivar["cultivarId"]?.GetValue<string>() ?? string.Empty,
-                    cultivarName = cultivar["name"]?.GetValue<string>() ?? string.Empty,
-                    cropTypeId,
-                    cropTypeName = crop?["name"]?.GetValue<string>() ?? cropTypeId,
-                    speciesDisplay = ResolveSpeciesDisplay(speciesById, speciesId),
-                    archived = cultivar["isArchived"]?.GetValue<bool>() ?? false
+                    CultivarId = cultivar["cultivarId"]?.GetValue<string>() ?? string.Empty,
+                    CultivarName = cultivar["name"]?.GetValue<string>() ?? string.Empty,
+                    CropTypeId = cropTypeId,
+                    CropTypeName = crop?["name"]?.GetValue<string>() ?? cropTypeId,
+                    SpeciesDisplay = ResolveSpeciesDisplay(speciesById, speciesId),
+                    Archived = cultivar["isArchived"]?.GetValue<bool>() ?? false
                 };
             });
 
-            return Results.Ok(new { crops = cropRows, cultivars = cultivarRows });
+            return Results.Ok(new TaxonomyPickerQueryResponseDto
+            {
+                Crops = cropRows.ToArray(),
+                Cultivars = cultivarRows.ToArray()
+            });
         });
 
         app.MapGet("/api/query/seed-inventory", async (IGardenApplicationService service, CancellationToken ct) =>
@@ -122,17 +126,17 @@ internal static class CoreEndpoints
                 var cropTypeId = cultivar?["cropTypeId"]?.GetValue<string>() ?? item["cropId"]?.GetValue<string>() ?? string.Empty;
                 var crop = crops.FirstOrDefault(candidate => string.Equals(candidate["cropId"]?.GetValue<string>(), cropTypeId, StringComparison.Ordinal));
                 var speciesId = crop?["speciesId"]?.GetValue<string>() ?? string.Empty;
-                return new
+                return new SeedInventoryQueryRowDto
                 {
-                    seedInventoryItemId = item["seedInventoryItemId"]?.GetValue<string>() ?? string.Empty,
-                    cultivarId,
-                    displayName = cultivar?["name"]?.GetValue<string>() ?? item["variety"]?.GetValue<string>() ?? cultivarId,
-                    cropTypeName = crop?["name"]?.GetValue<string>() ?? cropTypeId,
-                    speciesDisplay = ResolveSpeciesDisplay(speciesById, speciesId)
+                    SeedInventoryItemId = item["seedInventoryItemId"]?.GetValue<string>() ?? string.Empty,
+                    CultivarId = cultivarId,
+                    DisplayName = cultivar?["name"]?.GetValue<string>() ?? item["variety"]?.GetValue<string>() ?? cultivarId,
+                    CropTypeName = crop?["name"]?.GetValue<string>() ?? cropTypeId,
+                    SpeciesDisplay = ResolveSpeciesDisplay(speciesById, speciesId)
                 };
             });
 
-            return Results.Ok(rows);
+            return Results.Ok(rows.ToArray());
         });
 
         app.MapGet("/api/query/batch-list", async (IGardenApplicationService service, CancellationToken ct) =>
@@ -157,19 +161,19 @@ internal static class CoreEndpoints
                 var crop = crops.FirstOrDefault(candidate => string.Equals(candidate["cropId"]?.GetValue<string>(), cropTypeId, StringComparison.Ordinal));
                 var speciesId = crop?["speciesId"]?.GetValue<string>() ?? string.Empty;
 
-                return new
+                return new BatchListQueryRowDto
                 {
-                    batchId,
-                    identityId = cultivar?["cultivarId"]?.GetValue<string>() ?? lookupId,
-                    capabilityCropId = string.IsNullOrEmpty(cropTypeId) ? lookupId : cropTypeId,
-                    displayName = cultivar?["name"]?.GetValue<string>() ?? crop?["name"]?.GetValue<string>() ?? lookupId,
-                    cropTypeId,
-                    cropTypeName = crop?["name"]?.GetValue<string>() ?? cropTypeId,
-                    speciesDisplay = ResolveSpeciesDisplay(speciesById, speciesId)
+                    BatchId = batchId,
+                    IdentityId = cultivar?["cultivarId"]?.GetValue<string>() ?? lookupId,
+                    CapabilityCropId = string.IsNullOrEmpty(cropTypeId) ? lookupId : cropTypeId,
+                    DisplayName = cultivar?["name"]?.GetValue<string>() ?? crop?["name"]?.GetValue<string>() ?? lookupId,
+                    CropTypeId = cropTypeId,
+                    CropTypeName = crop?["name"]?.GetValue<string>() ?? cropTypeId,
+                    SpeciesDisplay = ResolveSpeciesDisplay(speciesById, speciesId)
                 };
             });
 
-            return Results.Ok(rows);
+            return Results.Ok(rows.ToArray());
         });
 
         MapEntityCrud(app, "species", "id");
@@ -211,6 +215,50 @@ internal static class CoreEndpoints
         }
 
         return species["commonName"]?.GetValue<string>() ?? species["scientificName"]?.GetValue<string>() ?? string.Empty;
+    }
+
+    private sealed class TaxonomyPickerQueryResponseDto
+    {
+        public required TaxonomyPickerCropDto[] Crops { get; init; }
+        public required TaxonomyPickerCultivarDto[] Cultivars { get; init; }
+    }
+
+    private sealed class TaxonomyPickerCropDto
+    {
+        public required string CropId { get; init; }
+        public required string CropName { get; init; }
+        public required string SpeciesId { get; init; }
+        public required string SpeciesDisplay { get; init; }
+    }
+
+    private sealed class TaxonomyPickerCultivarDto
+    {
+        public required string CultivarId { get; init; }
+        public required string CultivarName { get; init; }
+        public required string CropTypeId { get; init; }
+        public required string CropTypeName { get; init; }
+        public required string SpeciesDisplay { get; init; }
+        public required bool Archived { get; init; }
+    }
+
+    private sealed class SeedInventoryQueryRowDto
+    {
+        public required string SeedInventoryItemId { get; init; }
+        public required string CultivarId { get; init; }
+        public required string DisplayName { get; init; }
+        public required string CropTypeName { get; init; }
+        public required string SpeciesDisplay { get; init; }
+    }
+
+    private sealed class BatchListQueryRowDto
+    {
+        public required string BatchId { get; init; }
+        public required string IdentityId { get; init; }
+        public required string CapabilityCropId { get; init; }
+        public required string DisplayName { get; init; }
+        public required string CropTypeId { get; init; }
+        public required string CropTypeName { get; init; }
+        public required string SpeciesDisplay { get; init; }
     }
 
     private static void MapEntityCrud(WebApplication app, string collectionName, string idProperty)


### PR DESCRIPTION
### Motivation
- Replace anonymous objects returned by query endpoints with named DTOs to improve typing, serialization consistency, and client consumption.
- Ensure query results are materialized as arrays to avoid deferred enumeration and to provide stable payload shapes.

### Description
- Replaced anonymous response shapes in `/api/query/taxonomy-picker` with `TaxonomyPickerQueryResponseDto`, `TaxonomyPickerCropDto`, and `TaxonomyPickerCultivarDto` types and switched properties to PascalCase.
- Replaced anonymous rows in `/api/query/seed-inventory` with `SeedInventoryQueryRowDto` and in `/api/query/batch-list` with `BatchListQueryRowDto` and switched returned enumerables to arrays via `ToArray()`.
- Added private sealed DTO classes at the bottom of `CoreEndpoints.cs` to model the new responses and updated mapping code to construct these DTOs.

### Testing
- Built the solution with `dotnet build` and the build completed successfully.
- Ran the automated test suite with `dotnet test` and all tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f87062add48326ab8d6184d3666826)