### PR TITLE
Remove legacy `cropId` from seed inventory and migrate to `cropTypeId`

### DIFF
--- a/backend/SurvivalGarden.Api/Contracts/SeedInventoryItemUpsertRequest.cs
+++ b/backend/SurvivalGarden.Api/Contracts/SeedInventoryItemUpsertRequest.cs
@@ -6,8 +6,6 @@ internal sealed class SeedInventoryItemUpsertRequest
 
     public string? CultivarId { get; init; }
 
-    public string? CropId { get; init; }
-
     public string? Variety { get; init; }
 
     public string? CropTypeId { get; init; }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2190,7 +2190,13 @@ function SeedInventoryPage() {
     const getInventoryLabel = (item: SeedInventoryItem): string =>
       (item.cultivarId ? nextCultivarsById[item.cultivarId]?.name : undefined) ?? item.variety ?? item.cultivarId ?? '';
 
-    setItems(listSeedInventoryItemsFromAppState(appState).sort((left, right) => getInventoryLabel(left).localeCompare(getInventoryLabel(right))));
+    const normalizedItems = listSeedInventoryItemsFromAppState(appState).map((item) => {
+      const legacyCropId = (item as SeedInventoryItem & { cropId?: string }).cropId;
+      return legacyCropId && !item.cropTypeId
+        ? { ...item, cropTypeId: legacyCropId }
+        : item;
+    });
+    setItems(normalizedItems.sort((left, right) => getInventoryLabel(left).localeCompare(getInventoryLabel(right))));
     setCultivarsById(nextCultivarsById);
     setCropNames(Object.fromEntries(appState.crops.map((crop) => [crop.cropId, crop.name])));
     setSpeciesNames(
@@ -2460,7 +2466,7 @@ function SeedInventoryPage() {
           {items.map((item) => {
             const cultivar = item.cultivarId ? cultivarsById[item.cultivarId] : undefined;
             const projected = projectedRowsById[item.seedInventoryItemId];
-            const cropTypeId = cultivar?.cropTypeId ?? item.cropId ?? '';
+            const cropTypeId = cultivar?.cropTypeId ?? item.cropTypeId ?? '';
             const cropTypeName = isProjectedInventoryAuthoritative
               ? (projected?.cropTypeName ?? 'Unknown crop type')
               : (cropTypeId ? (cropNames[cropTypeId] ?? cropTypeId) : 'Unknown crop type');
@@ -2493,7 +2499,7 @@ function SeedInventoryPage() {
                       setEditingId(item.seedInventoryItemId);
                       setFormValues({
                         cultivarId: item.cultivarId ?? '',
-                        cropTypeId: item.cropTypeId ?? item.cropId ?? '',
+                        cropTypeId: item.cropTypeId ?? '',
                         speciesId: item.speciesId ?? '',
                         propagationType: item.propagationType ?? 'seed',
                         materialType: item.materialType ?? 'seed',
@@ -2556,7 +2562,7 @@ const mapBatchValidationIssuesToFormErrors = (issues: Array<{ path: string; mess
   const issueErrors: Record<string, string> = {};
 
   for (const issue of issues) {
-    if (issue.path.includes('/cultivarId') || issue.path.includes('/cropId')) {
+    if (issue.path.includes('/cultivarId') || issue.path.includes('/cropTypeId')) {
       issueErrors.cropInput = 'Choose a valid cultivar record.';
     }
 

--- a/frontend/src/contracts/seed-inventory-item.schema.json
+++ b/frontend/src/contracts/seed-inventory-item.schema.json
@@ -12,7 +12,7 @@
     "createdAt",
     "updatedAt"
   ],
-  "description": "Canonical records identify seed inventory using cultivarId. Legacy cropId+variety is accepted only for migration/import compatibility.",
+  "description": "Canonical records identify seed inventory using cultivarId, with cropTypeId+speciesId fallback when cultivar is unknown.",
   "oneOf": [
     {
       "title": "Canonical cultivar identity",
@@ -45,57 +45,10 @@
           },
           {
             "properties": {
-              "cropId": {}
-            },
-            "required": [
-              "cropId"
-            ]
-          },
-          {
-            "properties": {
               "variety": {}
             },
             "required": [
               "variety"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "title": "Legacy migration identity",
-      "properties": {
-        "cropId": {},
-        "variety": {}
-      },
-      "required": [
-        "cropId",
-        "variety"
-      ],
-      "not": {
-        "anyOf": [
-          {
-            "properties": {
-              "cultivarId": {}
-            },
-            "required": [
-              "cultivarId"
-            ]
-          },
-          {
-            "properties": {
-              "cropTypeId": {}
-            },
-            "required": [
-              "cropTypeId"
-            ]
-          },
-          {
-            "properties": {
-              "speciesId": {}
-            },
-            "required": [
-              "speciesId"
             ]
           }
         ]
@@ -108,10 +61,6 @@
     },
     "cultivarId": {
       "description": "Canonical identity for seed inventory items; points to a reusable cultivar record.",
-      "$ref": "#/$defs/id"
-    },
-    "cropId": {
-      "description": "Legacy migration-only field for imported records that do not yet resolve to cultivarId.",
       "$ref": "#/$defs/id"
     },
     "variety": {

--- a/frontend/src/generated/contracts.ts
+++ b/frontend/src/generated/contracts.ts
@@ -320,7 +320,6 @@ export interface CropPlan {
 export interface SeedInventoryItem {
   seedInventoryItemId: string;
   cultivarId?: string;
-  cropId?: string;
   cropTypeId?: string;
   speciesId?: string;
   variety?: string;

--- a/frontend/src/generated/contracts.ts
+++ b/frontend/src/generated/contracts.ts
@@ -320,6 +320,7 @@ export interface CropPlan {
 export interface SeedInventoryItem {
   seedInventoryItemId: string;
   cultivarId?: string;
+  cropId?: string;
   cropTypeId?: string;
   speciesId?: string;
   variety?: string;

--- a/frontend/src/generated/openapi-paths.ts
+++ b/frontend/src/generated/openapi-paths.ts
@@ -1736,7 +1736,6 @@ export interface components {
         RegenerateCalendarRequest: Record<string, never>;
         SeedInventoryItemUpsertRequest: {
             createdAt?: null | string;
-            cropId?: null | string;
             cropTypeId?: null | string;
             cultivarId?: null | string;
             expiryDate?: null | string;


### PR DESCRIPTION
### Motivation

- Remove the old legacy `cropId` identity from seed inventory records and consolidate on the canonical `cultivarId` with a `cropTypeId`+`speciesId` fallback.
- Simplify validation and client types by eliminating migration-only fields and normalizing any remaining legacy data at load time.

### Description

- Removed the `cropId` property from the backend contract `SeedInventoryItemUpsertRequest` so upserts no longer accept the legacy field.
- Updated the JSON schema `seed-inventory-item.schema.json` to remove the legacy `cropId` branch, clarified the description, and adjusted the `oneOf` rules to require `cropTypeId`+`speciesId` as the unknown-cultivar fallback.
- Regenerated frontend types (`generated/contracts.ts`) to drop `cropId` from `SeedInventoryItem` and aligned code to use `cropTypeId` only.
- Updated the UI in `App.tsx` to normalize legacy items by copying any existing `cropId` into `cropTypeId` when loading from AppState, and changed display/edit logic and error mapping to reference `cropTypeId` instead of `cropId`.

### Testing

- Built the backend with `dotnet build` and the frontend with `yarn build` to verify type changes and compilation succeeded.
- Ran frontend type checks and test suite with `yarn test`, and the test run completed successfully without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01a341aeb083269ac73906ca2d474b)