### PR TITLE
Use typed DTOs for query endpoints and prefer authoritative projected data in UI

### DIFF
--- a/backend/SurvivalGarden.Api/Endpoints/CoreEndpoints.cs
+++ b/backend/SurvivalGarden.Api/Endpoints/CoreEndpoints.cs
@@ -74,12 +74,12 @@ internal static class CoreEndpoints
             {
                 var cropId = crop["cropId"]?.GetValue<string>() ?? string.Empty;
                 var speciesId = crop["speciesId"]?.GetValue<string>() ?? string.Empty;
-                return new
+                return new TaxonomyPickerCropDto
                 {
-                    cropId,
-                    cropName = crop["name"]?.GetValue<string>() ?? cropId,
-                    speciesId,
-                    speciesDisplay = ResolveSpeciesDisplay(speciesById, speciesId)
+                    CropId = cropId,
+                    CropName = crop["name"]?.GetValue<string>() ?? cropId,
+                    SpeciesId = speciesId,
+                    SpeciesDisplay = ResolveSpeciesDisplay(speciesById, speciesId)
                 };
             });
 
@@ -88,18 +88,22 @@ internal static class CoreEndpoints
                 var cropTypeId = cultivar["cropTypeId"]?.GetValue<string>() ?? string.Empty;
                 var crop = crops.FirstOrDefault(candidate => string.Equals(candidate["cropId"]?.GetValue<string>(), cropTypeId, StringComparison.Ordinal));
                 var speciesId = crop?["speciesId"]?.GetValue<string>() ?? string.Empty;
-                return new
+                return new TaxonomyPickerCultivarDto
                 {
-                    cultivarId = cultivar["cultivarId"]?.GetValue<string>() ?? string.Empty,
-                    cultivarName = cultivar["name"]?.GetValue<string>() ?? string.Empty,
-                    cropTypeId,
-                    cropTypeName = crop?["name"]?.GetValue<string>() ?? cropTypeId,
-                    speciesDisplay = ResolveSpeciesDisplay(speciesById, speciesId),
-                    archived = cultivar["isArchived"]?.GetValue<bool>() ?? false
+                    CultivarId = cultivar["cultivarId"]?.GetValue<string>() ?? string.Empty,
+                    CultivarName = cultivar["name"]?.GetValue<string>() ?? string.Empty,
+                    CropTypeId = cropTypeId,
+                    CropTypeName = crop?["name"]?.GetValue<string>() ?? cropTypeId,
+                    SpeciesDisplay = ResolveSpeciesDisplay(speciesById, speciesId),
+                    Archived = cultivar["isArchived"]?.GetValue<bool>() ?? false
                 };
             });
 
-            return Results.Ok(new { crops = cropRows, cultivars = cultivarRows });
+            return Results.Ok(new TaxonomyPickerQueryResponseDto
+            {
+                Crops = cropRows.ToArray(),
+                Cultivars = cultivarRows.ToArray()
+            });
         });
 
         app.MapGet("/api/query/seed-inventory", async (IGardenApplicationService service, CancellationToken ct) =>
@@ -122,17 +126,17 @@ internal static class CoreEndpoints
                 var cropTypeId = cultivar?["cropTypeId"]?.GetValue<string>() ?? item["cropId"]?.GetValue<string>() ?? string.Empty;
                 var crop = crops.FirstOrDefault(candidate => string.Equals(candidate["cropId"]?.GetValue<string>(), cropTypeId, StringComparison.Ordinal));
                 var speciesId = crop?["speciesId"]?.GetValue<string>() ?? string.Empty;
-                return new
+                return new SeedInventoryQueryRowDto
                 {
-                    seedInventoryItemId = item["seedInventoryItemId"]?.GetValue<string>() ?? string.Empty,
-                    cultivarId,
-                    displayName = cultivar?["name"]?.GetValue<string>() ?? item["variety"]?.GetValue<string>() ?? cultivarId,
-                    cropTypeName = crop?["name"]?.GetValue<string>() ?? cropTypeId,
-                    speciesDisplay = ResolveSpeciesDisplay(speciesById, speciesId)
+                    SeedInventoryItemId = item["seedInventoryItemId"]?.GetValue<string>() ?? string.Empty,
+                    CultivarId = cultivarId,
+                    DisplayName = cultivar?["name"]?.GetValue<string>() ?? item["variety"]?.GetValue<string>() ?? cultivarId,
+                    CropTypeName = crop?["name"]?.GetValue<string>() ?? cropTypeId,
+                    SpeciesDisplay = ResolveSpeciesDisplay(speciesById, speciesId)
                 };
             });
 
