### PR TITLE
ci[fix]: Reorder Android MAUI target restore step in workflow

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -199,12 +199,6 @@ jobs:
           /p:WindowsPackageType=None
           /p:UseMonoRuntime=false
 
-      - name: Restore Android MAUI target
-        if: steps.check-artifacts.outputs.exists == 'false'
-        run: >-
-          dotnet restore backend/SurvivalGarden.Maui/SurvivalGarden.Maui.csproj
-          /p:EnableMauiTargets=true
-
       - name: Build Windows executable
         if: steps.check-artifacts.outputs.exists == 'false'
         run: >-
@@ -221,6 +215,12 @@ jobs:
           /p:AssemblyVersion=${{ steps.set-version.outputs.assembly_sem_file_ver }}
           /p:FileVersion=${{ steps.set-version.outputs.assembly_sem_file_ver }}
           /p:InformationalVersion=${{ steps.set-version.outputs.informational_version }}
+
+      - name: Restore Android MAUI target
+        if: steps.check-artifacts.outputs.exists == 'false'
+        run: >-
+          dotnet restore backend/SurvivalGarden.Maui/SurvivalGarden.Maui.csproj
+          /p:EnableMauiTargets=true
 
       - name: Build Android APK
         if: steps.check-artifacts.outputs.exists == 'false'


### PR DESCRIPTION
## Summary

- 

## Accessibility checklist

- [ ] All new/updated buttons and form controls have an accessible name (visible label or `aria-label`).
- [ ] Core keyboard path works (Tab/Shift+Tab, Enter/Space where applicable).
- [ ] Focus order is logical after navigation and major UI updates.
- [ ] Any dialog/modal traps focus while open, closes on Escape, and returns focus to the trigger.
- [ ] Basic ARIA sanity check completed (no obvious role/name/value mismatches).

## LLM workflow checklist

- [ ] I followed the contract-first workflow in [`docs/llm-workflow.md`](../docs/llm-workflow.md).
- [ ] I checked common failure modes for schema/codegen drift and deterministic task key + `sourceKey` stability.

## Testing

- 
