### PR TITLE
CI: enforce live contract drift check and add API route-ownership test; update docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,7 @@ jobs:
 
       - name: Verify generated contract types
         run: |
+          set -euo pipefail
           python3 -m http.server 5178 --directory ./.artifacts/openapi >/tmp/openapi-server.log 2>&1 &
           OPENAPI_PID=$!
 
@@ -219,7 +220,10 @@ jobs:
           export EXPECTED_CONTRACT_VERSION="1.0.0"
 
           pnpm --dir frontend gen:types
-          git diff --exit-code -- frontend/src/generated/contracts.ts frontend/src/generated/openapi-paths.ts frontend/src/generated/api-client.ts
+          if ! git diff --exit-code -- frontend/src/generated/contracts.ts frontend/src/generated/openapi-paths.ts frontend/src/generated/api-client.ts; then
+            echo "::error title=Contract drift detected::Generated frontend API contract artifacts changed after regeneration. Run 'pnpm --dir frontend gen:types', review updates in frontend/src/generated/*, and commit the regenerated files."
+            exit 1
+          fi
 
       - name: Test
         run: pnpm --dir frontend test
@@ -277,6 +281,18 @@ jobs:
             /p:FileVersion=${{ needs.gitVersion.outputs.assemblySemFileVer }} `
             /p:InformationalVersion=${{ needs.gitVersion.outputs.informationalVersion }} `
             "${{ steps.target.outputs.target }}"
+
+      - name: Verify API route ownership tests
+        shell: pwsh
+        run: |
+          dotnet test --logger "trx" --no-build -c Debug `
+            --filter "FullyQualifiedName~ApiContractRouteOwnershipTests" `
+            "${{ steps.target.outputs.target }}"
+
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "::error title=Route ownership violation::ApiContractRouteOwnershipTests failed. Update endpoint ownership mappings or route declarations so each API route is owned by exactly one feature boundary, then rerun dotnet test."
+            exit 1
+          }
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action/windows@v2

--- a/docs/live-contract-verification.md
+++ b/docs/live-contract-verification.md
@@ -144,3 +144,36 @@ Any of these indicates payload/runtime mismatch despite compile-time generation:
 - Backend-mode operations fail with contract validation errors (for example, "Backend contract mismatch ...").
 - Browser Network responses show missing required fields or incompatible types for entities used by the UI.
 - Manual smoke CRUD operations fail (`4xx/5xx`) due to schema/shape incompatibility.
+
+## Troubleshooting common CI failures
+
+### Route ownership violations (`ApiContractRouteOwnershipTests`)
+
+Typical CI signal:
+- Backend `dotnet test` fails in `backend/SurvivalGarden.Api.Tests/ApiContractRouteOwnershipTests.cs`.
+- CI emits a route ownership violation error.
+
+How to fix:
+1. Read the failing test output to identify the conflicting route/feature ownership expectation.
+2. Update the endpoint mapping/ownership metadata so the route is owned by exactly one boundary.
+3. Re-run:
+   ```bash
+   dotnet test backend/SurvivalGarden.Backend.sln --filter "FullyQualifiedName~ApiContractRouteOwnershipTests"
+   ```
+
+### Contract drift (generated frontend types changed)
+
+Typical CI signal:
+- Contract regeneration succeeds, then `git diff --exit-code` fails on:
+  - `frontend/src/generated/contracts.ts`
+  - `frontend/src/generated/openapi-paths.ts`
+  - `frontend/src/generated/api-client.ts`
+- CI emits a contract drift detected error.
+
+How to fix:
+1. Regenerate contracts locally:
+   ```bash
+   pnpm --dir frontend gen:types
+   ```
+2. Review generated diffs for expected API changes.
+3. Commit the regenerated files with the backend/API change (or revert unintended backend changes).


### PR DESCRIPTION
### Motivation

- Ensure frontend generated API artifacts remain in sync with the backend OpenAPI served in CI and provide clearer failure messages when drift is detected. 
- Detect and fail CI when API routes are not uniquely owned by a single feature boundary to prevent ambiguous endpoint ownership.
- Document common CI failure modes and remediation steps for contract drift and route ownership failures.

### Description

- Updated `.github/workflows/ci.yml` to harden the frontend contract verification step by enabling `set -euo pipefail` and replacing the bare `git diff --exit-code` invocation with an explicit `if` that emits a diagnostic `::error` message and exits non-zero when generated files differ.
- Added a new backend CI step `Verify API route ownership tests` that runs `dotnet test` filtered to `ApiContractRouteOwnershipTests` and emits a formatted error with guidance on failure.
- Updated `docs/live-contract-verification.md` to add a "Troubleshooting common CI failures" section that explains how to resolve `ApiContractRouteOwnershipTests` failures and contract drift, and includes commands to reproduce the tests locally.

### Testing

- The CI workflow will run existing frontend checks (`pnpm --dir frontend lint`, `typecheck`, `gen:types` and the contract diff check) and backend tests (`dotnet test`), and the new route-ownership filter is executed as part of the backend job. 
- Verified locally by running `pnpm --dir frontend gen:types` and the `dotnet test --filter "FullyQualifiedName~ApiContractRouteOwnershipTests"` command to confirm the new checks execute and produce actionable failure output when applicable. 
- No automated test regressions introduced by these changes during local verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a072793fac08326b17399dd94fb7728)