### PR TITLE
Add derived-field ownership guardrails for DTO upserts

### DIFF
--- a/backend/SurvivalGarden.Api/Contracts/DtoJsonMapper.cs
+++ b/backend/SurvivalGarden.Api/Contracts/DtoJsonMapper.cs
@@ -5,8 +5,81 @@ namespace SurvivalGarden.Api.Contracts;
 
 internal static class DtoJsonMapper
 {
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
     internal static JsonObject ToJsonObject<T>(T payload)
     {
-        return JsonSerializer.SerializeToNode(payload) as JsonObject ?? new JsonObject();
+        return JsonSerializer.SerializeToNode(payload, SerializerOptions) as JsonObject ?? new JsonObject();
+    }
+
+    internal static JsonObject ToCanonicalCropUpsert(CropUpsertRequest request, string cropId)
+    {
+        var payload = ToJsonObject(request);
+        return Pick(payload,
+            ("cropId", cropId),
+            "id",
+            "name",
+            "commonName",
+            "cultivar",
+            "cultivarGroup",
+            "speciesId",
+            "scientificName",
+            "taxonomy",
+            "aliases",
+            "isUserDefined",
+            "category",
+            "companionsGood",
+            "companionsAvoid",
+            "rules",
+            "taskRules",
+            "nutritionProfile",
+            "defaults",
+            "meta");
+    }
+
+    internal static JsonObject ToCanonicalSeedInventoryItemUpsert(SeedInventoryItemUpsertRequest request, string seedInventoryItemId)
+    {
+        var payload = ToJsonObject(request);
+        return Pick(payload,
+            ("seedInventoryItemId", seedInventoryItemId),
+            "cultivarId",
+            "variety",
+            "cropTypeId",
+            "speciesId",
+            "propagationType",
+            "materialType",
+            "supplier",
+            "lotNumber",
+            "quantity",
+            "unit",
+            "purchaseDate",
+            "expiryDate",
+            "status",
+            "storageLocation",
+            "notes");
+    }
+
+    private static JsonObject Pick(JsonObject payload, params string[] keys)
+    {
+        var mapped = new JsonObject();
+        foreach (var key in keys)
+        {
+            if (payload[key] is not null)
+            {
+                mapped[key] = payload[key]!.DeepClone();
+            }
+        }
+
+        return mapped;
+    }
+
+    private static JsonObject Pick(JsonObject payload, (string Key, string Value) requiredIdentity, params string[] keys)
+    {
+        var mapped = Pick(payload, keys);
+        mapped[requiredIdentity.Key] = requiredIdentity.Value;
+        return mapped;
     }
 }

--- a/backend/SurvivalGarden.Api/Endpoints/CoreEndpoints.cs
+++ b/backend/SurvivalGarden.Api/Endpoints/CoreEndpoints.cs
@@ -183,17 +183,9 @@ internal static class CoreEndpoints
         });
 
         MapEntityCrud(app, "species", "id");
-        MapTypedEntityCrud<CropUpsertRequest>(app, "crops", "cropId", (payload, id) =>
-        {
-            payload.CropId = id;
-            return DtoJsonMapper.ToJsonObject(payload);
-        });
+        MapTypedEntityCrud<CropUpsertRequest>(app, "crops", "cropId", DtoJsonMapper.ToCanonicalCropUpsert);
         MapEntityCrud(app, "cultivars", "id");
-        MapTypedEntityCrud<SeedInventoryItemUpsertRequest>(app, "seedInventoryItems", "seedInventoryItemId", (payload, id) =>
-        {
-            payload.SeedInventoryItemId = id;
-            return DtoJsonMapper.ToJsonObject(payload);
-        });
+        MapTypedEntityCrud<SeedInventoryItemUpsertRequest>(app, "seedInventoryItems", "seedInventoryItemId", DtoJsonMapper.ToCanonicalSeedInventoryItemUpsert);
         MapEntityCrud(app, "cropPlans", "planId");
 
         app.MapPost("/api/validate/{collection}", (IGardenApplicationService service, string collection, JsonObject payload) =>

--- a/docs/contracts/derived-field-ownership.md
+++ b/docs/contracts/derived-field-ownership.md
@@ -1,0 +1,33 @@
+# Derived Field Ownership
+
+Derived fields are server-owned output fields. Clients may include them in payloads, but API mapping removes them before validation/persistence.
+
+## Policy
+
+- **Canonical input fields**: accepted from client and persisted.
+- **Derived/output-only fields**: ignored from client payloads.
+- Endpoint handlers must use centralized mapper methods in `DtoJsonMapper` for typed upserts.
+
+## Current upsert guardrails
+
+### Crop upsert (`/api/crops/{id}`)
+
+- **Canonical input**: `id`, `name`, `commonName`, `cultivar`, `cultivarGroup`, `speciesId`, `scientificName`, `taxonomy`, `aliases`, `isUserDefined`, `category`, `companionsGood`, `companionsAvoid`, `rules`, `taskRules`, `nutritionProfile`, `defaults`, `meta`.
+- **Canonical identity override**: `cropId` always comes from route `{id}`.
+- **Ignored derived/output-only**: `createdAt`, `updatedAt`, `species`.
+
+### Seed inventory upsert (`/api/seedInventoryItems/{id}`)
+
+- **Canonical input**: `cultivarId`, `variety`, `cropTypeId`, `speciesId`, `propagationType`, `materialType`, `supplier`, `lotNumber`, `quantity`, `unit`, `purchaseDate`, `expiryDate`, `status`, `storageLocation`, `notes`.
+- **Canonical identity override**: `seedInventoryItemId` always comes from route `{id}`.
+- **Ignored derived/output-only**: `createdAt`, `updatedAt`.
+
+## Examples
+
+If a client sends:
+
+```json
+{ "cropId": "other", "name": "Tomato", "createdAt": "2020-01-01T00:00:00Z" }
+```
+
+for `PUT /api/crops/crop-123`, stored canonical payload uses `cropId = "crop-123"` and ignores `createdAt`.

--- a/frontend/src/contracts/bed.schema.json
+++ b/frontend/src/contracts/bed.schema.json
@@ -54,10 +54,12 @@
       "maxLength": 2000
     },
     "createdAt": {
-      "$ref": "#/$defs/isoDate"
+      "$ref": "#/$defs/isoDate",
+      "readOnly": true
     },
     "updatedAt": {
-      "$ref": "#/$defs/isoDate"
+      "$ref": "#/$defs/isoDate",
+      "readOnly": true
     }
   },
   "$defs": {

--- a/frontend/src/contracts/crop.schema.json
+++ b/frontend/src/contracts/crop.schema.json
@@ -101,7 +101,8 @@
             }
           }
         }
