### PR TITLE
Stop using JSON Schema as the primary home for business rules that belong in domain code

### DIFF
--- a/docs/adr/ADR-00X-backend-authority-and-boundaries.md
+++ b/docs/adr/ADR-00X-backend-authority-and-boundaries.md
@@ -24,20 +24,31 @@ Relevant code locations:
 1. **Business rules + derived/computed logic authority**
    - `backend/SurvivalGarden.Domain` and `backend/SurvivalGarden.Application` are the only authoritative locations for business rules and derived/computed logic.
    - `backend/SurvivalGarden.Api` may orchestrate transport concerns and route handling, but must not become a second rules engine.
+   - Batch timeline invariants, bed-assignment validity, workflow transitions, normalization decisions, entity existence checks, and validation error semantics belong in backend domain/application code.
 
-2. **Frontend boundary**
+2. **Contract artifact boundary**
+   - JSON Schema and OpenAPI DTOs define contract shape: required fields, primitive types, simple structural constraints, enums, and migration compatibility aliases.
+   - JSON Schema and OpenAPI DTOs must not be treated as the durable source of truth for invariants, derived fields, workflow transitions, assignment validity, crop/task rule execution, normalization decisions, or validation error semantics.
+   - Backend-published OpenAPI remains the canonical machine-readable contract artifact while migration-only JSON Schema files are retained for transitional compatibility validation.
+
+3. **Frontend boundary**
    - `frontend/src` is presentation and transport-client behavior only.
    - Frontend logic may shape UX, input flow, and request/response handling, but must not define canonical domain rules.
+   - Frontend validation may provide form UX and optimistic hints, but backend responses decide authoritative business outcomes.
 
-3. **Persistence policy**
+4. **Migration compatibility boundary**
+   - Migration code owns legacy alias handling, canonicalization, and explicit compatibility bridges.
+   - Migration aliases in schemas exist only to describe accepted compatibility shape; they do not define normalization authority.
+
+5. **Persistence policy**
    - Persist canonical source state.
    - Do not persist denormalized derived fields unless explicitly justified (for example, performance-critical caching with invalidation strategy and ownership documented).
 
-4. **Canonical query source-of-truth**
+6. **Canonical query source-of-truth**
    - Current-state persistence remains the canonical query source-of-truth.
    - Emitted events are history/integration signals and audit trail inputs, not canonical state.
 
-5. **Exceptions policy**
+7. **Exceptions policy**
    - Any exception to these boundaries requires an ADR update in `docs/adr` that documents scope, rationale, mitigation, and rollback path.
 
 ## Consequences
@@ -46,6 +57,7 @@ Relevant code locations:
 - Frontend and API layers stay thinner and easier to evolve independently.
 - Data model evolution remains safer because derived values are recomputed from canonical persisted state.
 - Event consumers do not treat event logs as replacement canonical storage.
+- Schema descriptions stay limited to shape and compatibility intent; detailed batch timeline and bed-assignment invariants are implemented under issue #57.
 
 ## Enforcement
 The following checks are required in CI and must remain green:
@@ -71,3 +83,4 @@ The following checks are required in CI and must remain green:
 - `.github/workflows/ci.yml`
 - `docs/workflow-endpoint-ownership.md`
 - `docs/live-contract-verification.md`
+- `https://github.com/com-mit-group/SurvivalGarden/issues/57`

--- a/docs/contracts/import-export-vnext.md
+++ b/docs/contracts/import-export-vnext.md
@@ -1,14 +1,13 @@
 # Import/Export Contract (vNext)
 
-This document defines the canonical import/export contract for vNext and provides migration mappings from accepted legacy payload variants.
+This document describes the vNext import/export contract shape and provides migration mappings from accepted legacy payload variants.
 
 ## Source of truth
 
-- `frontend/src/contracts/app-state.schema.json`
-- `frontend/src/contracts/crop.schema.json`
-- `frontend/src/contracts/batch.schema.json`
-- `frontend/src/contracts/species.schema.json`
-- `frontend/src/contracts/task.schema.json`
+- Backend domain/application code owns business rules, invariants, derived fields, workflow transitions, entity existence checks, normalization decisions, and validation error semantics.
+- Backend OpenAPI publication (`/openapi/v1.json`) is the canonical machine-readable contract artifact.
+- `frontend/src/contracts/*.schema.json` files are migration/compatibility artifacts for shape validation only: required fields, primitive types, simple structural constraints, enums, and legacy aliases.
+- Batch timeline and bed-assignment invariants are implementation work for issue #57, not JSON Schema authority.
 
 Canonical samples:
 
