### PR TITLE
Fix AJV strictRequired compilation in seed-inventory-item schema

### DIFF
--- a/frontend/src/contracts/seed-inventory-item.schema.json
+++ b/frontend/src/contracts/seed-inventory-item.schema.json
@@ -21,21 +21,7 @@
       },
       "required": [
         "cultivarId"
-      ],
-      "not": {
-        "anyOf": [
-          {
-            "required": [
-              "cropId"
-            ]
-          },
-          {
-            "required": [
-              "variety"
-            ]
-          }
-        ]
-      }
+      ]
     },
     {
       "title": "Fallback unknown-cultivar identity",
@@ -50,16 +36,25 @@
       "not": {
         "anyOf": [
           {
+            "properties": {
+              "cultivarId": {}
+            },
             "required": [
               "cultivarId"
             ]
           },
           {
+            "properties": {
+              "cropId": {}
+            },
             "required": [
               "cropId"
             ]
           },
           {
+            "properties": {
+              "variety": {}
+            },
             "required": [
               "variety"
             ]
@@ -80,16 +75,25 @@
       "not": {
         "anyOf": [
           {
+            "properties": {
+              "cultivarId": {}
+            },
             "required": [
               "cultivarId"
             ]
           },
           {
+            "properties": {
+              "cropTypeId": {}
+            },
             "required": [
               "cropTypeId"
             ]
           },
           {
+            "properties": {
+              "speciesId": {}
+            },
             "required": [
               "speciesId"
             ]


### PR DESCRIPTION
### Motivation
- AJV strict mode failed to compile the seed inventory schema because nested `required` entries in `not/anyOf` blocks had no corresponding local `properties`, causing valid AppState fixtures to be rejected.

### Description
- Updated `frontend/src/contracts/seed-inventory-item.schema.json` to ensure every nested `required` usage is paired with a local `properties` definition and removed the overly restrictive `not` block from the canonical `cultivarId` branch so migration-compatible fields do not break validation.

### Testing
- Ran `pnpm vitest run src/contracts/appstate.schema.test.ts src/contracts/crop.schema.test.ts` and both test files passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a019f0f5bbc8326ae5cc63767e0348d)