### PR TITLE
docs: clarify rule ownership and soften batch.schema.json domain-authority wording

### DIFF
--- a/docs/adr/ADR-00Z-contract-vs-domain-rule-ownership.md
+++ b/docs/adr/ADR-00Z-contract-vs-domain-rule-ownership.md
@@ -1,0 +1,43 @@
+# ADR-00Z: Contract Shape vs Domain Rule Ownership
+
+## Status
+Accepted
+
+## Date
+2026-05-18
+
+## Context
+Some contract schema descriptions currently read like executable business rules. This creates split authority between schemas, frontend helpers, and backend domain/application logic.
+
+## Decision
+
+1. **JSON Schema / OpenAPI DTO ownership**
+   - Owns contract shape, required fields, primitive validation, enum/value shape, and migration compatibility aliases.
+   - Does not own durable business/workflow authority.
+
+2. **Backend domain/application ownership**
+   - Owns invariants, derived fields, workflow transitions, entity existence checks, normalization decisions, and validation error semantics.
+   - Batch timeline and bed-assignment invariants are implemented under Issue #57.
+
+3. **Frontend ownership**
+   - Owns display behavior, form UX, and optimistic hints.
+   - Must not make authoritative business decisions.
+
+4. **Migration code ownership**
+   - Owns legacy alias handling, canonicalization, and explicit compatibility bridges.
+   - Migration aliases are compatibility-only and not canonical long-term domain authority.
+
+## Consequences
+- Schema descriptions remain user-readable contract guidance instead of durable domain-rule definitions.
+- Domain-rule implementation stays centralized in backend authority layers.
+- Migration bridges stay explicit and bounded rather than becoming permanent parallel semantics.
+
+## Non-goals
+- Implementing all batch invariants in this ADR.
+- Building the full migration pipeline.
+- Refactoring frontend forms beyond ownership clarification.
+
+## References
+- `docs/adr/ADR-00X-backend-authority-and-boundaries.md`
+- `frontend/src/contracts/batch.schema.json`
+- Issue #57 (batch timeline and bed-assignment invariants)

--- a/frontend/src/contracts/batch.schema.json
+++ b/frontend/src/contracts/batch.schema.json
@@ -28,7 +28,7 @@
   "properties": {
     "id": {
       "$ref": "#/$defs/id",
-      "description": "Migration alias for batchId."
+      "description": "Migration/compatibility alias for batchId; use batchId as canonical."
     },
     "batchId": {
       "$ref": "#/$defs/id"
@@ -39,7 +39,7 @@
     },
     "cropId": {
       "$ref": "#/$defs/id",
-      "description": "Legacy migration alias for cultivarId."
+      "description": "Migration/compatibility alias for cultivarId; use cultivarId as canonical."
     },
     "cropTypeId": {
       "$ref": "#/$defs/id",
@@ -52,7 +52,7 @@
     },
     "startedAt": {
       "$ref": "#/$defs/isoDate",
-      "description": "Canonical start anchor. Must match stageEvents[0].occurredAt."
+      "description": "Canonical start timestamp field for the batch contract shape. Timeline invariants are backend-owned (see docs/adr/ADR-00Z-contract-vs-domain-rule-ownership.md and Issue #57)."
     },
     "propagationType": {
       "$ref": "#/$defs/propagationType"
@@ -98,18 +98,18 @@
       "type": "string",
       "minLength": 1,
       "maxLength": 80,
-      "description": "Legacy alias for currentStage during migration input only."
+      "description": "Migration/compatibility alias for currentStage during input bridging only."
     },
     "currentStage": {
       "type": "string",
       "minLength": 1,
       "maxLength": 80,
-      "description": "Canonical current stage. Derived from the latest stage event during migration/import when omitted."
+      "description": "Canonical current stage field in the contract. Derivation and workflow authority are backend-owned (see docs/adr/ADR-00Z-contract-vs-domain-rule-ownership.md and Issue #57)."
     },
     "stageEvents": {
       "type": "array",
       "minItems": 1,
-      "description": "Canonical timeline. The first event represents batch start and should align with startedAt.",
+      "description": "Canonical stage-event timeline array in the contract shape. Ordering/timeline invariants are backend-owned (see docs/adr/ADR-00Z-contract-vs-domain-rule-ownership.md and Issue #57).",
       "items": {
         "$ref": "#/$defs/stageEvent"
       }
@@ -125,7 +125,7 @@
       "items": {
         "$ref": "#/$defs/bedAssignment"
       },
-      "description": "Legacy alias for bedAssignments during migration input only."
+      "description": "Migration/compatibility alias for bedAssignments during input bridging only."
     },
     "notes": {
       "type": "string",
@@ -217,7 +217,7 @@
           "type": "string",
           "minLength": 1,
           "maxLength": 80,
-          "description": "Migration alias for stage."
+          "description": "Migration/compatibility alias for stage; use stage as canonical."
         },
         "stage": {
           "type": "string",
@@ -226,7 +226,7 @@
         },
         "date": {
           "$ref": "#/$defs/isoDate",
-          "description": "Migration alias for occurredAt."
+          "description": "Migration/compatibility alias for occurredAt; use occurredAt as canonical."
         },
         "occurredAt": {
           "$ref": "#/$defs/isoDate"


### PR DESCRIPTION
### Motivation
- Prevent schema descriptions from implying executable domain/workflow authority and reduce split-rule risk between DTOs, frontend helpers, and backend domain code. 
- Provide a single discoverable ADR that assigns responsibility for invariants, migrations, and contract shape to avoid future drift (pointer to Issue #57 for batch invariants). 

### Description
- Added `docs/adr/ADR-00Z-contract-vs-domain-rule-ownership.md` to document ownership boundaries for JSON Schema/OpenAPI DTOs, backend domain/application, frontend UX, and migration code, and to reference Issue #57 as the implementation home for batch timeline and bed-assignment invariants. 
- Edited `frontend/src/contracts/batch.schema.json` to soften/remove phrasing that asserted domain/workflow authority (for example `startedAt`, `currentStage`, `stageEvents`, and several legacy aliases), marking legacy names as migration/compatibility aliases and pointing to the new ADR and Issue #57 for invariant/derivation responsibility. 
- Changes are wording/documentation-only and do not modify schema shape, types, required fields, models, persistence, or runtime behavior. 

### Testing
- No automated unit or integration tests were executed as part of this patch; changes are documentation and schema description text only. 
- Basic repository validation steps (file updates and commit) completed locally without modifying code behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b31eceaa483269c27acd597cbe205)