@@ -23,7 +22,6 @@ Canonical samples:
 
 ## Contract publication + version policy
 
-- Backend OpenAPI publication (`/openapi/v1.json`) is the canonical machine-readable contract artifact.
 - OpenAPI must include:
   - `info.version` = semantic contract version (`MAJOR.MINOR.PATCH`)
   - `x-contracts = backend-canonical`
@@ -55,7 +53,7 @@ Canonical samples:
   - placement in `bedAssignments`
   - current state in `currentStage`
   - start amount in `startQuantity`
-- Legacy aliases still exist in schema where needed for migration input:
+- Legacy aliases still exist in schema where needed for migration/compatibility input:
   - `batch.stage` (legacy alias)
   - `batch.assignments` (legacy alias)
   - `batch.id` (alias of `batchId`)
@@ -208,16 +206,16 @@ Use `meta.confidence` / `stageEvents[].meta.confidence` when the value quality m
 
 ## Backend/C# mapping notes (contract-preserving)
 
-- Keep JSON Schema canonical while backend stabilizes; C# DTOs should map 1:1 to schema fields.
+- Keep DTOs aligned with the published backend contract while JSON Schema remains as migration/compatibility shape validation.
 - Preserve legacy alias read-support during import (`id`, `commonName`, `stage`, `assignments`), but emit canonical names on export.
 - Recommended C# handling for crop identity/metadata:
   - `CropId = crop.cropId ?? crop.id`
   - `Name = crop.name ?? crop.commonName`
   - Map `ScientificName` and `Aliases` as optional values (nullable string + collection).
 - Recommended C# handling for batch timeline/state:
-  - Require persisted `StartedAt`, `StageEvents`, and legacy-required `Stage` + `Assignments` until schema requirement changes.
-  - Compute/validate `CurrentStage` from latest `StageEvents[*].Stage` when absent.
-  - Keep alias parity between `bedAssignments` and `assignments` in write paths until migration-only aliases are formally removed.
+   - Require persisted `StartedAt`, `StageEvents`, and legacy-required `Stage` + `Assignments` until schema requirement changes.
+   - Implement `CurrentStage` derivation and timeline validation in backend domain/application code, tracked by issue #57.
+   - Keep alias parity between `bedAssignments` and `assignments` in migration compatibility bridges until migration-only aliases are formally removed.
 
 ## Event import endpoint (incremental updates)
 

--- a/docs/dotnet-readiness.md
+++ b/docs/dotnet-readiness.md
@@ -21,10 +21,10 @@ Revisit OpenAPI only when all are true:
 
 1. Backend endpoint surface is stable across at least one release cycle.
 2. Repository operations are consistently mapped to HTTP semantics (CRUD + list filters) and no major renames are expected.
-3. Contract ownership is explicit: either JSON Schema remains source-of-truth and OpenAPI is generated from it, or OpenAPI replaces it with a migration plan that preserves existing generated consumers.
+3. Contract ownership is explicit: backend contracts/OpenAPI are canonical, while JSON Schema remains a migration/compatibility shape artifact that preserves existing generated consumers.
 4. Cross-language parity checks (golden vectors + contract tests) are already green and enforced in CI.
 
-If any criterion is unmet, stay JSON Schema-first.
+If any criterion is unmet, keep JSON Schema as a migration compatibility baseline without making it the authority for business rules.
 
 ---
 
@@ -283,7 +283,7 @@ If either language fails parity, block release.
 
 ## Exit criteria for “ready to start .NET implementation”
 
-- Team alignment on JSON Schema-first governance.
+- Team alignment on backend-first contract and rule ownership, with JSON Schema limited to migration compatibility.
 - Agreed endpoint naming and filter semantics for repository parity.
 - Golden vector ownership/versioning documented and enforced.
 - Initial CI gate draft covers schema conformance + parity checks.

