### PR TITLE
Publish stage transition events after persisting state and wire up event subscribers

### DIFF
--- a/backend/SurvivalGarden.Api.Tests/StageTransitionEventEmissionTests.cs
+++ b/backend/SurvivalGarden.Api.Tests/StageTransitionEventEmissionTests.cs
@@ -1,0 +1,84 @@
+using System.Text.Json.Nodes;
+using FluentAssertions;
+using NUnit.Framework;
+using SurvivalGarden.Application;
+
+namespace SurvivalGarden.Api.Tests;
+
+public class StageTransitionEventEmissionTests
+{
+    [Test]
+    public async Task ApplyBatchStageTransitionAsync_PersistsBeforePublishingEvent()
+    {
+        var store = new RecordingStore(CreateState("started"));
+        var publisher = new RecordingPublisher(store.Actions);
+        var service = new GardenApplicationService(store, publisher);
+
+        var result = await service.ApplyBatchStageTransitionAsync("batch-1", "transplant", "2026-01-01T00:00:00.000Z");
+
+        result.Ok.Should().BeTrue();
+        store.Actions.Should().ContainInOrder("save", "publish:StageAdvanced");
+    }
+
+    [Test]
+    public async Task ApplyBatchStageTransitionAsync_RepeatedStage_DoesNotPublishTransitionEvent()
+    {
+        var store = new RecordingStore(CreateState("transplant"));
+        var publisher = new RecordingPublisher(store.Actions);
+        var service = new GardenApplicationService(store, publisher);
+
+        var first = await service.ApplyBatchStageTransitionAsync("batch-1", "transplant", "2026-01-01T00:00:00.000Z");
+        var second = await service.ApplyBatchStageTransitionAsync("batch-1", "transplant", "2026-01-02T00:00:00.000Z");
+
+        first.Ok.Should().BeTrue();
+        second.Ok.Should().BeTrue();
+        publisher.Published.Should().BeEmpty();
+    }
+
+    private static JsonObject CreateState(string currentStage) => new()
+    {
+        ["batches"] = new JsonArray
+        {
+            new JsonObject
+            {
+                ["batchId"] = "batch-1",
+                ["currentStage"] = currentStage,
+                ["stageEvents"] = new JsonArray()
+            }
+        }
+    };
+
+    private sealed class RecordingStore : IGardenStateStore
+    {
+        private JsonObject _state;
+
+        public RecordingStore(JsonObject state)
+        {
+            _state = state;
+        }
+
+        public List<string> Actions { get; } = [];
+
+        public Task<JsonObject?> LoadAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult<JsonObject?>((JsonObject)_state.DeepClone());
+
+        public Task SaveAsync(JsonObject appState, CancellationToken cancellationToken = default)
+        {
+            Actions.Add("save");
+            _state = (JsonObject)appState.DeepClone();
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingPublisher(List<string> actions) : IApplicationEventPublisher
+    {
+        public List<IApplicationEvent> Published { get; } = [];
+
+        public Task PublishAsync(IApplicationEvent applicationEvent, CancellationToken cancellationToken = default)
+        {
+            Published.Add(applicationEvent);
+            actions.Add($"publish:{applicationEvent.GetType().Name}");
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/backend/SurvivalGarden.Api/Endpoints/BatchEndpoints.cs
+++ b/backend/SurvivalGarden.Api/Endpoints/BatchEndpoints.cs
@@ -6,6 +6,15 @@ namespace SurvivalGarden.Api.Endpoints;
 
 internal static class BatchEndpoints
 {
+    private const string ErrorValidationFailed = "validation_failed";
+    private const string ErrorAppStateNotFound = "app_state_not_found";
+    private const string ErrorBatchNotFound = "batch_not_found";
+    private const string ErrorInvalidStageTransition = "invalid_stage_transition";
+
+    private const string WorkflowCreateBatch = "create_batch";
+    private const string WorkflowStageEvent = "stage_event";
+    private const string WorkflowCompleteBatch = "complete_batch";
+
     internal static void MapBatchEndpoints(this WebApplication app)
     {
         app.MapGet("/api/batches", async (
@@ -34,8 +43,8 @@ internal static class BatchEndpoints
             {
                 return Results.BadRequest(new
                 {
-                    error = "validation_failed",
-                    workflow = "create_batch",
+                    error = ErrorValidationFailed,
+                    workflow = WorkflowCreateBatch,
                     errors = validation.Issues
                 });
             }
@@ -46,8 +55,8 @@ internal static class BatchEndpoints
             {
                 return Results.Conflict(new
                 {
-                    error = "validation_failed",
-                    workflow = "create_batch",
+                    error = ErrorValidationFailed,
+                    workflow = WorkflowCreateBatch,
                     errors = new[] { new { path = "/batchId", message = "batch_already_exists" } }
                 });
             }
@@ -62,18 +71,11 @@ internal static class BatchEndpoints
             StageEventRequest request,
             CancellationToken ct) =>
         {
+
             var state = await service.LoadAppStateAsync(ct);
             if (state is null)
             {
-                return Results.NotFound(new { error = "app_state_not_found", workflow = "stage_event" });
-            }
-
-            var batch = GetCollection(state, "batches")
-                .OfType<JsonObject>()
-                .FirstOrDefault(candidate => string.Equals(candidate["batchId"]?.GetValue<string>(), id, StringComparison.Ordinal));
-            if (batch is null)
-            {
-                return Results.NotFound(new { error = "batch_not_found", workflow = "stage_event", batchId = id });
+                return Results.NotFound(new { error = ErrorAppStateNotFound, workflow = WorkflowStageEvent });
             }
 
             var nextStage = request.Stage ?? string.Empty;
@@ -82,24 +84,28 @@ internal static class BatchEndpoints
             {
                 return Results.BadRequest(new
                 {
-                    error = "validation_failed",
-                    workflow = "stage_event",
+                    error = ErrorValidationFailed,
+                    workflow = WorkflowStageEvent,
                     errors = new[] { new { path = "/stage|/occurredAt", message = "stage_and_occurredAt_required" } }
                 });
             }
 
-            var transition = ApplyStageEvent(batch, nextStage, occurredAt);
+            var transition = await service.ApplyBatchStageTransitionAsync(id, nextStage, occurredAt, ct);
             if (!transition.Ok)
             {
+                if (transition.Error == ErrorBatchNotFound)
+                {
+                    return Results.NotFound(new { error = ErrorBatchNotFound, workflow = WorkflowStageEvent, batchId = id });
+                }
+
                 return Results.BadRequest(new
                 {
-                    error = "validation_failed",
-                    workflow = "stage_event",
-                    errors = new[] { new { path = "/stage", message = transition.Error ?? "invalid_stage_transition" } }
+                    error = ErrorValidationFailed,
+                    workflow = WorkflowStageEvent,
+                    errors = new[] { new { path = "/stage", message = transition.Error ?? ErrorInvalidStageTransition } }
                 });
             }
 
-            await service.SaveAppStateAsync(state, ct);
             return Results.Ok(transition.Batch);
         });
 
@@ -141,8 +147,8 @@ internal static class BatchEndpoints
             {
                 return Results.BadRequest(new
                 {
-                    error = "validation_failed",
-                    workflow = "complete_batch",
+                    error = ErrorValidationFailed,
+                    workflow = WorkflowCompleteBatch,
                     errors = new[] { new { path = "/occurredAt", message = "occurredAt_required" } }
                 });
             }
@@ -150,29 +156,25 @@ internal static class BatchEndpoints
             var state = await service.LoadAppStateAsync(ct);
             if (state is null)
             {
-                return Results.NotFound(new { error = "app_state_not_found", workflow = "complete_batch" });
+                return Results.NotFound(new { error = ErrorAppStateNotFound, workflow = WorkflowCompleteBatch });
             }
 
-            var batch = GetCollection(state, "batches")
-                .OfType<JsonObject>()
-                .FirstOrDefault(candidate => string.Equals(candidate["batchId"]?.GetValue<string>(), id, StringComparison.Ordinal));
-            if (batch is null)
-            {
-                return Results.NotFound(new { error = "batch_not_found", workflow = "complete_batch", batchId = id });
-            }
-
-            var transition = ApplyStageEvent(batch, "ended", occurredAt);
+            var transition = await service.ApplyBatchStageTransitionAsync(id, "ended", occurredAt, ct);
             if (!transition.Ok)
             {
+                if (transition.Error == ErrorBatchNotFound)
+                {
+                    return Results.NotFound(new { error = ErrorBatchNotFound, workflow = WorkflowCompleteBatch, batchId = id });
+                }
+
                 return Results.BadRequest(new
                 {
-                    error = "validation_failed",
-                    workflow = "complete_batch",
-                    errors = new[] { new { path = "/occurredAt", message = transition.Error ?? "invalid_stage_transition" } }
+                    error = ErrorValidationFailed,
+                    workflow = WorkflowCompleteBatch,
+                    errors = new[] { new { path = "/occurredAt", message = transition.Error ?? ErrorInvalidStageTransition } }
                 });
             }
 
-            await service.SaveAppStateAsync(state, ct);
             return Results.Ok(transition.Batch);
         });
 
@@ -181,58 +183,6 @@ internal static class BatchEndpoints
             var removed = await service.RemoveAsync("batches", "batchId", id, ct);
             return removed ? Results.NoContent() : Results.NotFound();
         });
-    }
-
-    private static string NormalizeStage(string stage) => stage switch
-    {
-        "pre_sown" => "sowing",
-        _ => stage
-    };
-
-    private static bool CanTransition(string currentStage, string nextStage)
-    {
-        var current = NormalizeStage(currentStage);
-        var next = NormalizeStage(nextStage);
-        if (next == "failed")
-        {
-            return true;
-        }
-
-        if (next == "ended")
-        {
-            return current is "harvest" or "failed";
-        }
-
-        return current switch
-        {
-            "sowing" => next is "transplant" or "harvest" or "failed",
-            "started" => next is "transplant" or "harvest" or "failed",
-            "transplant" => next is "harvest" or "failed",
-            "harvest" => next is "ended" or "failed",
-            "failed" => next is "ended",
-            "ended" => next is "failed",
-            _ => false
-        };
-    }
-
-    private static (bool Ok, string? Error, JsonObject Batch) ApplyStageEvent(JsonObject batch, string nextStage, string occurredAt)
-    {
-        var currentStage = NormalizeStage(batch["currentStage"]?.GetValue<string>() ?? batch["stage"]?.GetValue<string>() ?? "unknown");
-        var normalizedNextStage = NormalizeStage(nextStage);
-        if (normalizedNextStage != currentStage && !CanTransition(currentStage, normalizedNextStage))
-        {
-            return (false, "invalid_stage_transition", batch);
-        }
-
-        batch["currentStage"] = normalizedNextStage;
-        var stageEvents = batch["stageEvents"] as JsonArray ?? new JsonArray();
-        stageEvents.Add(new JsonObject
-        {
-            ["stage"] = normalizedNextStage,
-            ["occurredAt"] = occurredAt
-        });
-        batch["stageEvents"] = stageEvents;
-        return (true, null, batch);
     }
 
     private static bool IsWithinWindow(JsonObject assignment, string at)
@@ -376,7 +326,7 @@ internal static class BatchEndpoints
         {
             return Results.BadRequest(new
             {
-                error = "validation_failed",
+                error = ErrorValidationFailed,
                 workflow = operation switch
                 {
                     "assign" => "assign_bed",
@@ -390,7 +340,7 @@ internal static class BatchEndpoints
         var state = await service.LoadAppStateAsync(ct);
         if (state is null)
         {
-            return Results.NotFound(new { error = "app_state_not_found" });
+            return Results.NotFound(new { error = ErrorAppStateNotFound });
         }
 
         var batch = GetCollection(state, "batches")
@@ -398,7 +348,7 @@ internal static class BatchEndpoints
             .FirstOrDefault(candidate => string.Equals(candidate["batchId"]?.GetValue<string>(), id, StringComparison.Ordinal));
         if (batch is null)
         {
-            return Results.NotFound(new { error = "batch_not_found", batchId = id });
+            return Results.NotFound(new { error = ErrorBatchNotFound, batchId = id });
         }
 
         var mutation = MutateAssignment(batch, operation, bedId, at);
@@ -406,7 +356,7 @@ internal static class BatchEndpoints
         {
             return Results.BadRequest(new
             {
-                error = "validation_failed",
+                error = ErrorValidationFailed,
                 workflow = operation switch
                 {
                     "assign" => "assign_bed",

--- a/backend/SurvivalGarden.Application/ApplicationEventPublisher.cs
+++ b/backend/SurvivalGarden.Application/ApplicationEventPublisher.cs
@@ -1,0 +1,26 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace SurvivalGarden.Application;
+
+internal sealed class ApplicationEventPublisher(IServiceProvider serviceProvider) : IApplicationEventPublisher
+{
+    public async Task PublishAsync(IApplicationEvent applicationEvent, CancellationToken cancellationToken = default)
+    {
+        var subscriberType = typeof(IApplicationEventSubscriber<>).MakeGenericType(applicationEvent.GetType());
+        var subscribers = serviceProvider.GetServices(subscriberType);
+        foreach (var subscriber in subscribers)
+        {
+            var method = subscriberType.GetMethod(nameof(IApplicationEventSubscriber<IApplicationEvent>.HandleAsync));
+            if (method is null)
+            {
+                continue;
+            }
+
+            var task = (Task?)method.Invoke(subscriber, [applicationEvent, cancellationToken]);
+            if (task is not null)
+            {
+                await task;
+            }
+        }
+    }
+}

--- a/backend/SurvivalGarden.Application/DependencyInjection.cs
+++ b/backend/SurvivalGarden.Application/DependencyInjection.cs
@@ -6,6 +6,11 @@ public static class DependencyInjection
 {
     public static IServiceCollection AddApplication(this IServiceCollection services)
     {
+        services.AddScoped<IApplicationEventPublisher, ApplicationEventPublisher>();
+        services.AddSingleton<IStageTransitionAuditSink, InMemoryStageTransitionAuditSink>();
+        services.AddScoped<IApplicationEventSubscriber<StageAdvanced>, StageTransitionAuditSubscriber>();
+        services.AddScoped<IApplicationEventSubscriber<StageRegressed>, StageTransitionAuditSubscriber>();
+        services.AddScoped<IApplicationEventSubscriber<StageCompleted>, StageTransitionAuditSubscriber>();
         services.AddScoped<IGardenApplicationService, GardenApplicationService>();
         return services;
     }

--- a/backend/SurvivalGarden.Application/GardenApplicationService.cs
+++ b/backend/SurvivalGarden.Application/GardenApplicationService.cs
@@ -3,8 +3,11 @@ using System.Globalization;
 
 namespace SurvivalGarden.Application;
 
-public sealed class GardenApplicationService(IGardenStateStore store) : IGardenApplicationService
+public sealed class GardenApplicationService(IGardenStateStore store, IApplicationEventPublisher eventPublisher) : IGardenApplicationService
 {
+    private const string BatchNotFoundError = "batch_not_found";
+    private const string InvalidStageTransitionError = "invalid_stage_transition";
+
     private static readonly string[] RootCollections =
     [
         "species",
@@ -153,6 +156,48 @@ public sealed class GardenApplicationService(IGardenStateStore store) : IGardenA
         return new JsonArray(filtered);
     }
 
+    public async Task<(bool Ok, string? Error, JsonObject? Batch)> ApplyBatchStageTransitionAsync(string batchId, string nextStage, string occurredAt, CancellationToken cancellationToken = default)
+    {
+        var state = await EnsureStateAsync(cancellationToken);
+        var batch = GardenJsonCollectionHelpers.GetCollection(state, "batches")
+            .OfType<JsonObject>()
+            .FirstOrDefault(candidate => string.Equals(candidate["batchId"]?.GetValue<string>(), batchId, StringComparison.Ordinal));
+        if (batch is null)
+        {
+            return (false, BatchNotFoundError, null);
+        }
+
+        var currentStage = NormalizeStage(batch["currentStage"]?.GetValue<string>() ?? batch["stage"]?.GetValue<string>() ?? "unknown");
+        var normalizedNextStage = NormalizeStage(nextStage);
+        if (normalizedNextStage != currentStage && !CanTransition(currentStage, normalizedNextStage))
+        {
+            return (false, InvalidStageTransitionError, batch);
+        }
+
+        var stageEvents = batch["stageEvents"] as JsonArray ?? new JsonArray();
+        var transitionChanged = normalizedNextStage != currentStage;
+        batch["currentStage"] = normalizedNextStage;
+        stageEvents.Add(new JsonObject
+        {
+            ["stage"] = normalizedNextStage,
+            ["occurredAt"] = occurredAt
+        });
+        batch["stageEvents"] = stageEvents;
+
+        await store.SaveAsync(state, cancellationToken);
+
+        if (transitionChanged)
+        {
+            var emittedEvent = BuildStageTransitionEvent(batchId, currentStage, normalizedNextStage, occurredAt, stageEvents.Count);
+            if (emittedEvent is not null)
+            {
+                await eventPublisher.PublishAsync(emittedEvent, cancellationToken);
+            }
+        }
+
+        return (true, null, (JsonObject)batch.DeepClone());
+    }
+
     public ValidationResult Validate(string collectionName, JsonObject entity)
     {
         return collectionName switch
@@ -254,6 +299,54 @@ public sealed class GardenApplicationService(IGardenStateStore store) : IGardenA
         {
             GardenJsonCollectionHelpers.NormalizeBatchForPersistence(batch);
         }
+    }
+
+
+    private static string NormalizeStage(string stage) => stage switch
+    {
+        "pre_sown" => "sowing",
+        _ => stage
+    };
+
+    private static bool CanTransition(string currentStage, string nextStage)
+    {
+        if (nextStage == "failed") return true;
+        if (nextStage == "ended") return currentStage is "harvest" or "failed";
+
+        return currentStage switch
+        {
+            "sowing" => nextStage is "transplant" or "harvest" or "failed",
+            "started" => nextStage is "transplant" or "harvest" or "failed",
+            "transplant" => nextStage is "transplant" or "harvest" or "failed",
+            "harvest" => nextStage is "harvest" or "ended" or "failed",
+            "failed" => nextStage is "ended",
+            "ended" => nextStage is "failed",
+            _ => false
+        };
+    }
+
+    private static IApplicationEvent? BuildStageTransitionEvent(string batchId, string previousStage, string currentStage, string occurredAt, int stageEventCount)
+    {
+        if (currentStage == "ended") return new StageCompleted(batchId, previousStage, currentStage, occurredAt, stageEventCount);
+
+        var rank = new Dictionary<string, int>(StringComparer.Ordinal)
+        {
+            ["sowing"] = 1,
+            ["started"] = 1,
+            ["transplant"] = 2,
+            ["harvest"] = 3,
+            ["ended"] = 4,
+            ["failed"] = 99
+        };
+
+        if (!rank.TryGetValue(previousStage, out var oldRank) || !rank.TryGetValue(currentStage, out var newRank))
+        {
+            return null;
+        }
+
+        return newRank >= oldRank
+            ? new StageAdvanced(batchId, previousStage, currentStage, occurredAt, stageEventCount)
+            : new StageRegressed(batchId, previousStage, currentStage, occurredAt, stageEventCount);
     }
 
     private static string UtcNowIso() =>

--- a/backend/SurvivalGarden.Application/IGardenApplicationService.cs
+++ b/backend/SurvivalGarden.Application/IGardenApplicationService.cs
@@ -14,6 +14,8 @@ public interface IGardenApplicationService
 
     Task<JsonArray> ListBatchesAsync(string? stage, string? cropId, string? bedId, string? startedAtFrom, string? startedAtTo, CancellationToken cancellationToken = default);
 
+    Task<(bool Ok, string? Error, JsonObject? Batch)> ApplyBatchStageTransitionAsync(string batchId, string nextStage, string occurredAt, CancellationToken cancellationToken = default);
+
     ValidationResult Validate(string collectionName, JsonObject entity);
     ValidationResult ValidateAppState(JsonObject appState);
 }

--- a/backend/SurvivalGarden.Application/StageTransitionAuditSubscriber.cs
+++ b/backend/SurvivalGarden.Application/StageTransitionAuditSubscriber.cs
@@ -1,0 +1,40 @@
+using System.Collections.Concurrent;
+
+namespace SurvivalGarden.Application;
+
+public interface IStageTransitionAuditSink
+{
+    // Lightweight best-effort sink for side-effects only; not durable across process restarts.
+    void Record(IApplicationEvent applicationEvent);
+}
+
+internal sealed class InMemoryStageTransitionAuditSink : IStageTransitionAuditSink
+{
+    private readonly ConcurrentQueue<IApplicationEvent> _events = new();
+
+    public void Record(IApplicationEvent applicationEvent) => _events.Enqueue(applicationEvent);
+}
+
+internal sealed class StageTransitionAuditSubscriber(IStageTransitionAuditSink sink) :
+    IApplicationEventSubscriber<StageAdvanced>,
+    IApplicationEventSubscriber<StageRegressed>,
+    IApplicationEventSubscriber<StageCompleted>
+{
+    public Task HandleAsync(StageAdvanced applicationEvent, CancellationToken cancellationToken = default)
+    {
+        sink.Record(applicationEvent);
+        return Task.CompletedTask;
+    }
+
+    public Task HandleAsync(StageRegressed applicationEvent, CancellationToken cancellationToken = default)
+    {
+        sink.Record(applicationEvent);
+        return Task.CompletedTask;
+    }
+
+    public Task HandleAsync(StageCompleted applicationEvent, CancellationToken cancellationToken = default)
+    {
+        sink.Record(applicationEvent);
+        return Task.CompletedTask;
+    }
+}

--- a/backend/SurvivalGarden.Application/StageTransitionEvents.cs
+++ b/backend/SurvivalGarden.Application/StageTransitionEvents.cs
@@ -1,0 +1,35 @@
+namespace SurvivalGarden.Application;
+
+// NOTE: thin local contracts to keep transition side-effects decoupled; can be swapped to shared events package later.
+public interface IApplicationEvent;
+
+public interface IApplicationEventPublisher
+{
+    Task PublishAsync(IApplicationEvent applicationEvent, CancellationToken cancellationToken = default);
+}
+
+public interface IApplicationEventSubscriber<in TEvent> where TEvent : IApplicationEvent
+{
+    Task HandleAsync(TEvent applicationEvent, CancellationToken cancellationToken = default);
+}
+
+public sealed record StageAdvanced(
+    string BatchId,
+    string PreviousStage,
+    string CurrentStage,
+    string OccurredAt,
+    int StageEventCount) : IApplicationEvent;
+
+public sealed record StageRegressed(
+    string BatchId,
+    string PreviousStage,
+    string CurrentStage,
+    string OccurredAt,
+    int StageEventCount) : IApplicationEvent;
+
+public sealed record StageCompleted(
+    string BatchId,
+    string PreviousStage,
+    string CurrentStage,
+    string OccurredAt,
+    int StageEventCount) : IApplicationEvent;


### PR DESCRIPTION
### Motivation
- Emit domain events for batch stage transitions after state persistence to enable side-effects and auditing via subscribers.
- Consolidate stage transition logic into the application service and standardize endpoint error/workflow responses for clearer behavior and reuse.

### Description
- Add lightweight event contracts and types: `IApplicationEvent`, `StageAdvanced`, `StageRegressed`, and `StageCompleted` and the publisher/subscriber interfaces `IApplicationEventPublisher` and `IApplicationEventSubscriber<>`.
- Implement `ApplicationEventPublisher` which resolves subscribers via `IServiceProvider` and invokes `HandleAsync`, and add `StageTransitionAuditSubscriber` with an `IStageTransitionAuditSink` in-memory sink for auditing.
- Move stage transition validation, persistence and event emission into `GardenApplicationService` via `ApplyBatchStageTransitionAsync`, including `BuildStageTransitionEvent`, `NormalizeStage`, and `CanTransition`; ensure the store is saved before publishing events.
- Register new services in DI (`AddScoped<IApplicationEventPublisher, ApplicationEventPublisher>()`, audit sink and subscriber registrations) and update `IGardenApplicationService` and `GardenApplicationService` to accept the publisher.
- Update `BatchEndpoints` to call the new `ApplyBatchStageTransitionAsync`, centralize error/workflow constants, and remove duplicated in-endpoint transition logic.
- Add tests in `SurvivalGarden.Api.Tests/StageTransitionEventEmissionTests.cs` to verify persistence-before-publish ordering and idempotent behavior (no event published for repeated same-stage transitions).

### Testing
- Added and ran unit tests in `SurvivalGarden.Api.Tests/StageTransitionEventEmissionTests.cs` which verify event emission ordering and idempotency; the tests passed.
- Executed the existing unit test suite after changes and observed no test regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a074587b7508326b66eeb8d5722834b)