-            return Results.Ok(rows);
+            return Results.Ok(rows.ToArray());
         });
 
         app.MapGet("/api/query/batch-list", async (IGardenApplicationService service, CancellationToken ct) =>
@@ -157,19 +161,19 @@ internal static class CoreEndpoints
                 var crop = crops.FirstOrDefault(candidate => string.Equals(candidate["cropId"]?.GetValue<string>(), cropTypeId, StringComparison.Ordinal));
                 var speciesId = crop?["speciesId"]?.GetValue<string>() ?? string.Empty;
 
-                return new
+                return new BatchListQueryRowDto
                 {
-                    batchId,
-                    identityId = cultivar?["cultivarId"]?.GetValue<string>() ?? lookupId,
-                    capabilityCropId = string.IsNullOrEmpty(cropTypeId) ? lookupId : cropTypeId,
-                    displayName = cultivar?["name"]?.GetValue<string>() ?? crop?["name"]?.GetValue<string>() ?? lookupId,
-                    cropTypeId,
-                    cropTypeName = crop?["name"]?.GetValue<string>() ?? cropTypeId,
-                    speciesDisplay = ResolveSpeciesDisplay(speciesById, speciesId)
+                    BatchId = batchId,
+                    IdentityId = cultivar?["cultivarId"]?.GetValue<string>() ?? lookupId,
+                    CapabilityCropId = string.IsNullOrEmpty(cropTypeId) ? lookupId : cropTypeId,
+                    DisplayName = cultivar?["name"]?.GetValue<string>() ?? crop?["name"]?.GetValue<string>() ?? lookupId,
+                    CropTypeId = cropTypeId,
+                    CropTypeName = crop?["name"]?.GetValue<string>() ?? cropTypeId,
+                    SpeciesDisplay = ResolveSpeciesDisplay(speciesById, speciesId)
                 };
             });
 
-            return Results.Ok(rows);
+            return Results.Ok(rows.ToArray());
         });
 
         MapEntityCrud(app, "species", "id");
@@ -211,6 +215,50 @@ internal static class CoreEndpoints
         }
 
         return species["commonName"]?.GetValue<string>() ?? species["scientificName"]?.GetValue<string>() ?? string.Empty;