--- a/frontend/src/contracts/batch.schema.json
+++ b/frontend/src/contracts/batch.schema.json
@@ -28,7 +28,7 @@
   "properties": {
     "id": {
       "$ref": "#/$defs/id",
-      "description": "Migration alias for batchId."
+      "description": "Migration/compatibility alias for batchId."
     },
     "batchId": {
       "$ref": "#/$defs/id"
@@ -39,7 +39,7 @@
     },
     "cropId": {
       "$ref": "#/$defs/id",
-      "description": "Legacy migration alias for cultivarId."
+      "description": "Legacy migration/compatibility alias for cultivarId."
     },
     "cropTypeId": {
       "$ref": "#/$defs/id",
@@ -52,7 +52,7 @@
     },
     "startedAt": {
       "$ref": "#/$defs/isoDate",
-      "description": "Canonical start anchor. Must match stageEvents[0].occurredAt."
+      "description": "Batch start anchor field; backend domain/application code owns timeline consistency rules."
     },
     "propagationType": {
       "$ref": "#/$defs/propagationType"
@@ -71,13 +71,13 @@
       "type": "string",
       "minLength": 1,
       "maxLength": 80,
-      "description": "Optional batch-level default for start method. When present, exporters should also set stageEvents[0].method."
+      "description": "Optional batch-level start method metadata; backend/export code owns any timeline propagation."
     },
     "startLocation": {
       "type": "string",
       "minLength": 1,
       "maxLength": 120,
-      "description": "Optional batch-level default for start location. When present, exporters should also set stageEvents[0].location."
+      "description": "Optional batch-level start location metadata; backend/export code owns any timeline propagation."
     },
     "startQuantity": {
       "$ref": "#/$defs/startQuantity"
@@ -98,18 +98,18 @@
       "type": "string",
       "minLength": 1,
       "maxLength": 80,
-      "description": "Legacy alias for currentStage during migration input only."
+      "description": "Legacy migration/compatibility input alias for currentStage."
     },
     "currentStage": {
       "type": "string",
       "minLength": 1,
       "maxLength": 80,
-      "description": "Canonical current stage. Derived from the latest stage event during migration/import when omitted."
+      "description": "Current stage field in the contract shape; backend domain/application code owns derivation rules."
     },
     "stageEvents": {
       "type": "array",
       "minItems": 1,
-      "description": "Canonical timeline. The first event represents batch start and should align with startedAt.",
+      "description": "Timeline event array in the contract shape; backend domain/application code owns timeline invariants.",
       "items": {
         "$ref": "#/$defs/stageEvent"
       }
@@ -125,7 +125,7 @@
       "items": {
         "$ref": "#/$defs/bedAssignment"
       },
-      "description": "Legacy alias for bedAssignments during migration input only."
+      "description": "Legacy migration/compatibility input alias for bedAssignments."
     },
     "notes": {
       "type": "string",
@@ -217,7 +217,7 @@
           "type": "string",
           "minLength": 1,
           "maxLength": 80,
-          "description": "Migration alias for stage."
+          "description": "Migration/compatibility alias for stage."
         },
         "stage": {
           "type": "string",
@@ -226,7 +226,7 @@
         },
         "date": {
           "$ref": "#/$defs/isoDate",
-          "description": "Migration alias for occurredAt."
+          "description": "Migration/compatibility alias for occurredAt."
         },
         "occurredAt": {
           "$ref": "#/$defs/isoDate"


### PR DESCRIPTION
Implements:

# GitHub Issue #58: Stop using JSON Schema as the primary home for business rules that belong in domain code

URL: https://github.com/com-mit-group/SurvivalGarden/issues/58

## Problem

Some JSON schemas still blur the boundary between contract shape and business/workflow authority.

JSON Schema is useful for:
- field presence
- basic types
- simple structural constraints
- enum/value shape
- compatibility aliases during migration

But it should not be the durable source of truth for domain behavior such as:
- timeline invariants
- derived state
- assignment validity
- workflow transitions
- crop/task rule execution
- frontend decision authority

Examples include batch descriptions that imply `startedAt` must align with the first stage event, `currentStage` is derived from the latest event, and assignment aliases are normalized during migration.

## Why it matters

If schemas, frontend helpers, and backend domain code all encode pieces of business behavior, the .NET migration will recreate the same split-brain problem we are trying to remove.

We need a clear rule boundary before implementing stricter backend batch/domain invariants.

## Proposed fix

Add a short architecture decision record or documentation page defining rule ownership:

- **JSON Schema / OpenAPI DTOs**
  - contract shape
  - required fields
  - primitive validation
  - enums
  - compatibility aliases during migration

- **Backend domain/application code**
  - invariants
  - derived fields
  - workflow transitions
  - entity existence checks
  - normalization decisions
  - validation error semantics

- **Frontend**
  - display
  - form UX
  - optimistic hints only
  - no authoritative business decisions

- **Migration code**
  - legacy alias handling
  - canonicalization
  - explicit compatibility bridges

Then do a small schema cleanup pass:
- remove or soften schema descriptions that imply executable domain authority
- mark migration aliases clearly as migration/compatibility-only
- move detailed invariant wording into backend-domain documentation or issue #57
- do not attempt to implement all backend rules in this issue

## Acceptance criteria

- [ ] Rule ownership boundary is documented
- [ ] JSON Schema/OpenAPI role is explicitly limited to shape and basic constraints
- [ ] Backend domain/application code is documented as the home for invariants and workflow rules
- [ ] Frontend authority boundary is documented
- [ ] Migration-code responsibility is documented
- [ ] Obvious schema descriptions that imply domain execution are cleaned up or clarified
- [ ] Issue #57 is referenced as the implementation home for batch timeline and bed-assignment invariants
- [ ] No large domain-rule refactor is required for this issue

## Non-goals

- Do not implement all batch invariants here
- Do not build the migration pipeline here
- Do not refactor all frontend forms here
- Do not remove useful structural validation from schemas

Codex plan:

1) Where to look
   - `docs/adr/ADR-00X-backend-authority-and-boundaries.md`
   - `docs/contracts/import-export-vnext.md`
   - `frontend/src/contracts/batch.schema.json`
   - Search terms: `JSON Schema`, `OpenAPI`, `source of truth`, `startedAt`, `currentStage`, `assignments`
   - Related implementation reference: issue #57 for batch timeline and bed-assignment invariants

2) Files / areas likely to touch
   - `docs/adr/ADR-00X-backend-authority-and-boundaries.md`
   - `docs/contracts/import-export-vnext.md`
   - `frontend/src/contracts/batch.schema.json`

