### PR TITLE
Fix seed-inventory test fixtures to match schema identity (cropTypeId / cultivarId)

### DIFF
--- a/fixtures/golden/trier-v1.json
+++ b/fixtures/golden/trier-v1.json
@@ -751,7 +751,7 @@
   "seedInventoryItems": [
     {
       "createdAt": "2026-01-05T00:00:00Z",
-      "cropId": "crop_type_potato",
+      "cultivarId": "cultivar_potato_bintje",
       "notes": "Seed tubers represented as grams for MVP fixture simplicity.",
       "quantity": 2000,
       "seedInventoryItemId": "seed_001",

--- a/frontend/src/contracts/appstate.schema.test.ts
+++ b/frontend/src/contracts/appstate.schema.test.ts
@@ -195,7 +195,7 @@ describe('AppState schema', () => {
         {
           seedInventoryItemId: 'seed_item_001',
           cultivarId: 'cultivar_tomato_san_marzano',
-          cropId: 'crop_tomato_san_marzano',
+          cropTypeId: 'crop_tomato_san_marzano',
           variety: 'San Marzano',
           quantity: 120,
           unit: 'seeds',

--- a/frontend/src/data/validation/index.test.ts
+++ b/frontend/src/data/validation/index.test.ts
@@ -256,7 +256,7 @@ const validTask = {
 const validSeedInventoryItem = {
   seedInventoryItemId: 'seed-item-1',
   cultivarId: 'cultivar-1',
-  cropId: 'crop-1',
+  cropTypeId: 'crop-1',
   variety: 'Nantes',
   quantity: 120,
   unit: 'seeds',

--- a/frontend/src/data/workflowAdapter.test.ts
+++ b/frontend/src/data/workflowAdapter.test.ts
@@ -90,7 +90,7 @@ const validCropPlan = {
 const validSeedInventoryItem = {
   seedInventoryItemId: 'seed-item-1',
   cultivarId: 'cultivar-1',
-  cropId: 'crop-1',
+  cropTypeId: 'crop-1',
   variety: 'Nantes',
   quantity: 120,
   unit: 'seeds',


### PR DESCRIPTION
### Motivation
- Several test suites were failing because test payloads used legacy `cropId` on seed inventory records which no longer satisfy the seed-inventory schema's identity `oneOf` contract (requires either `cultivarId` or `cropTypeId+speciesId`).
- The intent is to repair only test fixtures so validation-based tests pass without changing any schema or runtime code.

### Description
- Replace legacy `cropId` with `cropTypeId` on test `SeedInventoryItem` objects in `frontend/src/data/workflowAdapter.test.ts` and `frontend/src/data/validation/index.test.ts` so they conform to the schema.
- Adjust the AppState test payload in `frontend/src/contracts/appstate.schema.test.ts` to keep task `cropId` values intact but use `cropTypeId` on the seed inventory record so the overall payload validates.
- Update the golden fixture `fixtures/golden/trier-v1.json` seed inventory entry to use a canonical `cultivarId` (canonical identity) instead of the legacy `cropId` so fixtures validate against the current contract.
- No schema files or production code were modified; changes are limited to tests and fixtures only.

### Testing
- Ran targeted test suites with `cd frontend && pnpm vitest src/contracts/appstate.schema.test.ts src/data/workflowAdapter.test.ts src/data/repos/taskRepository.test.ts src/data/validation/index.test.ts src/data/index.cutoverRouting.test.ts` and confirmed the updated suites pass.
- Final test run for the targeted suites returned all tests passing (targeted files passed and the previously failing validation/back-end contract checks are resolved).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01dcdbe56c8326b72b46d77a6d1b3d)