### PR TITLE
Return typed DTOs from query endpoints and improve batch/cultivar display logic

### DIFF
--- a/backend/SurvivalGarden.Api/Endpoints/CoreEndpoints.cs
+++ b/backend/SurvivalGarden.Api/Endpoints/CoreEndpoints.cs
@@ -74,12 +74,12 @@ internal static class CoreEndpoints
             {
                 var cropId = crop["cropId"]?.GetValue<string>() ?? string.Empty;
                 var speciesId = crop["speciesId"]?.GetValue<string>() ?? string.Empty;
-                return new
+                return new TaxonomyPickerCropDto
                 {
-                    cropId,
-                    cropName = crop["name"]?.GetValue<string>() ?? cropId,
-                    speciesId,
-                    speciesDisplay = ResolveSpeciesDisplay(speciesById, speciesId)
+                    CropId = cropId,
+                    CropName = crop["name"]?.GetValue<string>() ?? cropId,
+                    SpeciesId = speciesId,
+                    SpeciesDisplay = ResolveSpeciesDisplay(speciesById, speciesId)
                 };
             });
 
@@ -88,18 +88,22 @@ internal static class CoreEndpoints
                 var cropTypeId = cultivar["cropTypeId"]?.GetValue<string>() ?? string.Empty;
                 var crop = crops.FirstOrDefault(candidate => string.Equals(candidate["cropId"]?.GetValue<string>(), cropTypeId, StringComparison.Ordinal));
                 var speciesId = crop?["speciesId"]?.GetValue<string>() ?? string.Empty;
-                return new
+                return new TaxonomyPickerCultivarDto
                 {
-                    cultivarId = cultivar["cultivarId"]?.GetValue<string>() ?? string.Empty,
-                    cultivarName = cultivar["name"]?.GetValue<string>() ?? string.Empty,
-                    cropTypeId,
-                    cropTypeName = crop?["name"]?.GetValue<string>() ?? cropTypeId,
-                    speciesDisplay = ResolveSpeciesDisplay(speciesById, speciesId),
-                    archived = cultivar["isArchived"]?.GetValue<bool>() ?? false
+                    CultivarId = cultivar["cultivarId"]?.GetValue<string>() ?? string.Empty,
+                    CultivarName = cultivar["name"]?.GetValue<string>() ?? string.Empty,
+                    CropTypeId = cropTypeId,
+                    CropTypeName = crop?["name"]?.GetValue<string>() ?? cropTypeId,
+                    SpeciesDisplay = ResolveSpeciesDisplay(speciesById, speciesId),
+                    Archived = cultivar["isArchived"]?.GetValue<bool>() ?? false
                 };
             });
 
-            return Results.Ok(new { crops = cropRows, cultivars = cultivarRows });
+            return Results.Ok(new TaxonomyPickerQueryResponseDto
+            {
+                Crops = cropRows.ToArray(),
+                Cultivars = cultivarRows.ToArray()
+            });
         });
 
         app.MapGet("/api/query/seed-inventory", async (IGardenApplicationService service, CancellationToken ct) =>
@@ -122,17 +126,17 @@ internal static class CoreEndpoints
                 var cropTypeId = cultivar?["cropTypeId"]?.GetValue<string>() ?? item["cropId"]?.GetValue<string>() ?? string.Empty;
                 var crop = crops.FirstOrDefault(candidate => string.Equals(candidate["cropId"]?.GetValue<string>(), cropTypeId, StringComparison.Ordinal));
                 var speciesId = crop?["speciesId"]?.GetValue<string>() ?? string.Empty;
-                return new
+                return new SeedInventoryQueryRowDto
                 {
-                    seedInventoryItemId = item["seedInventoryItemId"]?.GetValue<string>() ?? string.Empty,
-                    cultivarId,
-                    displayName = cultivar?["name"]?.GetValue<string>() ?? item["variety"]?.GetValue<string>() ?? cultivarId,
-                    cropTypeName = crop?["name"]?.GetValue<string>() ?? cropTypeId,
-                    speciesDisplay = ResolveSpeciesDisplay(speciesById, speciesId)
+                    SeedInventoryItemId = item["seedInventoryItemId"]?.GetValue<string>() ?? string.Empty,
+                    CultivarId = cultivarId,
+                    DisplayName = cultivar?["name"]?.GetValue<string>() ?? item["variety"]?.GetValue<string>() ?? cultivarId,
+                    CropTypeName = crop?["name"]?.GetValue<string>() ?? cropTypeId,
+                    SpeciesDisplay = ResolveSpeciesDisplay(speciesById, speciesId)
                 };
             });
 