3) Assumptions
   - Updating the existing backend authority ADR is lower risk than creating a parallel ADR.
   - JSON Schema should keep required fields, primitive constraints, enums, and migration aliases.
   - Backend `Domain` and `Application` documentation should be the home for invariant and workflow-rule ownership.
   - This issue should only clarify wording and boundaries, not implement issue #57 invariants.
   - Schema alias descriptions should identify migration compatibility, not normalization authority.

4) Plan
   - Expand the backend authority ADR with explicit ownership for JSON Schema/OpenAPI DTOs, backend domain/application code, frontend behavior, and migration code.
   - Update import/export contract wording so backend OpenAPI/contracts are canonical and JSON Schema files are migration/compatibility artifacts.
   - Soften batch schema descriptions for `startedAt`, `startMethod`, `startLocation`, `currentStage`, `stageEvents`, and legacy aliases so they describe shape/compatibility rather than domain execution.
   - Reference issue #57 in docs as the implementation home for batch timeline and bed-assignment invariants.

5) Risks / gotchas
   - Do not remove useful schema required fields or structural validation.
   - Do not change generated contracts, backend DTOs, domain models, or API behavior.
   - Avoid introducing a second authority document that conflicts with the existing ADR.
   - Keep issue #57 as future invariant implementation work, not part of this change.
   - Ensure schema JSON remains valid after description edits.

6) Recommended implementation approach
   - Option A: Update the existing ADR and two contract/schema files with wording-only changes.
   - Option B: If the ADR becomes too crowded, add a short companion doc under `docs/contracts` and link it from the ADR.


Local verification:

~~~
pwsh -File "C:\Users\yaref92\codex-tools\codex-verify.ps1" -Profiles "backend,web"
~~~