+    }
+
+    private sealed class TaxonomyPickerQueryResponseDto
+    {
+        public required TaxonomyPickerCropDto[] Crops { get; init; }
+        public required TaxonomyPickerCultivarDto[] Cultivars { get; init; }
+    }
+
+    private sealed class TaxonomyPickerCropDto
+    {
+        public required string CropId { get; init; }
+        public required string CropName { get; init; }
+        public required string SpeciesId { get; init; }
+        public required string SpeciesDisplay { get; init; }
+    }
+
+    private sealed class TaxonomyPickerCultivarDto
+    {
+        public required string CultivarId { get; init; }
+        public required string CultivarName { get; init; }
+        public required string CropTypeId { get; init; }
+        public required string CropTypeName { get; init; }
+        public required string SpeciesDisplay { get; init; }
+        public required bool Archived { get; init; }
+    }
+
+    private sealed class SeedInventoryQueryRowDto
+    {
+        public required string SeedInventoryItemId { get; init; }
+        public required string CultivarId { get; init; }
+        public required string DisplayName { get; init; }
+        public required string CropTypeName { get; init; }
+        public required string SpeciesDisplay { get; init; }
+    }
+
+    private sealed class BatchListQueryRowDto
+    {
+        public required string BatchId { get; init; }
+        public required string IdentityId { get; init; }
+        public required string CapabilityCropId { get; init; }
+        public required string DisplayName { get; init; }
+        public required string CropTypeId { get; init; }
+        public required string CropTypeName { get; init; }
+        public required string SpeciesDisplay { get; init; }
     }
 
     private static void MapEntityCrud(WebApplication app, string collectionName, string idProperty)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2164,6 +2164,7 @@ function SeedInventoryPage() {
   const [cropNames, setCropNames] = useState<Record<string, string>>({});
   const [speciesNames, setSpeciesNames] = useState<Record<string, string>>({});
   const [projectedRowsById, setProjectedRowsById] = useState<Record<string, SeedInventoryQueryRow>>({});
+  const [isProjectedInventoryAuthoritative, setIsProjectedInventoryAuthoritative] = useState(false);
   const [cultivarIds, setCultivarIds] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [savingId, setSavingId] = useState<string | null>(null);
@@ -2185,6 +2186,7 @@ function SeedInventoryPage() {
       setSpeciesNames({});
       setCultivarIds([]);
       setProjectedRowsById({});
+      setIsProjectedInventoryAuthoritative(false);
       setIsLoading(false);
       return;
     }
@@ -2210,11 +2212,14 @@ function SeedInventoryPage() {
       if (response.ok) {
         const projectedRows = await response.json() as SeedInventoryQueryRow[];
         setProjectedRowsById(Object.fromEntries(projectedRows.map((row) => [row.seedInventoryItemId, row])));
+        setIsProjectedInventoryAuthoritative(true);
       } else {
         setProjectedRowsById({});
+        setIsProjectedInventoryAuthoritative(false);
       }
     } catch {
       setProjectedRowsById({});
+      setIsProjectedInventoryAuthoritative(false);
     }
 
     setIsLoading(false);
@@ -2362,9 +2367,15 @@ function SeedInventoryPage() {
             const cultivar = cultivarsById[item.cultivarId];
             const projected = projectedRowsById[item.seedInventoryItemId];
             const cropTypeId = cultivar?.cropTypeId ?? item.cropId ?? '';
-            const cropTypeName = projected?.cropTypeName ?? (cropTypeId ? (cropNames[cropTypeId] ?? cropTypeId) : 'Unknown crop type');
-            const speciesName = projected?.speciesDisplay ?? (cropTypeId ? speciesNames[cropTypeId] : '');
-            const displayName = projected?.displayName ?? cultivar?.name ?? item.variety ?? item.cultivarId;
+            const cropTypeName = isProjectedInventoryAuthoritative
+              ? (projected?.cropTypeName ?? 'Unknown crop type')
+              : (cropTypeId ? (cropNames[cropTypeId] ?? cropTypeId) : 'Unknown crop type');
+            const speciesName = isProjectedInventoryAuthoritative
+              ? (projected?.speciesDisplay ?? '')
+              : (cropTypeId ? speciesNames[cropTypeId] : '');
+            const displayName = isProjectedInventoryAuthoritative
+              ? (projected?.displayName ?? item.cultivarId)
+              : (cultivar?.name ?? item.variety ?? item.cultivarId);
 
             return (
               <li key={item.seedInventoryItemId} className="seed-inventory-row">
@@ -2988,7 +2999,13 @@ function BatchesPage({
       Array.from(
         new Set(
           batches
-            .map((batch) => batch.cropTypeId ?? cultivarsById[getBatchCultivarLookupId(batch) ?? '']?.cropTypeId)
+            .map((batch) => getBatchCultivarDisplay({
+              batch,
+              cultivarsById,
+              cropNames,
+              cropScientificNames,
+              projectedRowsByBatchId: projectedBatchRowsById,
+            }).cropTypeId)
             .filter((cropTypeId): cropTypeId is string => Boolean(cropTypeId)),
         ),
       )
@@ -3001,7 +3018,7 @@ function BatchesPage({
             scientificName: cropScientificNames[cropId],
           }),
         })),
-    [batches, cultivarsById, cropNames, cropScientificNames],
+    [batches, cultivarsById, cropNames, cropScientificNames, projectedBatchRowsById],
   );
 
   const stageOptions = useMemo(
@@ -3022,20 +3039,30 @@ function BatchesPage({
   );
 
   const cultivarOptions = useMemo(
-    () =>
-      Array.from(
-        new Set(
-          batches
-            .map((batch) => getBatchCultivarLookupId(batch))
-            .filter((cultivarId): cultivarId is string => Boolean(cultivarId && cultivarsById[cultivarId])),
-        ),
-      )
-        .map((cultivarId) => ({
-          value: cultivarId,
-          label: cultivarsById[cultivarId]?.name ?? cultivarId,
-        }))
-        .sort((left, right) => left.label.localeCompare(right.label)),
-    [batches, cultivarsById],
+    () => {
+      const optionsById = new Map<string, string>();
+
+      for (const batch of batches) {
+        const display = getBatchCultivarDisplay({
+          batch,
+          cultivarsById,
+          cropNames,
+          cropScientificNames,
+          projectedRowsByBatchId: projectedBatchRowsById,
+        });
+
+        if (!display.identityId) {
+          continue;
+        }
+
+        optionsById.set(display.identityId, display.name ?? cultivarsById[display.identityId]?.name ?? display.identityId);
+      }
+
+      return Array.from(optionsById.entries())
+        .map(([value, label]) => ({ value, label }))
+        .sort((left, right) => left.label.localeCompare(right.label));
+    },
+    [batches, cultivarsById, cropNames, cropScientificNames, projectedBatchRowsById],
   );
 
   const cultivarInputOptions = useMemo(
@@ -3079,8 +3106,6 @@ function BatchesPage({
         .filter((batch) => {
         const derivedBedId = getDerivedBedId(batch);
         const batchDate = batch.startedAt.slice(0, 10);
-        const cultivarId = getBatchCultivarLookupId(batch);
-        const cultivarName = cultivarId ? (cultivarsById[cultivarId]?.name ?? '') : '';
         const batchDisplay = getBatchCultivarDisplay({
           batch,
           cultivarsById,
@@ -3088,8 +3113,10 @@ function BatchesPage({
           cropScientificNames,
           projectedRowsByBatchId: projectedBatchRowsById,
         });
+        const cultivarId = batchDisplay.identityId;
+        const cultivarName = cultivarsById[cultivarId]?.name ?? batchDisplay.name ?? '';
 
-        const batchCropTypeId = batch.cropTypeId ?? cultivarsById[getBatchCultivarLookupId(batch) ?? '']?.cropTypeId;
+        const batchCropTypeId = batchDisplay.cropTypeId;
         if (filters.crop && batchCropTypeId !== filters.crop) {
           return false;
         }


### PR DESCRIPTION
### Motivation

- Replace ad-hoc anonymous response shapes with explicit DTOs to stabilize backend API contracts and improve serialization clarity.
- Ensure seed inventory display values from server projections are only applied when the projection data is authoritative to avoid showing stale or partial info in the UI.
- Unify batch/cultivar display derivation to use the same `getBatchCultivarDisplay` logic and incorporate projected batch rows for consistent filtering and option lists.

### Description

- Backend: introduce strongly-typed response DTOs (`TaxonomyPickerQueryResponseDto`, `TaxonomyPickerCropDto`, `TaxonomyPickerCultivarDto`, `SeedInventoryQueryRowDto`, `BatchListQueryRowDto`) and update `/api/query/taxonomy-picker`, `/api/query/seed-inventory`, and `/api/query/batch-list` to return these typed objects and arrays instead of anonymous objects or enumerables.
- Backend: ensure query endpoints produce concrete arrays via `.ToArray()` to make responses stable.
- Frontend: add `isProjectedInventoryAuthoritative` state and set it based on the `/api/query/seed-inventory` fetch result to control whether projected server-side fields override local app-state values.
- Frontend: switch batch-related logic to derive cultivar/crop display using `getBatchCultivarDisplay` and include `projectedBatchRowsById` in memo dependencies for `cropOptions`, `cultivarOptions`, and `filteredBatches` so projected data can influence filters and labels consistently.

### Testing

- Ran `dotnet build` for the backend and the solution compiled successfully.
- Ran backend tests with `dotnet test` and the test suite completed without failures.
- Built the frontend with `npm run build` and the TypeScript compilation and bundling finished successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f87062add48326ab8d6184d3666826)