-            return Results.Ok(rows);
+            return Results.Ok(rows.ToArray());
         });
 
         app.MapGet("/api/query/batch-list", async (IGardenApplicationService service, CancellationToken ct) =>
@@ -157,19 +161,19 @@ internal static class CoreEndpoints
                 var crop = crops.FirstOrDefault(candidate => string.Equals(candidate["cropId"]?.GetValue<string>(), cropTypeId, StringComparison.Ordinal));
                 var speciesId = crop?["speciesId"]?.GetValue<string>() ?? string.Empty;
 
-                return new
+                return new BatchListQueryRowDto
                 {
-                    batchId,
-                    identityId = cultivar?["cultivarId"]?.GetValue<string>() ?? lookupId,
-                    capabilityCropId = string.IsNullOrEmpty(cropTypeId) ? lookupId : cropTypeId,
-                    displayName = cultivar?["name"]?.GetValue<string>() ?? crop?["name"]?.GetValue<string>() ?? lookupId,
-                    cropTypeId,
-                    cropTypeName = crop?["name"]?.GetValue<string>() ?? cropTypeId,
-                    speciesDisplay = ResolveSpeciesDisplay(speciesById, speciesId)
+                    BatchId = batchId,
+                    IdentityId = cultivar?["cultivarId"]?.GetValue<string>() ?? lookupId,
+                    CapabilityCropId = string.IsNullOrEmpty(cropTypeId) ? lookupId : cropTypeId,
+                    DisplayName = cultivar?["name"]?.GetValue<string>() ?? crop?["name"]?.GetValue<string>() ?? lookupId,
+                    CropTypeId = cropTypeId,
+                    CropTypeName = crop?["name"]?.GetValue<string>() ?? cropTypeId,
+                    SpeciesDisplay = ResolveSpeciesDisplay(speciesById, speciesId)
                 };
             });
 
-            return Results.Ok(rows);
+            return Results.Ok(rows.ToArray());
         });
 
         MapEntityCrud(app, "species", "id");
@@ -211,6 +215,50 @@ internal static class CoreEndpoints
         }
 
         return species["commonName"]?.GetValue<string>() ?? species["scientificName"]?.GetValue<string>() ?? string.Empty;
+    }
+
+    private sealed class TaxonomyPickerQueryResponseDto
+    {
+        public required TaxonomyPickerCropDto[] Crops { get; init; }
+        public required TaxonomyPickerCultivarDto[] Cultivars { get; init; }
+    }
+
+    private sealed class TaxonomyPickerCropDto
+    {
+        public required string CropId { get; init; }
+        public required string CropName { get; init; }
+        public required string SpeciesId { get; init; }
+        public required string SpeciesDisplay { get; init; }
+    }
+
+    private sealed class TaxonomyPickerCultivarDto
+    {
+        public required string CultivarId { get; init; }
+        public required string CultivarName { get; init; }
+        public required string CropTypeId { get; init; }
+        public required string CropTypeName { get; init; }
+        public required string SpeciesDisplay { get; init; }
+        public required bool Archived { get; init; }
+    }
+
+    private sealed class SeedInventoryQueryRowDto
+    {
+        public required string SeedInventoryItemId { get; init; }
+        public required string CultivarId { get; init; }
+        public required string DisplayName { get; init; }
+        public required string CropTypeName { get; init; }
+        public required string SpeciesDisplay { get; init; }
+    }
+
+    private sealed class BatchListQueryRowDto
+    {
+        public required string BatchId { get; init; }
+        public required string IdentityId { get; init; }
+        public required string CapabilityCropId { get; init; }
+        public required string DisplayName { get; init; }
+        public required string CropTypeId { get; init; }
+        public required string CropTypeName { get; init; }
+        public required string SpeciesDisplay { get; init; }
     }
 
     private static void MapEntityCrud(WebApplication app, string collectionName, string idProperty)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2988,7 +2988,13 @@ function BatchesPage({
       Array.from(
         new Set(
           batches
-            .map((batch) => batch.cropTypeId ?? cultivarsById[getBatchCultivarLookupId(batch) ?? '']?.cropTypeId)
+            .map((batch) => getBatchCultivarDisplay({
+              batch,
+              cultivarsById,
+              cropNames,
+              cropScientificNames,
+              projectedRowsByBatchId: projectedBatchRowsById,
+            }).cropTypeId)
             .filter((cropTypeId): cropTypeId is string => Boolean(cropTypeId)),
         ),
       )
@@ -3001,7 +3007,7 @@ function BatchesPage({
             scientificName: cropScientificNames[cropId],
           }),
         })),
