### PR TITLE
docs: add ADR for event history and canonical state policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,9 @@ Migration mapping guidance:
 
 For non-seed propagation, use `propagationType` + `startQuantity` only; do not populate fake seed counts.
 
+
+
+## Architecture decision records
+
+- `docs/adr/ADR-00X-backend-authority-and-boundaries.md`
+- `docs/adr/ADR-00Y-event-history-policy.md`

--- a/docs/adr/ADR-00Y-event-history-policy.md
+++ b/docs/adr/ADR-00Y-event-history-policy.md
@@ -1,0 +1,60 @@
+# ADR-00Y: Event History and Canonical State Policy
+
+## Status
+Accepted
+
+## Date
+2026-05-18
+
+## Context
+SurvivalGarden emits domain/application events for auditability and integration workflows while also persisting current canonical state for reads and writes. Review feedback has shown ambiguity about whether event streams can be treated as canonical data stores or replay sources.
+
+This ADR clarifies event-history boundaries to keep storage, query, and integration behavior consistent across backend, frontend, and documentation.
+
+## Decision
+
+1. **Canonical source for reads/writes is current-state persistence.**
+   - The current-state store is the single canonical query and write source.
+   - All API query and command behavior must rely on canonical current-state persistence, not event log replay.
+
+2. **Events are append-only history and integration artifacts.**
+   - Emitted events are append-only historical records.
+   - Event streams are used for integration, notification, analytics, and auditing use cases.
+   - Event consumers must not treat event logs as the authoritative source for entity current state.
+
+3. **Rebuild-from-replay is out of scope for the current architecture.**
+   - Reconstructing canonical application state by replaying historical events is explicitly out of scope.
+   - No service or endpoint should require full event replay to answer canonical state queries or process canonical writes.
+
+4. **Event schema versioning and compatibility policy.**
+   - Every event contract must carry an explicit version identifier (for example, semantic event type versioning or explicit schema-version field).
+   - Event changes must default to additive, backward-compatible evolution for existing subscribers.
+   - Breaking event schema changes require introducing a new event version and a documented migration/deprecation path for subscribers.
+   - Existing event versions must remain consumable for a defined overlap period during rollout.
+
+## Allowed patterns (examples)
+
+- Persisting updated batch `currentStage` and `stageEvents` in canonical storage, then emitting a `StageAdvanced` event for downstream subscribers.
+- Reading current batch status from canonical persistence for API responses, while separately using events for audit timelines.
+- Adding an optional field (for example `meta.correlationId`) to an existing event version without breaking existing subscribers.
+- Publishing `StageAdvanced.v2` while continuing to support `StageAdvanced.v1` during migration.
+
+## Disallowed patterns (examples)
+
+- Serving canonical `GET /api/batches/{id}` by replaying all historical stage events instead of reading canonical persisted state.
+- Applying canonical write logic by appending events only, without updating canonical current-state persistence.
+- Replacing canonical database migrations with one-time global event replay as the primary state rebuild mechanism.
+- Introducing incompatible event payload changes under the same event version without a version bump and migration plan.
+
+## Consequences
+
+- PR reviews should reject code/designs that imply event logs are canonical state stores.
+- Integration/eventing evolution remains possible without destabilizing canonical reads/writes.
+- Subscriber compatibility risk is reduced through explicit versioning and overlap policy.
+
+## References
+
+- `docs/adr/ADR-00X-backend-authority-and-boundaries.md`
+- `docs/workflow-endpoint-ownership.md`
+- `docs/llm-workflow.md`
+- `docs/stage-event-bus-rollout.md`

--- a/docs/llm-workflow.md
+++ b/docs/llm-workflow.md
@@ -73,3 +73,9 @@ What this manual workflow does:
 This commit becomes the new expected baseline that CI compares against.
 
 Keep regular CI fail-fast for drift detection (`git diff --exit-code`/equivalent checks after generation) and **do not auto-commit from standard CI jobs**.
+
+
+## Related ADRs
+
+- `docs/adr/ADR-00X-backend-authority-and-boundaries.md`
+- `docs/adr/ADR-00Y-event-history-policy.md`

--- a/docs/stage-event-bus-rollout.md
+++ b/docs/stage-event-bus-rollout.md
@@ -40,3 +40,9 @@
 
 - **Metric:** same transition validation and resulting batch `currentStage`/`stageEvents` content across adapters.
 - **Target:** identical API-observable transition outcomes between `InProcess` and `External` modes.
+
+
+## Related ADRs
+
+- `docs/adr/ADR-00X-backend-authority-and-boundaries.md`
+- `docs/adr/ADR-00Y-event-history-policy.md`

--- a/docs/workflow-endpoint-ownership.md
+++ b/docs/workflow-endpoint-ownership.md
@@ -7,3 +7,9 @@ Workflow-owned entities must not expose generic CRUD mutation endpoints.
 - Workflow-owned entities (currently segments, and batches once migration/cutover is complete) should accept writes via explicit command-style routes.
 - Generic mutation shapes such as broad `PUT /api/{entity}/{id}` or `PATCH /api/{entity}/{id}` must not be introduced for those workflow-owned entities.
 - Contract checks should guard this rule so route drift is caught during tests/review.
+
+
+## Related ADRs
+
+- `docs/adr/ADR-00X-backend-authority-and-boundaries.md`
+- `docs/adr/ADR-00Y-event-history-policy.md`


### PR DESCRIPTION
### Motivation
- Clarify the boundary between canonical current-state persistence and event streams to remove ambiguity during design and PR review. 
- Record explicit policy that current-state storage is the canonical query/write source and that events are append-only history/integration artifacts. 
- Document that rebuilding canonical state from event replay is out of scope for the current architecture and define event schema versioning/compatibility expectations. 

### Description
- Add `docs/adr/ADR-00Y-event-history-policy.md` which states the four policy points: canonical current-state store, events as append-only history, replay-based state rebuild is out of scope, and event schema/versioning rules with examples. 
- Link the new ADR from `README.md` under an "Architecture decision records" section. 
- Link the new ADR from `docs/workflow-endpoint-ownership.md`, `docs/llm-workflow.md`, and `docs/stage-event-bus-rollout.md` under "Related ADRs" to surface the policy in workflow and rollout docs. 
- Include concrete allowed and disallowed example patterns in the ADR to reduce ambiguity in future PR reviews. 

### Testing
- No automated tests were run because this is a docs-only change and does not affect runtime behavior. 
- Standard CI (unchanged) will continue to run on the branch and will catch any downstream validation issues during the usual pipeline execution.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0af8299b1083268fa03883e2ddc5b2)