-      }
+      },
+      "readOnly": true
     },
     "scientificName": {
       "type": "string",
@@ -194,10 +195,12 @@
       }
     },
     "createdAt": {
-      "$ref": "#/$defs/isoDate"
+      "$ref": "#/$defs/isoDate",
+      "readOnly": true
     },
     "updatedAt": {
-      "$ref": "#/$defs/isoDate"
+      "$ref": "#/$defs/isoDate",
+      "readOnly": true
     },
     "id": {
       "$ref": "#/$defs/id",

--- a/frontend/src/contracts/seed-inventory-item.schema.json
+++ b/frontend/src/contracts/seed-inventory-item.schema.json
@@ -124,10 +124,12 @@
       "maxLength": 1000
     },
     "createdAt": {
-      "$ref": "#/$defs/isoDate"
+      "$ref": "#/$defs/isoDate",
+      "readOnly": true
     },
     "updatedAt": {
-      "$ref": "#/$defs/isoDate"
+      "$ref": "#/$defs/isoDate",
+      "readOnly": true
     },
     "cropTypeId": {
       "description": "Fallback crop type when cultivar is unknown; canonical flow should use cultivarId.",

--- a/frontend/src/generated/contracts.ts
+++ b/frontend/src/generated/contracts.ts
@@ -339,6 +339,48 @@ export interface SeedInventoryItem {
   updatedAt: string;
 }
 
+
+export interface CropUpsertInput {
+  cropId?: string;
+  id?: string;
+  name?: string;
+  commonName?: string;
+  cultivar?: string;
+  cultivarGroup?: string;
+  speciesId?: string;
+  scientificName?: string;
+  taxonomy?: Record<string, unknown>;
+  aliases?: unknown[];
+  isUserDefined?: boolean;
+  category?: string;
+  companionsGood?: unknown[];
+  companionsAvoid?: unknown[];
+  rules?: Record<string, unknown>;
+  taskRules?: unknown[];
+  nutritionProfile?: unknown[];
+  defaults?: Record<string, unknown>;
+  meta?: Record<string, unknown>;
+}
+
+export interface SeedInventoryItemUpsertInput {
+  seedInventoryItemId?: string;
+  cultivarId?: string;
+  variety?: string;
+  cropTypeId?: string;
+  speciesId?: string;
+  propagationType?: string;
+  materialType?: string;
+  supplier?: string;
+  lotNumber?: string;
+  quantity?: number;
+  unit?: string;
+  purchaseDate?: string;
+  expiryDate?: string;
+  status?: string;
+  storageLocation?: string;
+  notes?: string;
+}
+
 export interface Settings {
   settingsId: string;
   locale: string;


### PR DESCRIPTION
### Motivation
- Prevent clients from persisting server-owned derived/output-only fields by centralizing mapping and allowlisting for typed upserts. 
- Ensure route-owned identity fields (e.g. `cropId`, `seedInventoryItemId`) always override client payloads. 
- Align frontend types and JSON schemas with backend ownership semantics and document the policy.

### Description
- Add `SerializerOptions` and centralized canonical mappers `ToCanonicalCropUpsert` and `ToCanonicalSeedInventoryItemUpsert` to `DtoJsonMapper` with explicit allowlisted fields and `Pick` helpers to drop derived/output-only properties. 
- Change `CoreEndpoints` `MapTypedEntityCrud` wiring so crop and seed-inventory PUT handlers use the centralized mappers, ensuring route IDs win and derived fields are ignored. 
- Add `CropUpsertInput` and `SeedInventoryItemUpsertInput` interfaces to `frontend/src/generated/contracts.ts` to represent client-upsert shapes. 
- Mark known derived timestamps and computed payloads (`createdAt`, `updatedAt`, and `species` where applicable) as `readOnly` in frontend JSON schemas and add `docs/contracts/derived-field-ownership.md` explaining the policy and examples.

### Testing
- Committed changes successfully with `git commit` (commit created). 
- Attempted `dotnet build backend/SurvivalGarden.Api/SurvivalGarden.Api.csproj` but the build could not run because `dotnet` is not available in the execution environment. 
- No frontend build or schema validation was run in this environment; changes are limited to code/schema edits and documentation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06e2d7daf08326a9cc193111f47be6)