-    [batches, cultivarsById, cropNames, cropScientificNames],
+    [batches, cultivarsById, cropNames, cropScientificNames, projectedBatchRowsById],
   );
 
   const stageOptions = useMemo(
@@ -3022,20 +3028,30 @@ function BatchesPage({
   );
 
   const cultivarOptions = useMemo(
-    () =>
-      Array.from(
-        new Set(
-          batches
-            .map((batch) => getBatchCultivarLookupId(batch))
-            .filter((cultivarId): cultivarId is string => Boolean(cultivarId && cultivarsById[cultivarId])),
-        ),
-      )
-        .map((cultivarId) => ({
-          value: cultivarId,
-          label: cultivarsById[cultivarId]?.name ?? cultivarId,
-        }))
-        .sort((left, right) => left.label.localeCompare(right.label)),
-    [batches, cultivarsById],
+    () => {
+      const optionsById = new Map<string, string>();
+
+      for (const batch of batches) {
+        const display = getBatchCultivarDisplay({
+          batch,
+          cultivarsById,
+          cropNames,
+          cropScientificNames,
+          projectedRowsByBatchId: projectedBatchRowsById,
+        });
+
+        if (!display.identityId) {
+          continue;
+        }
+
+        optionsById.set(display.identityId, display.name ?? cultivarsById[display.identityId]?.name ?? display.identityId);
+      }
+
+      return Array.from(optionsById.entries())
+        .map(([value, label]) => ({ value, label }))
+        .sort((left, right) => left.label.localeCompare(right.label));
+    },
+    [batches, cultivarsById, cropNames, cropScientificNames, projectedBatchRowsById],
   );
 
   const cultivarInputOptions = useMemo(
@@ -3079,8 +3095,6 @@ function BatchesPage({
         .filter((batch) => {
         const derivedBedId = getDerivedBedId(batch);
         const batchDate = batch.startedAt.slice(0, 10);
-        const cultivarId = getBatchCultivarLookupId(batch);
-        const cultivarName = cultivarId ? (cultivarsById[cultivarId]?.name ?? '') : '';
         const batchDisplay = getBatchCultivarDisplay({
           batch,
           cultivarsById,
@@ -3088,8 +3102,10 @@ function BatchesPage({
           cropScientificNames,
           projectedRowsByBatchId: projectedBatchRowsById,
         });
+        const cultivarId = batchDisplay.identityId;
+        const cultivarName = cultivarsById[cultivarId]?.name ?? batchDisplay.name ?? '';
 
-        const batchCropTypeId = batch.cropTypeId ?? cultivarsById[getBatchCultivarLookupId(batch) ?? '']?.cropTypeId;
+        const batchCropTypeId = batchDisplay.cropTypeId;
         if (filters.crop && batchCropTypeId !== filters.crop) {
           return false;
         }


### PR DESCRIPTION
### Motivation
- Improve API response typing and clarity by replacing anonymous response shapes with explicit DTOs for query endpoints.
- Ensure endpoints return concrete arrays and consistent property names to aid serialization and client consumption.
- Improve frontend batch listing and filtering by deriving cultivar/crop display values from a unified `getBatchCultivarDisplay` result to handle projected rows and avoid duplicate options.

### Description
- Replaced anonymous response objects in `backend/SurvivalGarden.Api/Endpoints/CoreEndpoints.cs` with dedicated DTO types: `TaxonomyPickerQueryResponseDto`, `TaxonomyPickerCropDto`, `TaxonomyPickerCultivarDto`, `SeedInventoryQueryRowDto`, and `BatchListQueryRowDto` and updated endpoints to return typed arrays.
- Normalized property naming to PascalCase on the backend DTOs and returned arrays via `.ToArray()` for `taxonomy-picker`, `seed-inventory`, and `batch-list` endpoints.
- Added the new private DTO classes into `CoreEndpoints.cs` and kept existing helper functions such as `BuildSpeciesLookup` and `ResolveSpeciesDisplay` unchanged.
- Updated `frontend/src/App.tsx` to use `getBatchCultivarDisplay` when building `cropOptions`, `cultivarOptions`, and when computing `filteredBatches`, added `projectedBatchRowsById` to relevant `useMemo` dependency lists, and reworked cultivar option generation to deduplicate by identity and prefer display names.

### Testing
- Built the backend with `dotnet build` and ran the test suite with `dotnet test`, which completed successfully.
- Built the frontend with `npm run build` and ran the frontend test suite with `npm test`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f87062add48326ab8d6184d3666826)